### PR TITLE
Mcp improvements

### DIFF
--- a/crates/mcp/src/surfpool/set_token_account.rs
+++ b/crates/mcp/src/surfpool/set_token_account.rs
@@ -1,5 +1,7 @@
 use bs58;
 use reqwest::blocking::Client;
+use rmcp::schemars;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use solana_sdk::{
     pubkey::Pubkey,
@@ -7,20 +9,29 @@ use solana_sdk::{
 };
 use spl_associated_token_account::get_associated_token_address_with_program_id;
 use spl_token;
-use surfpool_types::{types::AccountUpdate, verified_tokens::VERIFIED_TOKENS_BY_SYMBOL};
+use surfpool_types::{
+    types::{AccountUpdate, TokenAccountUpdateParams},
+    verified_tokens::VERIFIED_TOKENS_BY_SYMBOL,
+};
+
+const SOL_DECIMALS: u32 = 9;
+const DEFAULT_TOKEN_AMOUNT: u64 = 100_000_000_000;
+const SOL_SYMBOL: &str = "SOL";
 
 #[derive(Serialize)]
 struct JsonRpcRequest {
+    /// The JSON-RPC version
     jsonrpc: String,
+    /// The request ID
     id: u64,
+    /// The method to call
     method: String,
+    /// The parameters to pass to the method
     params: serde_json::Value,
 }
 
 #[derive(Deserialize, Debug)]
 struct JsonRpcResponse<T> {
-    // jsonrpc: String,
-    // id: u64,
     #[allow(dead_code)]
     result: Option<T>,
     error: Option<JsonRpcError>,
@@ -32,40 +43,56 @@ struct JsonRpcError {
     message: String,
 }
 
-#[derive(Serialize)]
-struct TokenAccountUpdateParams {
-    amount: Option<u64>,
-    // delegate: Option<String>, // null or pubkey // TODO: add this
-    // state: Option<String>, // "uninitialized", "frozen", "initialized" // TODO: add this
-    // delegated_amount: Option<u64>, // TODO: add this
-    // close_authority: Option<String>, // null or pubkey // TODO: add this
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+pub struct SolAccountUpdated {
+    /// the account that was updated
+    account: SeededAccount,
+    /// The amount of SOL assigned to the wallet, in lamports.
+    lamports: u64,
+    /// the address of the owner of the account
+    owner: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[serde(untagged)]
+pub enum SetAccountSuccess {
+    Sol(SolAccountUpdated),
+    Token(AccountUpdated),
 }
 
 #[derive(Serialize, Debug, Clone)]
 pub struct SetTokenAccountResponse {
-    pub success: Option<AccountUpdated>,
+    pub success: Option<SetAccountSuccess>,
     pub error: Option<String>,
 }
 #[derive(Serialize, Debug, Clone)]
 pub struct SetTokenAccountsResponse {
-    pub success: Option<Vec<AccountUpdated>>,
+    pub success: Option<Vec<SetAccountSuccess>>,
     pub error: Option<String>,
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 pub struct AccountUpdated {
+    /// the account that was updated
     account: SeededAccount,
-    token_address: String,            // Mint address or "SOL"
-    token_symbol: Option<String>,     // e.g., "SOL", "USDC", or mint symbol
-    associated_token_address: String, // Wallet address for SOL, ATA for SPL
-    amount: u64,
-    owner_pubkey: String,
+    /// The mint address of the token that was updated, or the "SOL" symbol
+    token_mint: String,
+    /// USDC/JUP/etc. If not provided, the token symbol will be inferred from the token mint address.
+    token_symbol: Option<String>,
+    /// the associated token address for the owner/token_mint/token_program_id combo
+    associated_token_address: String,
+    /// the amount of tokens assigned to the wallet, in human-readable units
+    token_amount: u64,
+    /// the address of the owner of a token
+    owner: String,
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 pub enum SeededAccount {
-    Provided(String),      // Existing public key
-    Generated(NewAccount), // Details of a newly generated account
+    /// Existing public key
+    Provided(String),
+    /// Details of a newly generated account
+    Generated(NewAccount),
 }
 
 impl SeededAccount {
@@ -90,14 +117,28 @@ impl SeededAccount {
     }
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 pub struct NewAccount {
-    secret_key: String, // Base58 encoded secret key
+    /// Base58 encoded secret key
+    secret_key: String,
+    /// Base58 encoded public key
     public_key: String,
 }
 
+#[derive(Serialize, Debug, Clone)]
+struct TokenDetails {
+    /// If the token is SOL or not
+    is_sol: bool,
+    /// The mint address of the token
+    mint_address: String,
+    /// The symbol of the token
+    symbol: Option<String>,
+    /// The number of decimals of the token
+    decimals: u32,
+}
+
 impl SetTokenAccountResponse {
-    pub fn success(details: AccountUpdated) -> Self {
+    pub fn success(details: SetAccountSuccess) -> Self {
         Self {
             success: Some(details),
             error: None,
@@ -113,7 +154,7 @@ impl SetTokenAccountResponse {
 }
 
 impl SetTokenAccountsResponse {
-    pub fn success(details: Vec<AccountUpdated>) -> Self {
+    pub fn success(details: Vec<SetAccountSuccess>) -> Self {
         Self {
             success: Some(details),
             error: None,
@@ -127,9 +168,6 @@ impl SetTokenAccountsResponse {
         }
     }
 }
-const SOL_DECIMALS: u32 = 9; // Define SOL decimals constant
-const DEFAULT_TOKEN_AMOUNT: u64 = 100_000_000_000; // 100 SOL or 100 of a token with 9 decimals
-const SOL_SYMBOL: &str = "SOL";
 
 /// Handles the MCP tool call to set a token balance for a specified account on a Surfnet instance.
 ///
@@ -140,9 +178,9 @@ const SOL_SYMBOL: &str = "SOL";
 /// * `surfnet_address`: The HTTP RPC endpoint of the target Surfnet instance .
 /// * `wallet_address_opt`: An optional base58-encoded public key of the wallet to fund.
 ///                         If `None`, a new keypair is generated, and its details are returned.
-/// * `token_identifier_str`: A string indicating the token to fund. Can be "SOL" (case-insensitive),
+/// * `token_identifier`: A string indicating the token to fund. Can be "SOL" (case-insensitive),
 ///                          a base58-encoded SPL token mint address, or a known symbol.
-/// * `token_amount_opt`: An optional amount of the token to set (in its smallest unit, e.g., lamports for SOL).
+/// * `token_amount`: An optional amount of the token to set (in its smallest unit, e.g., lamports for SOL).
 ///                       If `None`, a default amount is used.
 /// * `program_id_opt`: An optional base58-encoded public key of the token-issuing program.
 ///                     If `None`, defaults to the standard SPL Token program ID.
@@ -152,62 +190,70 @@ const SOL_SYMBOL: &str = "SOL";
 pub fn run(
     surfnet_address: String,
     owner_seeded_account: SeededAccount,
-    token_identifier_str: String, // Can be "SOL", a mint address, or a known symbol
-    token_amount_opt: Option<u64>,
-    program_id_opt: Option<String>,
+    token_identifier: String,
+    token_amount: Option<u64>,
+    token_program_id: Option<String>,
+    token_symbol: Option<String>,
 ) -> SetTokenAccountResponse {
     let client = Client::new();
     let rpc_url = surfnet_address;
+    let amount_to_set = token_amount.unwrap_or(DEFAULT_TOKEN_AMOUNT);
 
-    let amount_to_set = token_amount_opt.unwrap_or(DEFAULT_TOKEN_AMOUNT);
-
-    // Determine if it's SOL, a direct mint address, or a symbol to look up.
-    let is_sol = token_identifier_str.to_uppercase() == SOL_SYMBOL;
-    let actual_mint_address_str: String;
-    let mut actual_token_symbol_opt: Option<String> = None;
-
-    if is_sol {
-        actual_mint_address_str = SOL_SYMBOL.to_string(); // Set to "SOL" for native SOL
-        actual_token_symbol_opt = Some(SOL_SYMBOL.to_string());
-    } else {
-        // Not SOL, try parsing as a mint address directly.
-        match Pubkey::try_from(token_identifier_str.as_str()) {
-            Ok(_mint_pubkey) => {
-                actual_mint_address_str = token_identifier_str.clone();
-                actual_token_symbol_opt = VERIFIED_TOKENS_BY_SYMBOL
-                    .iter()
-                    .find(|(_, info)| info.address == actual_mint_address_str)
-                    .map(|(sym, _)| sym.clone());
-            }
-            Err(_) => {
-                // if not a direct mint address, try looking up as a symbol in VERIFIED_TOKENS_BY_SYMBOL (case-insensitive).
-                match VERIFIED_TOKENS_BY_SYMBOL.get(&token_identifier_str.to_uppercase()) {
-                    Some(token_info) => {
-                        actual_mint_address_str = token_info.address.clone();
-                        actual_token_symbol_opt = Some(token_info.symbol.clone());
-                    }
-                    None => {
-                        return SetTokenAccountResponse::error(format!(
-                            "The token symbol provided '{}' is not a verified token. Please provide the token address instead.",
-                            token_identifier_str
-                        ));
-                    }
-                }
-            }
+    let token_details = if token_identifier.to_uppercase() == SOL_SYMBOL {
+        Ok(TokenDetails {
+            is_sol: true,
+            mint_address: SOL_SYMBOL.to_string(),
+            symbol: Some(SOL_SYMBOL.to_string()),
+            decimals: SOL_DECIMALS,
+        })
+    } else if let Ok(mint_pubkey) = Pubkey::try_from(token_identifier.as_str()) {
+        let mint_str = mint_pubkey.to_string();
+        let token_info = VERIFIED_TOKENS_BY_SYMBOL
+            .iter()
+            .find(|(_, info)| info.address == mint_str)
+            .map(|(symbol, info)| (symbol.clone(), info.decimals as u32));
+        if let Some((symbol, decimals)) = token_info {
+            Ok(TokenDetails {
+                is_sol: false,
+                mint_address: mint_str,
+                symbol: Some(symbol),
+                decimals,
+            })
+        } else {
+            Ok(TokenDetails {
+                is_sol: false,
+                mint_address: mint_str,
+                symbol: None,
+                decimals: 0,
+            })
         }
-    }
+    } else if let Some(token_info) = VERIFIED_TOKENS_BY_SYMBOL.get(&token_identifier.to_uppercase())
+    {
+        Ok(TokenDetails {
+            is_sol: false,
+            mint_address: token_info.address.clone(),
+            symbol: Some(token_info.symbol.clone()),
+            decimals: token_info.decimals as u32,
+        })
+    } else {
+        Err(format!(
+            "The token symbol provided '{}' is not a verified token. Please provide the token address instead.",
+            token_identifier
+        ))
+    };
 
-    // Construct the appropriate JSON-RPC request payload based on whether it's SOL or an SPL token.
-    let request_payload = if is_sol {
-        // For SOL, use the `surfnet_setAccount` RPC method.
-        // Parameters: (pubkey: String, update: AccountUpdate)
-        // amount_to_set converted to lamports
-        let lamports_to_set = amount_to_set
-            .checked_mul(10u64.pow(SOL_DECIMALS))
-            .unwrap_or(amount_to_set);
+    let token_details = match token_details {
+        Ok(details) => details,
+        Err(e) => return SetTokenAccountResponse::error(e),
+    };
 
+    let amount_in_smallest_unit = amount_to_set
+        .checked_mul(10u64.pow(token_details.decimals))
+        .unwrap_or(amount_to_set);
+
+    let request_payload = if token_details.is_sol {
         let update_params = AccountUpdate {
-            lamports: Some(lamports_to_set),
+            lamports: Some(amount_in_smallest_unit),
             ..Default::default()
         };
         let params_tuple = (owner_seeded_account.pubkey(), update_params);
@@ -227,23 +273,12 @@ pub fn run(
             params: params_value,
         }
     } else {
-        let token_amount_to_set = match &actual_token_symbol_opt {
-            Some(token_symbol) => match VERIFIED_TOKENS_BY_SYMBOL.get(&token_symbol.to_uppercase())
-            {
-                Some(token_info) => amount_to_set
-                    .checked_mul(10u64.pow(token_info.decimals as u32))
-                    .unwrap_or(amount_to_set),
-                None => amount_to_set,
-            },
-            None => amount_to_set,
-        };
         let update_params = TokenAccountUpdateParams {
-            amount: Some(token_amount_to_set),
+            amount: Some(amount_in_smallest_unit),
         };
-
         let params_tuple = (
-            owner_seeded_account.pubkey(), // Use the public key of the provided or generated account
-            actual_mint_address_str.clone(), // Use the resolved mint address
+            owner_seeded_account.pubkey(),
+            token_details.mint_address.clone(),
             update_params,
             None::<String>,
         );
@@ -264,28 +299,34 @@ pub fn run(
         }
     };
 
-    // Send the HTTP POST request to the Surfnet RPC endpoint.
     match client.post(&rpc_url).json(&request_payload).send() {
         Ok(response) => {
             if response.status().is_success() {
                 match response.json::<JsonRpcResponse<serde_json::Value>>() {
                     Ok(rpc_response) => {
                         if let Some(err) = rpc_response.error {
-                            SetTokenAccountResponse::error(format!(
+                            return SetTokenAccountResponse::error(format!(
                                 "RPC Error (code {}): {}",
                                 err.code, err.message
-                            ))
+                            ));
+                        }
+
+                        let success_details = if token_details.is_sol {
+                            let sol_account_updated = SolAccountUpdated {
+                                account: owner_seeded_account.clone(),
+                                lamports: amount_in_smallest_unit,
+                                owner: owner_seeded_account.pubkey(),
+                            };
+                            SetAccountSuccess::Sol(sol_account_updated)
                         } else {
-                            // Successfully processed by Surfnet.
-
-                            let final_token_account_address = if is_sol {
-                                owner_seeded_account.pubkey()
-                            } else {
+                            let associated_token_address = {
                                 let mint_pubkey =
-                                    Pubkey::try_from(actual_mint_address_str.as_str())
+                                    Pubkey::try_from(token_details.mint_address.as_str())
                                         .expect("Mint pubkey should be validated by now");
-
-                                let token_program_id = match program_id_opt {
+                                let owner_pubkey =
+                                    Pubkey::try_from(owner_seeded_account.pubkey().as_str())
+                                        .expect("Owner pubkey should be valid");
+                                let token_program_id_pk = match &token_program_id {
                                     Some(id_str) => match Pubkey::try_from(id_str.as_str()) {
                                         Ok(pk) => pk,
                                         Err(_) => {
@@ -295,28 +336,30 @@ pub fn run(
                                             ))
                                         }
                                     },
-                                    None => spl_token::id(), // Default to SPL Token program ID
+                                    None => spl_token::id(),
                                 };
-
                                 get_associated_token_address_with_program_id(
-                                    &Pubkey::from_str_const(&owner_seeded_account.pubkey()),
+                                    &owner_pubkey,
                                     &mint_pubkey,
-                                    &token_program_id, // Use the determined program ID
+                                    &token_program_id_pk,
                                 )
                                 .to_string()
                             };
 
-                            // Construct the successful response details.
+                            let response_token_symbol =
+                                token_symbol.clone().or(token_details.symbol);
+
                             let account_updated = AccountUpdated {
                                 account: owner_seeded_account.clone(),
-                                token_address: actual_mint_address_str.clone(),
-                                token_symbol: actual_token_symbol_opt.clone(), // Use resolved symbol
-                                associated_token_address: final_token_account_address,
-                                amount: amount_to_set,
-                                owner_pubkey: owner_seeded_account.pubkey(),
+                                token_mint: token_details.mint_address,
+                                token_symbol: response_token_symbol,
+                                associated_token_address,
+                                token_amount: amount_in_smallest_unit,
+                                owner: owner_seeded_account.pubkey(),
                             };
-                            SetTokenAccountResponse::success(account_updated)
-                        }
+                            SetAccountSuccess::Token(account_updated)
+                        };
+                        SetTokenAccountResponse::success(success_details)
                     }
                     Err(e) => SetTokenAccountResponse::error(format!(
                         "Failed to parse JSON RPC response: {}",
@@ -324,7 +367,6 @@ pub fn run(
                     )),
                 }
             } else {
-                // HTTP request to Surfnet failed.
                 SetTokenAccountResponse::error(format!(
                     "HTTP Error: {} - {}",
                     response.status(),
@@ -334,11 +376,8 @@ pub fn run(
                 ))
             }
         }
-        Err(_e) => {
-            // Network error or other issue preventing the request from being sent.
-            SetTokenAccountResponse::error(
-                "RPC request failed (timeout or other network error)".to_string(),
-            )
-        }
+        Err(_e) => SetTokenAccountResponse::error(
+            "RPC request failed (timeout or other network error)".to_string(),
+        ),
     }
 }

--- a/crates/mcp/src/surfpool/start_surfnet.rs
+++ b/crates/mcp/src/surfpool/start_surfnet.rs
@@ -30,7 +30,7 @@ impl StartSurfnetResponse {
     }
 }
 
-pub fn run(surfnet_id: u16) -> StartSurfnetResponse {
+pub fn run(surfnet_id: u16, rpc_port: u16, ws_port: u16) -> StartSurfnetResponse {
     let (surfnet_svm, simnet_events_rx, geyser_events_rx) = SurfnetSvm::new();
 
     let (simnet_commands_tx, simnet_commands_rx) = crossbeam_channel::unbounded();
@@ -39,8 +39,6 @@ pub fn run(surfnet_id: u16) -> StartSurfnetResponse {
     let simnet_events_tx = surfnet_svm.simnet_events_tx.clone();
 
     let mut config = SurfpoolConfig::default();
-    let rpc_port = 8899 + 10000 * surfnet_id;
-    let ws_port = 8890 + 10000 * surfnet_id;
     config.rpc.bind_port = rpc_port;
     config.rpc.ws_port = ws_port;
 

--- a/crates/types/src/types.rs
+++ b/crates/types/src/types.rs
@@ -449,3 +449,12 @@ pub struct AccountUpdate {
     /// providing this value sets the epoch at which this account will next owe rent
     pub rent_epoch: Option<Epoch>,
 }
+
+#[derive(Serialize, Debug, Clone)]
+pub struct TokenAccountUpdateParams {
+    pub amount: Option<u64>,
+    // delegate: Option<String>, // null or pubkey // TODO: add this
+    // state: Option<String>, // "uninitialized", "frozen", "initialized" // TODO: add this
+    // delegated_amount: Option<u64>, // TODO: add this
+    // close_authority: Option<String>, // null or pubkey // TODO: add this
+}


### PR DESCRIPTION
enhance Surfpool functionality with token account management and port allocation

- Updated Surfpool to use a HashMap for managing surfnets instead of a Vec.
- Introduced functions to find available ports for surfnet instances.
- Enhanced token account creation and funding methods to support multiple accounts in a single call.
- Updated JSON-RPC request handling for setting token balances, including SOL and SPL tokens.
- Improved response structures for better clarity on success and error states.
- Refactored start_surfnet to accept custom RPC and WS ports.