### PR TITLE
feat: introduce control over runloop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8331,7 +8331,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surfpool-cli"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -8358,7 +8358,7 @@ dependencies = [
 
 [[package]]
 name = "surfpool-core"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "base64 0.22.1",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.1.3"
+version = "0.1.5"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -49,7 +49,7 @@ struct Opts {
 #[derive(Subcommand, PartialEq, Clone, Debug)]
 enum Command {
     /// Start Simnet
-    #[clap(name = "simnet", bin_name = "simnet", aliases = &["run", "start"])]
+    #[clap(name = "run", bin_name = "run", aliases = &["run", "start", "simnet"])]
     Simnet(StartSimnet),
     /// Generate shell completions scripts
     #[clap(name = "completions", bin_name = "completions", aliases = &["completion"])]

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -213,7 +213,6 @@ pub fn scaffold_runbooks_layout(
                     e
                 )
             })?;
-            println!("{} deployment", green!("Created directory"));
         }
     }
 
@@ -245,7 +244,6 @@ pub fn scaffold_runbooks_layout(
                     e
                 )
             })?;
-            println!("{} runbooks", green!("Created directory"));
         }
     }
 
@@ -264,7 +262,7 @@ pub fn scaffold_runbooks_layout(
             runbook_file_location.write_content(runbook_src.as_bytes())?;
             println!(
                 "{} {}",
-                green!("Created runbook"),
+                green!("Created file"),
                 runbook_file_location
                     .get_relative_path_from_base(&base_location)
                     .unwrap()
@@ -275,7 +273,7 @@ pub fn scaffold_runbooks_layout(
             base_dir.write_content(signer_simnet.as_bytes())?;
             println!(
                 "{} {}",
-                green!("Created runbook"),
+                green!("Created file"),
                 base_dir
                     .get_relative_path_from_base(&base_location)
                     .unwrap()
@@ -286,7 +284,7 @@ pub fn scaffold_runbooks_layout(
             base_dir.write_content(signer_testnet.as_bytes())?;
             println!(
                 "{} {}",
-                green!("Created runbook"),
+                green!("Created file"),
                 base_dir
                     .get_relative_path_from_base(&base_location)
                     .unwrap()
@@ -297,7 +295,7 @@ pub fn scaffold_runbooks_layout(
             base_dir.write_content(signer_mainnet.as_bytes())?;
             println!(
                 "{} {}",
-                green!("Created runbook"),
+                green!("Created file"),
                 base_dir
                     .get_relative_path_from_base(&base_location)
                     .unwrap()

--- a/crates/cli/src/tui/simnet.rs
+++ b/crates/cli/src/tui/simnet.rs
@@ -273,6 +273,9 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
             if let Event::Key(key) = event::read()? {
                 if key.kind == KeyEventKind::Press {
                     use KeyCode::*;
+                    if key.modifiers == KeyModifiers::CONTROL && key.code == Char('c') {
+                        return Ok(());
+                    }
                     match key.code {
                         Char('q') | Esc => return Ok(()),
                         Char('j') | Down => app.next(),

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -12,11 +12,11 @@ pub mod rpc;
 pub mod simnet;
 pub mod types;
 
-use crossbeam_channel::Sender;
+use crossbeam_channel::{Receiver, Sender};
 pub use jsonrpc_core;
 pub use jsonrpc_http_server;
 pub use litesvm;
-use simnet::SimnetEvent;
+use simnet::{SimnetCommand, SimnetEvent};
 pub use solana_rpc_client;
 pub use solana_sdk;
 use types::SurfpoolConfig;
@@ -24,7 +24,8 @@ use types::SurfpoolConfig;
 pub async fn start_simnet(
     config: &SurfpoolConfig,
     simnet_events_tx: Sender<SimnetEvent>,
+    simnet_commands_rx: Receiver<SimnetCommand>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    simnet::start(config, simnet_events_tx).await?;
+    simnet::start(config, simnet_events_tx, simnet_commands_rx).await?;
     Ok(())
 }

--- a/crates/core/src/rpc/mod.rs
+++ b/crates/core/src/rpc/mod.rs
@@ -1,11 +1,11 @@
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
+use crossbeam_channel::Sender;
 use jsonrpc_core::{
     futures::future::Either, middleware, FutureResponse, Metadata, Middleware, Request, Response,
 };
 use solana_client::rpc_custom_error::RpcCustomError;
 use solana_sdk::{blake3::Hash, clock::Slot, transaction::VersionedTransaction};
-use tokio::sync::broadcast;
 
 pub mod accounts_data;
 pub mod bank_data;
@@ -26,7 +26,7 @@ pub struct SurfpoolRpc;
 pub struct RunloopContext {
     pub id: Hash,
     pub state: Arc<RwLock<GlobalState>>,
-    pub mempool_tx: broadcast::Sender<(Hash, VersionedTransaction)>,
+    pub mempool_tx: Sender<(Hash, VersionedTransaction)>,
 }
 
 trait State {
@@ -77,7 +77,7 @@ use std::future::Future;
 #[derive(Clone)]
 pub struct SurfpoolMiddleware {
     pub context: Arc<RwLock<GlobalState>>,
-    pub mempool_tx: broadcast::Sender<(Hash, VersionedTransaction)>,
+    pub mempool_tx: Sender<(Hash, VersionedTransaction)>,
     pub config: RpcConfig,
 }
 

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -1,3 +1,10 @@
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RunloopTriggerMode {
+    Clock,
+    Manual,
+    Transaction,
+}
+
 #[derive(Clone, Debug)]
 pub struct SurfpoolConfig {
     pub simnet: SimnetConfig,
@@ -8,6 +15,7 @@ pub struct SurfpoolConfig {
 pub struct SimnetConfig {
     pub remote_rpc_url: String,
     pub slot_time: u64,
+    pub runloop_trigger_mode: RunloopTriggerMode,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This PR is polishing the devx (Ctrl+C) to quit, and introducing 3 "runloop trigger mode":
- Clock: key `c` to enter this mode (default). A slot is created every N ms (default 400). Can be paused and resumed using the key Space.
- Transaction: key `t` to enter this mode. a slot is created every time a transaction is being received. Entering this mode disable the clock.
- Manual: every time the key `Tab` is pressed, a slot is created . Entering this mode disable the clock.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Package version updated to 0.1.5.
- **New Features**
	- Renamed the primary simulation command from “simnet” to “run” (retaining familiar aliases) for a streamlined CLI experience.
	- Enhanced interactive simulation controls with new keyboard shortcuts for adjusting simulation states.
	- Updated user output messages in scaffolded file creation for improved clarity.
	- Introduced flexible configuration options with multiple runloop trigger modes, offering greater control over simulation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->