### PR TITLE
fix(core): log error and continue if processing transaction fails

### DIFF
--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -172,7 +172,9 @@ pub async fn start_block_production_runloop(
                         continue
                     }
                     SimnetCommand::TransactionReceived(_key, transaction, status_tx, skip_preflight) => {
-                        svm_locker.process_transaction(remote_rpc_client, transaction, status_tx, skip_preflight).await?;
+                       if let Err(e) = svm_locker.process_transaction(remote_rpc_client, transaction, status_tx, skip_preflight).await {
+                            let _ = svm_locker.simnet_events_tx().send(SimnetEvent::error(format!("Failed to process transaction: {}", e)));
+                       }
                     }
                     SimnetCommand::Terminate(_) => {
                         let _ = svm_locker.simnet_events_tx().send(SimnetEvent::Aborted("Terminated due to inactivity.".to_string()));


### PR DESCRIPTION
Previously if we hit this codepath, the simnet would stop. Now we log and continue