### PR TITLE
feat: expose `/config` endpoint

### DIFF
--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -8,8 +8,8 @@ use solana_pubkey::Pubkey;
 use solana_signer::{EncodableKey, Signer};
 use surfpool_mcp::McpOptions;
 use surfpool_types::{
-    DEFAULT_NETWORK_HOST, DEFAULT_RPC_PORT, DEFAULT_WS_PORT, RpcConfig, SimnetConfig,
-    SubgraphConfig, SurfpoolConfig,
+    CHANGE_TO_DEFAULT_STUDIO_PORT_ONCE_SUPERVISOR_MERGED, DEFAULT_NETWORK_HOST, DEFAULT_RPC_PORT,
+    DEFAULT_WS_PORT, RpcConfig, SimnetConfig, StudioConfig, SubgraphConfig, SurfpoolConfig,
 };
 use txtx_cloud::LoginCommand;
 use txtx_core::manifest::WorkspaceManifest;
@@ -27,8 +27,6 @@ pub struct Context {
 }
 
 pub const DEFAULT_SLOT_TIME_MS: &str = "400";
-pub const DEFAULT_STUDIO_PORT: u16 = 8488;
-pub const CHANGE_TO_DEFAULT_STUDIO_PORT_ONCE_SUPERVISOR_MERGED: u16 = 18488;
 pub const DEFAULT_RPC_URL: &str = "https://api.mainnet-beta.solana.com";
 pub const DEVNET_RPC_URL: &str = "https://api.devnet.solana.com";
 pub const TESTNET_RPC_URL: &str = "https://api.testnet.solana.com";
@@ -248,6 +246,13 @@ impl StartSimnet {
         }
     }
 
+    pub fn studio_config(&self) -> StudioConfig {
+        StudioConfig {
+            bind_host: self.network_host.clone(),
+            bind_port: self.studio_port,
+        }
+    }
+
     pub fn simnet_config(&self, airdrop_addresses: Vec<Pubkey>) -> SimnetConfig {
         let remote_rpc_url = match &self.network {
             Some(NetworkType::Mainnet) => DEFAULT_RPC_URL.to_string(),
@@ -287,6 +292,7 @@ impl StartSimnet {
             simnets: vec![self.simnet_config(airdrop_addresses)],
             rpc: self.rpc_config(),
             subgraph: self.subgraph_config(),
+            studio: self.studio_config(),
             plugin_config_path,
         }
     }

--- a/crates/cli/src/cli/simnet/mod.rs
+++ b/crates/cli/src/cli/simnet/mod.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use solana_keypair::Keypair;
 use solana_signer::Signer;
 use surfpool_core::{start_local_surfnet, surfnet::svm::SurfnetSvm};
-use surfpool_types::{SimnetEvent, SubgraphEvent};
+use surfpool_types::{SanitizedConfig, SimnetEvent, SubgraphEvent};
 use txtx_core::kit::{
     channel::Receiver, futures::future::join_all, helpers::fs::FileLocation,
     types::frontend::BlockEvent,
@@ -27,7 +27,6 @@ use txtx_gql::kit::reqwest;
 
 use super::{Context, DEFAULT_CLOUD_URL, ExecuteRunbook, StartSimnet};
 use crate::{
-    cli::CHANGE_TO_DEFAULT_STUDIO_PORT_ONCE_SUPERVISOR_MERGED,
     http::start_subgraph_and_explorer_server,
     runbook::execute_runbook,
     scaffold::{detect_program_frameworks, scaffold_iac_layout},
@@ -64,22 +63,31 @@ pub async fn handle_start_local_surfnet_command(
 
     // Build config
     let config = cmd.surfpool_config(airdrop_addresses);
-    let remote_rpc_url = config.simnets[0].remote_rpc_url.clone();
 
-    let local_rpc_url = format!("http://{}", config.rpc.get_socket_address());
-    let network_binding = format!(
-        "{}:{}",
-        cmd.network_host, CHANGE_TO_DEFAULT_STUDIO_PORT_ONCE_SUPERVISOR_MERGED
-    );
+    let studio_binding_address = config.studio.get_studio_base_url();
+    let rpc_url = format!("http://{}", config.rpc.get_rpc_base_url());
+    let ws_url = format!("ws://{}", config.rpc.get_ws_base_url());
+    let studio_url = format!("http://{}", studio_binding_address);
+    let graphql_query_route_url = format!("{}/gql/v1/graphql", studio_url);
+    let rpc_datasource_url = config.simnets[0].get_sanitized_datasource_url();
+
+    let sanitized_config = SanitizedConfig {
+        rpc_url,
+        ws_url,
+        rpc_datasource_url,
+        studio_url,
+        graphql_query_route_url,
+    };
+
     let subgraph_database_path = cmd
         .subgraph_database_path
         .as_ref()
         .map(|p| p.as_str())
         .unwrap_or(":memory:");
     let explorer_handle = match start_subgraph_and_explorer_server(
-        network_binding,
+        studio_binding_address,
         subgraph_database_path,
-        config.clone(),
+        sanitized_config.clone(),
         subgraph_events_tx.clone(),
         subgraph_commands_rx,
         ctx,
@@ -166,16 +174,9 @@ pub async fn handle_start_local_surfnet_command(
     }
 
     let displayed_url = if cmd.no_studio {
-        let datasource_base_url = remote_rpc_url
-            .split("?")
-            .map(|e| e.to_string())
-            .collect::<Vec<String>>()
-            .first()
-            .expect("datasource url invalid")
-            .to_string();
-        DisplayedUrl::Datasource(datasource_base_url)
+        DisplayedUrl::Datasource(sanitized_config)
     } else {
-        DisplayedUrl::Studio(format!("http://127.0.0.1:{}", cmd.studio_port))
+        DisplayedUrl::Studio(sanitized_config)
     };
 
     // Start frontend - kept on main thread
@@ -194,7 +195,6 @@ pub async fn handle_start_local_surfnet_command(
             cmd.debug,
             deploy_progress_rx,
             displayed_url,
-            local_rpc_url,
             breaker,
         )
         .map_err(|e| format!("{}", e))?;

--- a/crates/cli/src/http/mod.rs
+++ b/crates/cli/src/http/mod.rs
@@ -11,7 +11,7 @@ use actix_web::{
     dev::ServerHandle,
     http::header::{self},
     middleware,
-    web::{self, Data},
+    web::{self, Data, route},
 };
 use convert_case::{Case, Casing};
 use crossbeam::channel::{Receiver, Select, Sender};
@@ -26,10 +26,12 @@ use surfpool_gql::{
     query::{CollectionMetadataMap, Dataloader, DataloaderContext, SqlStore},
     types::{CollectionEntry, CollectionEntryData, collections::CollectionMetadata},
 };
-use surfpool_types::{DataIndexingCommand, SubgraphCommand, SubgraphEvent, SurfpoolConfig};
+use surfpool_types::{
+    DataIndexingCommand, SanitizedConfig, SubgraphCommand, SubgraphEvent, SurfpoolConfig,
+};
 use txtx_core::kit::types::types::Value;
 
-use crate::cli::{CHANGE_TO_DEFAULT_STUDIO_PORT_ONCE_SUPERVISOR_MERGED, Context};
+use crate::cli::Context;
 
 #[cfg(feature = "explorer")]
 #[derive(RustEmbed)]
@@ -39,7 +41,7 @@ pub struct Asset;
 pub async fn start_subgraph_and_explorer_server(
     network_binding: String,
     subgraph_database_path: &str,
-    _config: SurfpoolConfig,
+    config: SanitizedConfig,
     subgraph_events_tx: Sender<SubgraphEvent>,
     subgraph_commands_rx: Receiver<SubgraphCommand>,
     ctx: &Context,
@@ -51,6 +53,7 @@ pub async fn start_subgraph_and_explorer_server(
     let schema = RwLock::new(Some(new_dynamic_schema(schema_datasource.clone())));
     let schema_wrapped = Data::new(schema);
     let context_wrapped = Data::new(RwLock::new(context));
+    let config_wrapped = Data::new(RwLock::new(config.clone()));
 
     let subgraph_handle = start_subgraph_runloop(
         subgraph_events_tx,
@@ -58,6 +61,7 @@ pub async fn start_subgraph_and_explorer_server(
         context_wrapped.clone(),
         schema_wrapped.clone(),
         schema_datasource,
+        config,
         ctx,
     )?;
 
@@ -65,6 +69,7 @@ pub async fn start_subgraph_and_explorer_server(
         App::new()
             .app_data(schema_wrapped.clone())
             .app_data(context_wrapped.clone())
+            .app_data(config_wrapped.clone())
             .wrap(
                 Cors::default()
                     .allow_any_origin()
@@ -76,6 +81,7 @@ pub async fn start_subgraph_and_explorer_server(
             )
             .wrap(middleware::Compress::default())
             .wrap(middleware::Logger::default())
+            .service(get_config)
             .service(
                 web::scope("/gql")
                     .route("/v1/graphql?<request..>", web::get().to(get_graphql))
@@ -110,6 +116,21 @@ fn handle_embedded_file(path: &str) -> HttpResponse {
             }
         }
     }
+}
+
+#[actix_web::get("/config")]
+async fn get_config(
+    req: HttpRequest,
+    payload: web::Payload,
+    config: Data<RwLock<SanitizedConfig>>,
+) -> Result<HttpResponse, Error> {
+    let config = config
+        .read()
+        .map_err(|_| actix_web::error::ErrorInternalServerError("Failed to read context"))?;
+    let api_config = serde_json::json!(*config);
+    Ok(HttpResponse::Ok()
+        .content_type("application/json")
+        .body(api_config.to_string()))
 }
 
 #[cfg(not(feature = "explorer"))]
@@ -191,6 +212,7 @@ fn start_subgraph_runloop(
     gql_context: Data<RwLock<DataloaderContext>>,
     gql_schema: Data<RwLock<Option<DynamicSchema>>>,
     mut collections_map: CollectionMetadataMap,
+    config: SanitizedConfig,
     ctx: &Context,
 ) -> Result<JoinHandle<Result<(), String>>, String> {
     let ctx = ctx.clone();
@@ -234,10 +256,7 @@ fn start_subgraph_runloop(
                                 collections_map.add_collection(metadata);
                                 gql_schema.replace(new_dynamic_schema(collections_map.clone()));
 
-                                let console_url = format!(
-                                    "http://127.0.0.1:{}/gql/console",
-                                    CHANGE_TO_DEFAULT_STUDIO_PORT_ONCE_SUPERVISOR_MERGED
-                                );
+                                let console_url = format!("{}/data", config.studio_url.clone());
                                 let _ = sender.send(console_url);
                             }
                             SubgraphCommand::ObserveCollection(subgraph_observer_rx) => {

--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -459,7 +459,7 @@ async fn start_http_rpc_server_runloop(
 ) -> Result<JoinHandle<()>, String> {
     let server_bind: SocketAddr = config
         .rpc
-        .get_socket_address()
+        .get_rpc_base_url()
         .parse::<SocketAddr>()
         .map_err(|e| e.to_string())?;
 
@@ -509,7 +509,7 @@ async fn start_ws_rpc_server_runloop(
 ) -> Result<JoinHandle<()>, String> {
     let ws_server_bind: SocketAddr = config
         .rpc
-        .get_ws_address()
+        .get_ws_base_url()
         .parse::<SocketAddr>()
         .map_err(|e| e.to_string())?;
 

--- a/crates/types/src/types.rs
+++ b/crates/types/src/types.rs
@@ -21,6 +21,8 @@ use uuid::Uuid;
 pub const DEFAULT_RPC_URL: &str = "https://api.mainnet-beta.solana.com";
 pub const DEFAULT_RPC_PORT: u16 = 8899;
 pub const DEFAULT_WS_PORT: u16 = 8900;
+pub const DEFAULT_STUDIO_PORT: u16 = 8488;
+pub const CHANGE_TO_DEFAULT_STUDIO_PORT_ONCE_SUPERVISOR_MERGED: u16 = 18488;
 pub const DEFAULT_NETWORK_HOST: &str = "127.0.0.1";
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -287,11 +289,21 @@ pub enum ClockEvent {
     ExpireBlockHash,
 }
 
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct SanitizedConfig {
+    pub rpc_url: String,
+    pub ws_url: String,
+    pub rpc_datasource_url: String,
+    pub studio_url: String,
+    pub graphql_query_route_url: String,
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct SurfpoolConfig {
     pub simnets: Vec<SimnetConfig>,
     pub rpc: RpcConfig,
     pub subgraph: SubgraphConfig,
+    pub studio: StudioConfig,
     pub plugin_config_path: Vec<PathBuf>,
 }
 
@@ -318,6 +330,18 @@ impl Default for SimnetConfig {
     }
 }
 
+impl SimnetConfig {
+    pub fn get_sanitized_datasource_url(&self) -> String {
+        self.remote_rpc_url
+            .split("?")
+            .map(|e| e.to_string())
+            .collect::<Vec<String>>()
+            .first()
+            .expect("datasource url invalid")
+            .to_string()
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct SubgraphConfig {}
 
@@ -329,19 +353,12 @@ pub struct RpcConfig {
 }
 
 impl RpcConfig {
-    pub fn get_socket_address(&self) -> String {
+    pub fn get_rpc_base_url(&self) -> String {
         format!("{}:{}", self.bind_host, self.bind_port)
     }
-    pub fn get_ws_address(&self) -> String {
+    pub fn get_ws_base_url(&self) -> String {
         format!("{}:{}", self.bind_host, self.ws_port)
     }
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct SubgraphPluginConfig {
-    pub uuid: Uuid,
-    pub ipc_token: String,
-    pub subgraph_request: SubgraphRequest,
 }
 
 impl Default for RpcConfig {
@@ -352,6 +369,34 @@ impl Default for RpcConfig {
             ws_port: DEFAULT_WS_PORT,
         }
     }
+}
+
+#[derive(Clone, Debug)]
+pub struct StudioConfig {
+    pub bind_host: String,
+    pub bind_port: u16,
+}
+
+impl StudioConfig {
+    pub fn get_studio_base_url(&self) -> String {
+        format!("{}:{}", self.bind_host, self.bind_port)
+    }
+}
+
+impl Default for StudioConfig {
+    fn default() -> Self {
+        Self {
+            bind_host: DEFAULT_NETWORK_HOST.to_string(),
+            bind_port: CHANGE_TO_DEFAULT_STUDIO_PORT_ONCE_SUPERVISOR_MERGED,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SubgraphPluginConfig {
+    pub uuid: Uuid,
+    pub ipc_token: String,
+    pub subgraph_request: SubgraphRequest,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]


### PR DESCRIPTION
GET `/config` returns:

```json
{
  "rpc_url": "http://127.0.0.1:8899",
  "ws_url": "ws://127.0.0.1:8900",
  "rpc_datasource_url": "https://mainnet.helius-rpc.com/",
  "studio_url": "http://127.0.0.1:18488",
  "graphql_query_route_url": "http://127.0.0.1:18488/gql/v1/graphql"
}
```