### PR TITLE
fix(svm_tricks): properly convert bytes to hex in `svm_setAccount` rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9242,6 +9242,7 @@ dependencies = [
  "chrono",
  "crossbeam",
  "crossbeam-channel",
+ "hex",
  "hiro-system-kit",
  "ipc-channel",
  "itertools 0.14.0",
@@ -10002,9 +10003,9 @@ dependencies = [
 
 [[package]]
 name = "txtx-cloud"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4377bab66d6b1c5aa1ddd391d4acf8d43390f2b717f1881f9c8c74e0be831192"
+checksum = "fc0df98d01446d782a8650f7d16e4cf84e2a93f4c84616f2f00f077fc6213bc7"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ resolver = "2"
 [workspace.dependencies]
 agave-geyser-plugin-interface = "2.2.1"
 bincode = "1.3.3"
+hex = "0.4.3"
 ipc-channel = "0.19.0"
 surfpool-core = { path = "crates/core", default-features = false }
 surfpool-gql = { path = "crates/gql", default-features = false }
@@ -69,6 +70,7 @@ spl-associated-token-account =  "6.0.0"
 # txtx-core = { path = "../txtx/crates/txtx-core" }
 # txtx-gql = { path = "../txtx/crates/txtx-gql" }
 # txtx-supervisor-ui = { path = "../txtx/crates/txtx-supervisor-ui", default-features = false, features = ["bin_build"] }
+# txtx-cloud = { path = "../txtx/crates/txtx-cloud" }
 txtx-addon-kit = { version = "0.2.10", features = ["wasm"] }
 txtx-core = { version = "0.2.13" }
 txtx-addon-network-svm = { version = "0.1.18" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,6 +20,7 @@ bs58 = "0.5.1"
 chrono = "0.4"
 crossbeam = "0.8.4"
 crossbeam-channel = "0.5.14"
+hex = { workspace = true}
 hiro-system-kit = { version = "0.3.4" }
 ipc-channel = { workspace = true }
 itertools = "0.14.0"

--- a/crates/core/src/rpc/svm_tricks.rs
+++ b/crates/core/src/rpc/svm_tricks.rs
@@ -58,7 +58,7 @@ impl AccountUpdate {
                 owner: verify_pubkey(&self.owner.clone().unwrap())?,
                 executable: self.executable.unwrap(),
                 rent_epoch: self.rent_epoch.unwrap(),
-                data: self.data.clone().unwrap(),
+                data: self.expect_hex_data()?,
             }))
         } else {
             Ok(None)
@@ -69,7 +69,7 @@ impl AccountUpdate {
         if let Some(lamports) = self.lamports {
             account.lamports = lamports;
         }
-        if let Some(owner) = self.owner {
+        if let Some(owner) = &self.owner {
             account.owner = verify_pubkey(&owner)?;
         }
         if let Some(executable) = self.executable {
@@ -78,10 +78,16 @@ impl AccountUpdate {
         if let Some(rent_epoch) = self.rent_epoch {
             account.rent_epoch = rent_epoch;
         }
-        if let Some(data) = &self.data {
-            account.data = data.clone();
+        if let Some(_) = &self.data {
+            account.data = self.expect_hex_data()?;
         }
         Ok(())
+    }
+
+    pub fn expect_hex_data(&self) -> Result<Vec<u8>> {
+        let data = self.data.as_ref().expect("missing expected data field");
+        hex::decode(data)
+            .map_err(|e| Error::invalid_params(format!("Invalid hex data provided: {}", e)))
     }
 }
 


### PR DESCRIPTION
In my original implementation I had assumed that the `BytesOrString` macro I'm using to deserialize the `data` bytes was converting the bytes to hex, but that was incorrect.

This PR fixes the RPC method by properly decoding the `data` field when setting an account to hex.