### PR TITLE
fix(core/rpc): use `noSigVerify` in `simulateTransaction` endpoint

### DIFF
--- a/crates/core/src/rpc/full.rs
+++ b/crates/core/src/rpc/full.rs
@@ -2407,7 +2407,7 @@ mod tests {
         setup
             .context
             .svm_locker
-            .with_svm_writer(|svm_writer| svm_writer.inner.set_sigverify(true));
+            .with_svm_writer(|svm_writer| svm_writer.inner.set_sigverify(false));
 
         //build_legacy_transaction
         let mut msg = LegacyMessage::new(

--- a/crates/core/src/rpc/full.rs
+++ b/crates/core/src/rpc/full.rs
@@ -2423,7 +2423,7 @@ mod tests {
                 Some(setup.context),
                 bs58::encode(bincode::serialize(&tx).unwrap()).into_string(),
                 Some(RpcSimulateTransactionConfig {
-                    sig_verify: false,
+                    sig_verify: true,
                     replace_recent_blockhash: false,
                     commitment: Some(CommitmentConfig::finalized()),
                     encoding: None,


### PR DESCRIPTION
Add config.sig_verify to take effect when calling simulate_transaction, and add a test case test_simulate_transaction_no_signers.

https://github.com/txtx/surfpool/issues/117