### PR TITLE
Support for deployments from anchor cli

### DIFF
--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -54,7 +54,7 @@ struct Opts {
 #[derive(Subcommand, PartialEq, Clone, Debug)]
 enum Command {
     /// Start Simnet
-    #[clap(name = "run", bin_name = "run", aliases = &["run", "start", "simnet"])]
+    #[clap(name = "run", bin_name = "run", aliases = &["start", "simnet"])]
     Simnet(StartSimnet),
     /// Generate shell completions scripts
     #[clap(name = "completions", bin_name = "completions", aliases = &["completion"])]
@@ -74,7 +74,7 @@ pub struct StartSimnet {
     #[arg(long = "port", short = 'p', default_value = DEFAULT_SIMNET_PORT)]
     pub simnet_port: u16,
     /// Set the Simnet host address
-    #[arg(long = "host", short = 'h', default_value = DEFAULT_NETWORK_HOST)]
+    #[arg(long = "host", short = 'o', default_value = DEFAULT_NETWORK_HOST)]
     pub network_host: String,
     /// Set the slot time
     #[arg(long = "slot-time", short = 's', default_value = DEFAULT_SLOT_TIME_MS)]

--- a/crates/core/src/rpc/accounts_data.rs
+++ b/crates/core/src/rpc/accounts_data.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::rpc::utils::verify_pubkey;
 use crate::rpc::State;
 
@@ -5,6 +7,7 @@ use jsonrpc_core::futures::future;
 use jsonrpc_core::BoxFuture;
 use jsonrpc_core::{Error, Result};
 use jsonrpc_derive::rpc;
+use solana_account::Account;
 use solana_account_decoder::parse_token::UiTokenAmount;
 use solana_account_decoder::{encode_ui_account, UiAccount, UiAccountEncoding};
 use solana_client::rpc_config::RpcAccountInfoConfig;
@@ -12,6 +15,7 @@ use solana_client::rpc_response::RpcBlockCommitment;
 use solana_client::rpc_response::RpcResponseContext;
 use solana_rpc_client_api::response::Response as RpcResponse;
 use solana_runtime::commitment::BlockCommitmentArray;
+use solana_sdk::pubkey::Pubkey;
 use solana_sdk::{clock::Slot, commitment_config::CommitmentConfig};
 
 use super::RunloopContext;
@@ -170,29 +174,39 @@ impl AccountsData for SurfpoolAccountsDataRpc {
         drop(state_reader);
 
         Box::pin(async move {
-            let fetched_account =
-                rpc_client
-                    .get_multiple_accounts(&pubkeys)
-                    .await
-                    .map_err(|err| {
-                        Error::invalid_params(format!("failed to fetch accounts: {err:?}"))
-                    })?;
+            let missing_accounts_pks = accounts
+                .iter()
+                .filter_map(|(pk, acc)| if acc.is_none() { Some(*pk) } else { None })
+                .collect::<Vec<_>>();
+            let fetched_accounts = missing_accounts_pks
+                .iter()
+                .zip(
+                    rpc_client
+                        .get_multiple_accounts(&missing_accounts_pks)
+                        .await
+                        .map_err(|err| {
+                            Error::invalid_params(format!("failed to fetch accounts: {err:?}"))
+                        })?,
+                )
+                .filter_map(|(pk, acc)| acc.map(|acc| (*pk, acc)))
+                .collect::<HashMap<Pubkey, Account>>();
             let mut state_reader = meta.get_state_mut()?;
             let mut combined_accounts = vec![];
-            for (i, (pk, acc)) in pubkeys.iter().zip(fetched_account).enumerate() {
-                if let Some(fetched) = acc.clone() {
-                    if let Some((_, local)) = accounts.get(i) {
-                        combined_accounts.push((pk.clone(), local.clone()));
-                    } else {
-                        combined_accounts.push((pk.clone(), acc));
-                        state_reader.svm.set_account(*pk, fetched).map_err(|err| {
+            for (pk, acc) in accounts.iter() {
+                if acc.is_some() {
+                    combined_accounts.push((pk.clone(), acc.clone()));
+                } else if let Some(fetched) = fetched_accounts.get(&pk) {
+                    combined_accounts.push((pk.clone(), Some(fetched.clone())));
+                    state_reader
+                        .svm
+                        .set_account(*pk, fetched.clone())
+                        .map_err(|err| {
                             Error::invalid_params(format!(
                                 "failed to save fetched account {pk:?}: {err:?}"
                             ))
                         })?;
-                    }
                 } else {
-                    combined_accounts.push((*pk, None));
+                    combined_accounts.push((pk.clone(), None));
                 }
             }
 

--- a/crates/core/src/rpc/minimal.rs
+++ b/crates/core/src/rpc/minimal.rs
@@ -183,12 +183,11 @@ impl Minimal for SurfpoolMinimalRpc {
 
     fn get_block_height(
         &self,
-        _meta: Self::Metadata,
+        meta: Self::Metadata,
         _config: Option<RpcContextConfig>,
     ) -> Result<u64> {
-        println!("get_block_height rpc request received");
-        // meta.get_block_height(config.unwrap_or_default())
-        unimplemented!()
+        let state_reader = meta.get_state()?;
+        Ok(state_reader.epoch_info.block_height)
     }
 
     fn get_highest_snapshot_slot(&self, _meta: Self::Metadata) -> Result<RpcSnapshotSlotInfo> {

--- a/crates/core/src/rpc/mod.rs
+++ b/crates/core/src/rpc/mod.rs
@@ -110,10 +110,7 @@ impl Middleware<Option<RunloopContext>> for SurfpoolMiddleware {
             state: self.context.clone(),
             mempool_tx: self.mempool_tx.clone(),
         });
-        // println!("Processing request {:?}", request);
-        Either::Left(Box::pin(next(request, meta).map(move |res| {
-            // println!("Processing took: {:?}", start.elapsed());
-            res
-        })))
+        println!("Processing request {:?}", request);
+        Either::Left(Box::pin(next(request, meta).map(move |res| res)))
     }
 }

--- a/crates/core/src/rpc/mod.rs
+++ b/crates/core/src/rpc/mod.rs
@@ -110,7 +110,6 @@ impl Middleware<Option<RunloopContext>> for SurfpoolMiddleware {
             state: self.context.clone(),
             mempool_tx: self.mempool_tx.clone(),
         });
-        println!("Processing request {:?}", request);
         Either::Left(Box::pin(next(request, meta).map(move |res| res)))
     }
 }


### PR DESCRIPTION
This PR adds features and fixes to enable deploying and testing programs.

However, Anchor by default uses websockets and TPU client, which are not available in Surfpool yet. So deploying requires running `solana program deploy -u localhost target/deploy/surfpool_test.so --use-rpc` to do everything through the RPC, and testing programs works (transactions are correctely received and processed by Surfpool) but Anchor tries to stream program logs through websockets and so it currently gets no response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Refined the command line interface by simplifying command aliases and updating the shortcut for network host configuration.
  - Now provides accurate block height reporting.

- **Bug Fixes**
  - Streamlined account data retrieval for more consistent and efficient responses.

- **Chores**
  - Removed redundant logging statements during request processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->