### PR TITLE
add connect set clock,fix slot_index

### DIFF
--- a/crates/cli/src/tui/simnet.rs
+++ b/crates/cli/src/tui/simnet.rs
@@ -257,8 +257,8 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                                     EventType::Success,
                                     Local::now(),
                                     format!(
-                                        "Connection established at Slot {} / Epoch {}.",
-                                        app.epoch_info.epoch, app.epoch_info.slot_index
+                                        "Connection established at Slot index {} Slot {} / Epoch {}.",
+                                        app.epoch_info.slot_index,app.epoch_info.absolute_slot,app.epoch_info.epoch,
                                     ),
                                 ));
                             }

--- a/crates/core/src/surfnet/mod.rs
+++ b/crates/core/src/surfnet/mod.rs
@@ -168,9 +168,6 @@ impl SurfnetSvm {
             epoch_start_timestamp: 0, // todo
             leader_schedule_epoch: 0, // todo
         };
-        let _ = self
-            .simnet_events_tx
-            .send(SimnetEvent::ClockUpdate(clock.clone()));
         self.inner.set_sysvar(&clock);
         Ok(epoch_info)
     }

--- a/crates/core/src/surfnet/mod.rs
+++ b/crates/core/src/surfnet/mod.rs
@@ -160,6 +160,18 @@ impl SurfnetSvm {
         let _ = self
             .simnet_events_tx
             .send(SimnetEvent::EpochInfoUpdate(epoch_info.clone()));
+
+        let clock: Clock = Clock {
+            slot: self.latest_epoch_info.absolute_slot, //.slot_index,
+            epoch: self.latest_epoch_info.epoch,
+            unix_timestamp: Utc::now().timestamp(),
+            epoch_start_timestamp: 0, // todo
+            leader_schedule_epoch: 0, // todo
+        };
+        let _ = self
+            .simnet_events_tx
+            .send(SimnetEvent::ClockUpdate(clock.clone()));
+        self.inner.set_sysvar(&clock);
         Ok(epoch_info)
     }
 
@@ -828,7 +840,7 @@ impl SurfnetSvm {
             self.latest_epoch_info.epoch += 1;
         }
         let clock: Clock = Clock {
-            slot: self.latest_epoch_info.slot_index,
+            slot: self.latest_epoch_info.absolute_slot, //.slot_index,
             epoch: self.latest_epoch_info.epoch,
             unix_timestamp: Utc::now().timestamp(),
             epoch_start_timestamp: 0, // todo


### PR DESCRIPTION
During testing with klend, I encountered the following error: 

```"Program log: AnchorError thrown in programs/kamino-lending/src/state/last update.rs:87. Error Code: MathOverflow. Error Number: 6007. Error Message: Math operation overflow.",```

However, this issue does not occur on the mainnet. After analysis, I found that the problem stems from the `clock.slot` value in the following call being inconsistent with the mainnet:

```
lending_operations::refresh_reserve(
        reserve,
        &Clock::get()?,
        None,
        lending_market.referral_fee_bps,
    )?;
    pub fn refresh_reserve(
    reserve: &mut Reserve,
    clock: &Clock,
    price: Option<GetPriceResult>,
    referral_fee_bps: u16,
) -> Result<()> {
    let slot = clock.slot;
    
    pub fn slots_elapsed(&self, slot: Slot) -> Result<u64> {
        let slots_elapsed = slot
            .checked_sub(self.slot)
            .ok_or_else(|| error!(LendingError::MathOverflow))?;
        Ok(slots_elapsed)
    }
```

Upon reviewing the code, I discovered that the current implementation uses:

```
let clock: Clock = Clock {
    slot: self.latest_epoch_info.slot_index,
    epoch: self.latest_epoch_info.epoch,
    unix_timestamp: Utc::now().timestamp(),
    epoch_start_timestamp: 0, // todo
    leader_schedule_epoch: 0, // todo
};
```

This is clearly problematic. It should use `absolute_slot` instead.