### PR TITLE
Add t2 rpc methods

### DIFF
--- a/crates/core/src/rpc/bank_data.rs
+++ b/crates/core/src/rpc/bank_data.rs
@@ -85,7 +85,7 @@ impl BankData for SurfpoolBankDataRpc {
     }
 
     fn get_epoch_schedule(&self, _meta: Self::Metadata) -> Result<EpochSchedule> {
-         not_implemented_err()
+        not_implemented_err()
     }
 
     fn get_slot_leader(

--- a/crates/core/src/rpc/bank_data.rs
+++ b/crates/core/src/rpc/bank_data.rs
@@ -84,14 +84,8 @@ impl BankData for SurfpoolBankDataRpc {
         not_implemented_err()
     }
 
-    fn get_epoch_schedule(&self, _meta: Self::Metadata) -> Result<EpochSchedule> {
-        Ok(EpochSchedule {
-            slots_per_epoch: 0,
-            leader_schedule_slot_offset: 0,
-            warmup: false,
-            first_normal_epoch: 0,
-            first_normal_slot: 0,
-        })
+    fn get_epoch_schedule(&self, meta: Self::Metadata) -> Result<EpochSchedule> {
+         not_implemented_err()
     }
 
     fn get_slot_leader(

--- a/crates/core/src/rpc/bank_data.rs
+++ b/crates/core/src/rpc/bank_data.rs
@@ -84,7 +84,7 @@ impl BankData for SurfpoolBankDataRpc {
         not_implemented_err()
     }
 
-    fn get_epoch_schedule(&self, meta: Self::Metadata) -> Result<EpochSchedule> {
+    fn get_epoch_schedule(&self, _meta: Self::Metadata) -> Result<EpochSchedule> {
          not_implemented_err()
     }
 

--- a/crates/core/src/rpc/minimal.rs
+++ b/crates/core/src/rpc/minimal.rs
@@ -12,6 +12,7 @@ use solana_client::{
         RpcVoteAccountStatus,
     },
 };
+use solana_version::Version;
 use solana_rpc_client_api::response::Response as RpcResponse;
 use solana_sdk::{
     clock::{Clock, Slot},

--- a/crates/core/src/rpc/minimal.rs
+++ b/crates/core/src/rpc/minimal.rs
@@ -12,12 +12,12 @@ use solana_client::{
         RpcVoteAccountStatus,
     },
 };
-use solana_version::Version;
 use solana_rpc_client_api::response::Response as RpcResponse;
 use solana_sdk::{
     clock::{Clock, Slot},
     epoch_info::EpochInfo,
 };
+use solana_version::Version;
 
 #[rpc]
 pub trait Minimal {


### PR DESCRIPTION
Closes #15 

- getTransactionCount has been implemented already
- getRecentPerformance_samples has been implemented already

- getSupply Done
- getFirstAvailableBlock Done 
- getBlockTime Done
- getBlock Done

- getEpochSchedule 

Was seeing some comments -> `// TODO: Refactor `agave-validator wait-for-restart-window` to not require this method, so
    //       it can be removed from rpc_minimal` does it affect `get_epoch_schedule` too? I should just write the method using the `rpc_client` ?  

Also, writing the tests is a bit tricky, I just hardcoded the assertions against my local validator values, but I confirmed that the rpc client methods work 

Please review @lgalabru 