### PR TITLE
fix simulate_transaction alts

### DIFF
--- a/crates/core/src/rpc/full.rs
+++ b/crates/core/src/rpc/full.rs
@@ -1535,7 +1535,6 @@ impl Full for SurfpoolFullRpc {
         let (_, unsanitized_tx) =
             decode_and_deserialize::<VersionedTransaction>(data, binary_encoding).unwrap();
 
-
         let SurfnetRpcContext {
             svm_locker,
             remote_ctx,

--- a/crates/core/src/rpc/full.rs
+++ b/crates/core/src/rpc/full.rs
@@ -774,7 +774,7 @@ pub trait Full {
     /// - The `commitment` setting determines the level of finality for the blocks returned (e.g., "finalized", "confirmed", etc.).
     ///
     /// # See Also
-    /// - `getBlock`, `getSlot`, `getBlockTime`    
+    /// - `getBlock`, `getSlot`, `getBlockTime`
     #[rpc(meta, name = "getBlocks")]
     fn get_blocks(
         &self,
@@ -1535,10 +1535,6 @@ impl Full for SurfpoolFullRpc {
         let (_, unsanitized_tx) =
             decode_and_deserialize::<VersionedTransaction>(data, binary_encoding).unwrap();
 
-        let pubkeys = match &unsanitized_tx.message {
-            VersionedMessage::Legacy(msg) => msg.account_keys.clone(),
-            VersionedMessage::V0(msg) => msg.account_keys.clone(),
-        };
 
         let SurfnetRpcContext {
             svm_locker,
@@ -1549,6 +1545,10 @@ impl Full for SurfpoolFullRpc {
         };
 
         Box::pin(async move {
+            let pubkeys = svm_locker
+                .get_pubkeys_from_message(&remote_ctx, &unsanitized_tx.message)
+                .await?;
+
             let SvmAccessContext {
                 slot,
                 inner: account_updates,

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -25,6 +25,10 @@ use surfpool_types::{
     SimnetCommand, SimnetEvent, SurfpoolConfig,
 };
 use tokio::{sync::RwLock, task};
+use solana_client::rpc_config::RpcSimulateTransactionConfig;
+use solana_client::rpc_config::RpcSimulateTransactionAccountsConfig;
+use solana_commitment_config::CommitmentConfig;
+//use solana_rpc_client_api::config::RpcSimulateTransactionAccountsConfig;
 
 use crate::{
     error::SurfpoolError,
@@ -302,7 +306,7 @@ async fn test_simnet_some_sol_transfers() {
 // and that the lookup table and its entries are fetched from mainnet and added to the accounts in the SVM.
 // However, we are not actually setting up a tx that will use the lookup table internally,
 // we are kind of just trusting that LiteSVM will do its job here.
-#[ignore = "flaky CI tests"]
+//#[ignore = "flaky CI tests"]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_add_alt_entries_fetching() {
     let payer = Keypair::new();
@@ -455,6 +459,109 @@ async fn test_add_alt_entries_fetching() {
         "account not found"
     );
 }
+
+// This test is pretty minimal for lookup tables at this point.
+// We are creating a v0 transaction with a lookup table that does exist on mainnet,
+// and sending that tx to surfpool. We are verifying that the transaction is processed
+// and that the lookup table and its entries are fetched from mainnet and added to the accounts in the SVM.
+// However, we are not actually setting up a tx that will use the lookup table internally,
+// we are kind of just trusting that LiteSVM will do its job here.
+//#[ignore = "flaky CI tests"]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_add_alt_entries_fetching() {
+    let payer = Keypair::new();
+    let pk = payer.pubkey();
+
+    let bind_host = "127.0.0.1";
+    let bind_port = get_free_port().unwrap();
+    let airdrop_token_amount = LAMPORTS_PER_SOL;
+    let config = SurfpoolConfig {
+        simnets: vec![SimnetConfig {
+            slot_time: 1,
+            airdrop_addresses: vec![pk], // just one
+            airdrop_token_amount,
+            ..SimnetConfig::default()
+        }],
+        rpc: RpcConfig {
+            bind_host: bind_host.to_string(),
+            bind_port,
+            ..Default::default()
+        },
+        ..SurfpoolConfig::default()
+    };
+
+    let (surfnet_svm, simnet_events_rx, geyser_events_rx) = SurfnetSvm::new();
+    let (simnet_commands_tx, simnet_commands_rx) = unbounded();
+    let (subgraph_commands_tx, _subgraph_commands_rx) = unbounded();
+    let svm_locker = Arc::new(RwLock::new(surfnet_svm));
+
+    let moved_svm_locker = svm_locker.clone();
+    let _handle = hiro_system_kit::thread_named("test").spawn(move || {
+        let future = start_local_surfnet_runloop(
+            SurfnetSvmLocker(moved_svm_locker),
+            config,
+            subgraph_commands_tx,
+            simnet_commands_tx,
+            simnet_commands_rx,
+            geyser_events_rx,
+        );
+        if let Err(e) = hiro_system_kit::nestable_block_on(future) {
+            panic!("{e:?}");
+        }
+    });
+    let svm_locker = SurfnetSvmLocker(svm_locker);
+
+    wait_for_ready_and_connected(&simnet_events_rx);
+
+    let full_client =
+        http::connect::<FullClient>(format!("http://{bind_host}:{bind_port}").as_str())
+            .await
+            .expect("Failed to connect to Surfpool");
+
+
+    let recent_blockhash =
+        svm_locker
+        .with_svm_reader(|svm_reader| svm_reader.latest_blockhash());
+
+    let random_address = pubkey!("7zdYkYf7yD83j3TLXmkhxn6LjQP9y9bQ4pjfpquP8Hqw");
+
+    let instruction = transfer(&pk, &random_address, 100);
+
+    let alt_address = pubkey!("5KcPJehcpBLcPde2UhmY4dE9zCrv2r9AKFmW5CGtY1io"); // a mainnet lookup table
+
+    let address_lookup_table_account = AddressLookupTableAccount {
+        key: alt_address,
+        addresses: vec![random_address],
+    };
+
+    let tx = VersionedTransaction::try_new(
+        VersionedMessage::V0(
+            v0::Message::try_compile(
+                &payer.pubkey(),
+                &[instruction],
+                &[address_lookup_table_account],
+                recent_blockhash,
+            )
+            .expect("Failed to compile message"),
+        ),
+        &[payer],
+    )
+    .expect("Failed to create transaction");
+
+    let Ok(encoded) = bincode::serialize(&tx) else {
+        panic!("Failed to serialize transaction");
+    };
+    let data = bs58::encode(encoded).into_string();
+
+    let simulation_res = full_client.simulate_transaction(data,None).await.unwrap();
+    assert_eq!(
+        simulation_res.value.err, None,
+        "Unexpected simulation error"
+    );
+
+}
+
+
 
 #[ignore = "flaky CI tests"]
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -16,6 +16,7 @@ use solana_message::{
 use solana_native_token::LAMPORTS_PER_SOL;
 use solana_pubkey::{pubkey, Pubkey};
 use solana_rpc_client_api::response::Response as RpcResponse;
+use solana_runtime::snapshot_utils::should_take_incremental_snapshot;
 use solana_sdk::system_instruction::transfer;
 use solana_signer::Signer;
 use solana_system_interface::instruction as system_instruction;
@@ -462,7 +463,7 @@ async fn test_add_alt_entries_fetching() {
 // and that the lookup table and its entries are fetched from mainnet and added to the accounts in the SVM.
 // However, we are not actually setting up a tx that will use the lookup table internally,
 // we are kind of just trusting that LiteSVM will do its job here.
-//#[ignore = "flaky CI tests"]
+#[ignore = "flaky CI tests"]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_simulate_add_alt_entries_fetching() {
     let payer = Keypair::new();
@@ -514,11 +515,10 @@ async fn test_simulate_add_alt_entries_fetching() {
             .await
             .expect("Failed to connect to Surfpool");
 
-    let recent_blockhash = svm_locker.with_svm_reader(|svm_reader| svm_reader.latest_blockhash());
-
     let random_address = pubkey!("7zdYkYf7yD83j3TLXmkhxn6LjQP9y9bQ4pjfpquP8Hqw");
 
     let instruction = transfer(&pk, &random_address, 100);
+    let recent_blockhash = svm_locker.with_svm_reader(|svm_reader| svm_reader.latest_blockhash());
 
     let alt_address = pubkey!("5KcPJehcpBLcPde2UhmY4dE9zCrv2r9AKFmW5CGtY1io"); // a mainnet lookup table
 

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -25,10 +25,6 @@ use surfpool_types::{
     SimnetCommand, SimnetEvent, SurfpoolConfig,
 };
 use tokio::{sync::RwLock, task};
-use solana_client::rpc_config::RpcSimulateTransactionConfig;
-use solana_client::rpc_config::RpcSimulateTransactionAccountsConfig;
-use solana_commitment_config::CommitmentConfig;
-//use solana_rpc_client_api::config::RpcSimulateTransactionAccountsConfig;
 
 use crate::{
     error::SurfpoolError,
@@ -518,10 +514,7 @@ async fn test_simulate_add_alt_entries_fetching() {
             .await
             .expect("Failed to connect to Surfpool");
 
-
-    let recent_blockhash =
-        svm_locker
-        .with_svm_reader(|svm_reader| svm_reader.latest_blockhash());
+    let recent_blockhash = svm_locker.with_svm_reader(|svm_reader| svm_reader.latest_blockhash());
 
     let random_address = pubkey!("7zdYkYf7yD83j3TLXmkhxn6LjQP9y9bQ4pjfpquP8Hqw");
 
@@ -553,15 +546,12 @@ async fn test_simulate_add_alt_entries_fetching() {
     };
     let data = bs58::encode(encoded).into_string();
 
-    let simulation_res = full_client.simulate_transaction(data,None).await.unwrap();
+    let simulation_res = full_client.simulate_transaction(data, None).await.unwrap();
     assert_eq!(
         simulation_res.value.err, None,
         "Unexpected simulation error"
     );
-
 }
-
-
 
 #[ignore = "flaky CI tests"]
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
The code modification is insufficient; it still throws an error when simulating the call to alt. During simulation, calling the same method to retrieve alt account data should suffice.