### PR TITLE
chore: rename svm_tricks to surfnet_cheatcodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9921,9 +9921,9 @@ dependencies = [
 
 [[package]]
 name = "txtx-addon-kit"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e65c843fe3840055b289265b760c94e6d6f988700156106b98c13c88c846781a"
+checksum = "793c2c37113f215c0c7aa41eb1ad5adfa7cdca66d6012afa33f85b19170c8b2d"
 dependencies = [
  "crossbeam-channel",
  "dirs 5.0.1",
@@ -9955,9 +9955,9 @@ dependencies = [
 
 [[package]]
 name = "txtx-addon-network-svm"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65802f6607e2eba76e31de65b14e31df663315dd3761c96224d5e8750653ae70"
+checksum = "99b4ad2d325a7b4470a066cabaec7542b3fccb5ecc8035150f8f38ae9e8ac3d8"
 dependencies = [
  "async-recursion",
  "bincode",
@@ -10004,9 +10004,9 @@ dependencies = [
 
 [[package]]
 name = "txtx-cloud"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "477bb9c51200dabfc494d9b143cf3e685aa7cf8a8ebc805febf3f78867108892"
+checksum = "1d85530fe49a82c986b3a2bfb0234bbb151a7e78d2e7fb2ad6d155f17ac5c2e0"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,11 +73,11 @@ spl-associated-token-account =  "6.0.0"
 # txtx-cloud = { path = "../txtx/crates/txtx-cloud" }
 # txtx-supervisor-ui = { path = "../txtx/crates/txtx-supervisor-ui", default-features = false, features = ["bin_build"] }
 # txtx-cloud = { path = "../txtx/crates/txtx-cloud" }
-txtx-addon-kit = { version = "0.2.11", features = ["wasm"] }
+txtx-addon-kit = { version = "0.2.12", features = ["wasm"] }
 txtx-core = { version = "0.2.14" }
-txtx-addon-network-svm = { version = "0.1.18" }
+txtx-addon-network-svm = { version = "0.1.19" }
 txtx-addon-network-svm-types = { version = "0.1.17" }
 txtx-gql = { version = "0.2.6" }
 txtx-supervisor-ui = { version = "0.1.4", default-features = false, features = ["crates_build"]}
-txtx-cloud = "0.1.3"
+txtx-cloud = "0.1.4"
 uuid = "1.15.1"

--- a/crates/core/src/rpc/mod.rs
+++ b/crates/core/src/rpc/mod.rs
@@ -14,7 +14,7 @@ pub mod admin;
 pub mod bank_data;
 pub mod full;
 pub mod minimal;
-pub mod svm_tricks;
+pub mod surfnet_cheatcodes;
 pub mod utils;
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]

--- a/crates/core/src/rpc/surfnet_cheatcodes.rs
+++ b/crates/core/src/rpc/surfnet_cheatcodes.rs
@@ -222,7 +222,7 @@ pub trait SvmTricksRpc {
     /// {
     ///   "jsonrpc": "2.0",
     ///   "id": 1,
-    ///   "method": "svm_setAccount",
+    ///   "method": "surfnet_setAccount",
     ///   "params": ["account_pubkey", {"lamports": 1000, "data": "base58string", "owner": "program_pubkey"}]
     /// }
     /// ```
@@ -242,7 +242,7 @@ pub trait SvmTricksRpc {
     ///
     /// # See Also
     /// - `getAccount`, `getAccountInfo`, `getAccountBalance`
-    #[rpc(meta, name = "svm_setAccount")]
+    #[rpc(meta, name = "surfnet_setAccount")]
     fn set_account(
         &self,
         meta: Self::Metadata,
@@ -270,7 +270,7 @@ pub trait SvmTricksRpc {
     /// {
     ///   "jsonrpc": "2.0",
     ///   "id": 1,
-    ///   "method": "svm_setTokenAccount",
+    ///   "method": "surfnet_setTokenAccount",
     ///   "params": ["owner_pubkey", "mint_pubkey", {"amount": 1000, "state": "initialized"}]
     /// }
     /// ```
@@ -290,7 +290,7 @@ pub trait SvmTricksRpc {
     ///
     /// # See Also
     /// - `getTokenAccountInfo`, `getTokenAccountBalance`, `getTokenAccountDelegate`
-    #[rpc(meta, name = "svm_setTokenAccount")]
+    #[rpc(meta, name = "surfnet_setTokenAccount")]
     fn set_token_account(
         &self,
         meta: Self::Metadata,
@@ -301,8 +301,8 @@ pub trait SvmTricksRpc {
     ) -> BoxFuture<Result<RpcResponse<()>>>;
 }
 
-pub struct SurfpoolSvmTricksRpc;
-impl SvmTricksRpc for SurfpoolSvmTricksRpc {
+pub struct SurfnetCheatcodesRpc;
+impl SvmTricksRpc for SurfnetCheatcodesRpc {
     type Metadata = Option<RunloopContext>;
 
     fn set_account(

--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -15,7 +15,7 @@ use tokio::sync::RwLock;
 use crate::{
     rpc::{
         self, accounts_data::AccountsData, accounts_scan::AccountsScan, admin::AdminRpc,
-        bank_data::BankData, full::Full, minimal::Minimal, svm_tricks::SvmTricksRpc,
+        bank_data::BankData, full::Full, minimal::Minimal, surfnet_cheatcodes::SvmTricksRpc,
         SurfpoolMiddleware,
     },
     surfnet::{GeyserEvent, SurfnetSvm},
@@ -374,7 +374,7 @@ async fn start_rpc_server_runloop(
     io.extend_with(rpc::accounts_data::SurfpoolAccountsDataRpc.to_delegate());
     io.extend_with(rpc::accounts_scan::SurfpoolAccountsScanRpc.to_delegate());
     io.extend_with(rpc::bank_data::SurfpoolBankDataRpc.to_delegate());
-    io.extend_with(rpc::svm_tricks::SurfpoolSvmTricksRpc.to_delegate());
+    io.extend_with(rpc::surfnet_cheatcodes::SurfnetCheatcodesRpc.to_delegate());
     io.extend_with(rpc::admin::SurfpoolAdminRpc.to_delegate());
 
     if !config.plugin_config_path.is_empty() {


### PR DESCRIPTION
breaking change -> should be shipped under `v0.3.0`