### PR TITLE
fix: clippy lints

### DIFF
--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -631,13 +631,9 @@ pub fn setup_logger(
         log_location.append_path(&filename)?;
 
         if !log_location.exists() {
-            log_location.create_dir_and_file().map_err(|e| {
-                format!(
-                    "Failed to create log file {}: {}",
-                    log_location.to_string(),
-                    e
-                )
-            })?;
+            log_location
+                .create_dir_and_file()
+                .map_err(|e| format!("Failed to create log file {}: {}", log_location, e))?;
         }
         log_location
     };

--- a/crates/cli/src/cli/simnet/mod.rs
+++ b/crates/cli/src/cli/simnet/mod.rs
@@ -91,11 +91,7 @@ pub async fn handle_start_local_surfnet_command(
         workspace: None,
     };
 
-    let subgraph_database_path = cmd
-        .subgraph_db
-        .as_ref()
-        .map(|p| p.as_str())
-        .unwrap_or(":memory:");
+    let subgraph_database_path = cmd.subgraph_db.as_deref().unwrap_or(":memory:");
     let explorer_handle = match start_subgraph_and_explorer_server(
         studio_binding_address,
         subgraph_database_path,
@@ -207,6 +203,7 @@ pub async fn handle_start_local_surfnet_command(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn start_service(
     cmd: StartSimnet,
     simnet_events_rx: Receiver<SimnetEvent>,
@@ -400,16 +397,17 @@ fn log_events(
                 }
             },
             i => match oper.recv(&deploy_progress_rx[i - 2]) {
-                Ok(event) => match event {
-                    BlockEvent::LogEvent(log) => handle_log_event(
-                        &mut multi_progress,
-                        log,
-                        &log_filter,
-                        &mut active_spinners,
-                        false,
-                    ),
-                    _ => {}
-                },
+                Ok(event) => {
+                    if let BlockEvent::LogEvent(log) = event {
+                        handle_log_event(
+                            &mut multi_progress,
+                            log,
+                            &log_filter,
+                            &mut active_spinners,
+                            false,
+                        )
+                    }
+                }
                 Err(_e) => {
                     deployment_completed = true;
                 }

--- a/crates/cli/src/http/mod.rs
+++ b/crates/cli/src/http/mod.rs
@@ -153,6 +153,7 @@ async fn dist(path: web::Path<String>) -> impl Responder {
     handle_embedded_file(path_str)
 }
 
+#[allow(clippy::await_holding_lock)]
 async fn post_graphql(
     req: HttpRequest,
     payload: web::Payload,
@@ -173,6 +174,7 @@ async fn post_graphql(
     graphql_handler(schema, &context, req, payload).await
 }
 
+#[allow(clippy::await_holding_lock)]
 async fn get_graphql(
     req: HttpRequest,
     payload: web::Payload,
@@ -245,7 +247,7 @@ fn start_subgraph_runloop(
                                 })?;
 
                                 let metadata = CollectionMetadata::from_request(&uuid, &request, "surfpool");
-                                cached_metadata.insert(uuid.clone(), metadata.clone());
+                                cached_metadata.insert(uuid, metadata.clone());
 
                                 let gql_context = gql_context.write().map_err(|_| {
                                     format!(
@@ -300,7 +302,7 @@ fn start_subgraph_runloop(
 
                                 if let Err(e) = gql_context
                                     .pool
-                                    .insert_entries_into_collection(entries, &metadata)
+                                    .insert_entries_into_collection(entries, metadata)
                                 {
                                     let _ = subgraph_events_tx.send(SubgraphEvent::error(format!(
                                         "{err_ctx}: {e}"

--- a/crates/cli/src/runbook/mod.rs
+++ b/crates/cli/src/runbook/mod.rs
@@ -41,10 +41,9 @@ use crate::cli::{DEFAULT_ID_SVC_URL, ExecuteRunbook, setup_logger};
 
 lazy_static::lazy_static! {
     static ref CLI_SPINNER_STYLE: ProgressStyle = {
-        let style = ProgressStyle::with_template("{spinner} {msg}")
+        ProgressStyle::with_template("{spinner} {msg}")
             .unwrap()
-            .tick_strings(&["⠋", "⠙", "⠸", "⠴", "⠦", "⠇"]);
-        style
+            .tick_strings(&["⠋", "⠙", "⠸", "⠴", "⠦", "⠇"])
     };
 }
 
@@ -103,15 +102,14 @@ pub async fn handle_execute_runbook_command(cmd: ExecuteRunbook) -> Result<(), S
         let mut active_spinners: IndexMap<Uuid, ProgressBar> = IndexMap::new();
         let mut multi_progress = MultiProgress::new();
         while let Ok(msg) = progress_rx.recv() {
-            match msg {
-                BlockEvent::LogEvent(log) => handle_log_event(
+            if let BlockEvent::LogEvent(log) = msg {
+                handle_log_event(
                     &mut multi_progress,
                     log,
                     &log_filter,
                     &mut active_spinners,
                     true,
-                ),
-                _ => {}
+                )
             }
         }
     });
@@ -749,32 +747,32 @@ pub fn persist_log(
     match log_level {
         LogLevel::Trace => {
             trace!(target: &namespace, "{}", msg);
-            if do_log_to_cli && log_filter.should_log(&log_level) {
+            if do_log_to_cli && log_filter.should_log(log_level) {
                 println!("→ {}", msg);
             }
         }
         LogLevel::Debug => {
             debug!(target: &namespace, "{}", msg);
-            if do_log_to_cli && log_filter.should_log(&log_level) {
+            if do_log_to_cli && log_filter.should_log(log_level) {
                 println!("→ {}", msg);
             }
         }
 
         LogLevel::Info => {
             info!(target: &namespace, "{}", msg);
-            if do_log_to_cli && log_filter.should_log(&log_level) {
+            if do_log_to_cli && log_filter.should_log(log_level) {
                 println!("{} {} - {}", purple!("→"), purple!(summary), message);
             }
         }
         LogLevel::Warn => {
             warn!(target: &namespace, "{}", msg);
-            if do_log_to_cli && log_filter.should_log(&log_level) {
+            if do_log_to_cli && log_filter.should_log(log_level) {
                 println!("{} {} - {}", yellow!("!"), yellow!(summary), message);
             }
         }
         LogLevel::Error => {
             error!(target: &namespace, "{}", msg);
-            if do_log_to_cli && log_filter.should_log(&log_level) {
+            if do_log_to_cli && log_filter.should_log(log_level) {
                 println!("{} {} - {}", red!("x"), red!(summary), message);
             }
         }
@@ -796,7 +794,7 @@ pub fn handle_log_event(
                 &summary,
                 &static_log_event.namespace,
                 &static_log_event.level,
-                &log_filter,
+                log_filter,
                 do_log_to_cli,
             );
         }
@@ -821,7 +819,7 @@ pub fn handle_log_event(
                         &summary,
                         &log.namespace,
                         &log.level,
-                        &log_filter,
+                        log_filter,
                         false,
                     );
                 }
@@ -841,7 +839,7 @@ pub fn handle_log_event(
                     &summary,
                     &log.namespace,
                     &log.level,
-                    &log_filter,
+                    log_filter,
                     false,
                 );
             }
@@ -859,7 +857,7 @@ pub fn handle_log_event(
                     &summary,
                     &log.namespace,
                     &log.level,
-                    &log_filter,
+                    log_filter,
                     false,
                 );
             }

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -180,7 +180,7 @@ pub fn scaffold_iac_layout(
     // signer_simnet.push_str(&get_interpolated_addon_template("http://localhost:8899"));
     signer_localnet.push_str(&get_interpolated_localnet_signer_template(&format!(
         "\"{}\"",
-        DEFAULT_SOLANA_KEYPAIR_PATH.to_string()
+        *DEFAULT_SOLANA_KEYPAIR_PATH
     )));
 
     for program_metadata in selected_programs.iter() {

--- a/crates/cli/src/tui/simnet.rs
+++ b/crates/cli/src/tui/simnet.rs
@@ -584,7 +584,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                                         persist_log(
                                             &message,
                                             &summary,
-                                            &ns,
+                                            ns,
                                             &level,
                                             &LogLevel::Info,
                                             false,
@@ -631,7 +631,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                                             persist_log(
                                                 &message,
                                                 &summary,
-                                                &ns,
+                                                ns,
                                                 &level,
                                                 &LogLevel::Info,
                                                 false,
@@ -647,7 +647,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io::Result<(
                                             persist_log(
                                                 &message,
                                                 &summary,
-                                                &ns,
+                                                ns,
                                                 &level,
                                                 &LogLevel::Info,
                                                 false,

--- a/crates/core/src/helpers/time_travel.rs
+++ b/crates/core/src/helpers/time_travel.rs
@@ -8,7 +8,7 @@ use crate::types::{TimeTravelConfig, TimeTravelError};
 /// This module contains pure functions that calculate the new clock state when time traveling
 /// in a Solana network. These functions are extracted from the RPC implementation to make
 /// them testable and reusable.
-
+///
 /// Calculates the new clock state when traveling to an absolute timestamp.
 ///
 /// # Arguments
@@ -143,11 +143,7 @@ pub fn calculate_absolute_epoch_clock(
     }
 
     let new_absolute_slot = new_epoch * epoch_info.slots_in_epoch;
-    let time_jump_in_absolute_slots = if new_absolute_slot >= current_absolute_slot {
-        new_absolute_slot - current_absolute_slot
-    } else {
-        0 // Same epoch case
-    };
+    let time_jump_in_absolute_slots = new_absolute_slot.saturating_sub(current_absolute_slot);
     let time_jump_in_ms = time_jump_in_absolute_slots * slot_time;
     let timestamp_target = current_updated_at + time_jump_in_ms;
 

--- a/crates/core/src/rpc/accounts_scan.rs
+++ b/crates/core/src/rpc/accounts_scan.rs
@@ -1219,9 +1219,8 @@ mod tests {
                 result
                     .value
                     .iter()
-                    .find(|bal| bal.address == large_circulating_pubkey.to_string()
-                        && bal.lamports == large_circulating_amount)
-                    .is_some(),
+                    .any(|bal| bal.address == large_circulating_pubkey.to_string()
+                        && bal.lamports == large_circulating_amount),
                 "Circulating account should be in circulating accounts list"
             );
             assert_eq!(large_circulating_amount, result.value[0].lamports);
@@ -1250,14 +1249,9 @@ mod tests {
 
             assert_eq!(result.value.len(), 1);
             assert!(
-                result
-                    .value
-                    .iter()
-                    .find(
-                        |bal| bal.address == large_non_circulating_pubkey.to_string()
-                            && bal.lamports == large_non_circulating_amount
-                    )
-                    .is_some(),
+                result.value.iter().any(|bal| bal.address
+                    == large_non_circulating_pubkey.to_string()
+                    && bal.lamports == large_non_circulating_amount),
                 "Non-circulating account should be in non-circulating accounts list: {:?}",
                 result.value
             );

--- a/crates/core/src/rpc/full.rs
+++ b/crates/core/src/rpc/full.rs
@@ -1686,7 +1686,7 @@ impl Full for SurfpoolFullRpc {
                                     ui_account = Some(
                                         svm_locker
                                             .account_to_rpc_keyed_account(
-                                                &*updated_pubkey,
+                                                updated_pubkey,
                                                 account,
                                                 &RpcAccountInfoConfig::default(),
                                                 None,
@@ -2338,7 +2338,7 @@ fn get_simulate_transaction_result(
         logs: Some(metadata.logs.clone()),
         replacement_blockhash,
         return_data: if metadata.return_data.program_id == system_program::id()
-            && metadata.return_data.data.len() == 0
+            && metadata.return_data.data.is_empty()
         {
             None
         } else {

--- a/crates/core/src/rpc/surfnet_cheatcodes.rs
+++ b/crates/core/src/rpc/surfnet_cheatcodes.rs
@@ -1163,7 +1163,7 @@ impl SurfnetCheatcodes for SurfnetCheatcodesRpc {
     ) -> Result<RpcResponse<Option<UiKeyedProfileResult>>> {
         let config = config.unwrap_or_default();
         let svm_locker = meta.get_svm_locker()?;
-        let profile_result = svm_locker.get_profile_result(signature_or_uuid.clone(), &config)?;
+        let profile_result = svm_locker.get_profile_result(signature_or_uuid, &config)?;
         let context_slot = profile_result
             .as_ref()
             .map(|pr| pr.slot)
@@ -1223,7 +1223,7 @@ impl SurfnetCheatcodes for SurfnetCheatcodesRpc {
             Err(e) => return e.into(),
         };
 
-        let limit = limit.unwrap_or_else(|| 50);
+        let limit = limit.unwrap_or(50);
         let latest = svm_locker.get_latest_absolute_slot();
         if limit == 0 {
             return Box::pin(async move {

--- a/crates/core/src/rpc/ws.rs
+++ b/crates/core/src/rpc/ws.rs
@@ -668,7 +668,7 @@ impl Rpc for SurfpoolWsRpc {
         let config = config.unwrap_or_default();
         let rpc_transaction_config = RpcTransactionConfig {
             encoding: Some(UiTransactionEncoding::Json),
-            commitment: config.commitment.clone(),
+            commitment: config.commitment,
             max_supported_transaction_version: Some(0),
         };
 

--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -68,7 +68,7 @@ pub async fn start_local_surfnet_runloop(
     let remote_rpc_client = match simnet.offline_mode {
         true => None,
         false => SurfnetRemoteClient::new_unsafe(
-            &simnet
+            simnet
                 .remote_rpc_url
                 .as_ref()
                 .unwrap_or(&DEFAULT_RPC_URL.to_string()),
@@ -128,6 +128,7 @@ pub async fn start_local_surfnet_runloop(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn start_block_production_runloop(
     clock_event_rx: Receiver<ClockEvent>,
     clock_command_tx: Sender<ClockCommand>,
@@ -433,7 +434,7 @@ fn start_geyser_runloop(
                         let transaction = match sanitized_transaction {
                             Some(tx) => tx,
                             None => {
-                                let _ = simnet_events_tx.send(SimnetEvent::warn(format!("Unable to index sanitized transaction")));
+                                let _ = simnet_events_tx.send(SimnetEvent::warn("Unable to index sanitized transaction".to_string()));
                                 continue;
                             }
                         };

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -746,6 +746,7 @@ impl SurfnetSvmLocker {
 /// Functions for simulating and processing transactions in the underlying SurfnetSvm instance
 impl SurfnetSvmLocker {
     /// Simulates a transaction on the SVM, returning detailed info or failure metadata.
+    #[allow(clippy::result_large_err)]
     pub fn simulate_transaction(
         &self,
         transaction: VersionedTransaction,
@@ -942,14 +943,7 @@ impl SurfnetSvmLocker {
                 let token_accounts_before = transaction_accounts
                     .iter()
                     .enumerate()
-                    .filter_map(|(i, p)| {
-                        svm_reader
-                            .token_accounts
-                            .get(&p)
-                            .cloned()
-                            .map(|a| (i, a))
-                            .clone()
-                    })
+                    .filter_map(|(i, p)| svm_reader.token_accounts.get(p).cloned().map(|a| (i, a)))
                     .collect::<Vec<_>>();
 
                 let token_programs = token_accounts_before
@@ -1019,6 +1013,7 @@ impl SurfnetSvmLocker {
         ))
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn generate_instruction_profiles(
         &self,
         transaction: &VersionedTransaction,
@@ -1071,14 +1066,14 @@ impl SurfnetSvmLocker {
             if let Some((partial_tx, all_required_accounts_for_last_ix)) = self
                 .create_partial_transaction(
                     instructions,
-                    &transaction_accounts,
+                    transaction_accounts,
                     mutable_signers,
                     readonly_signers,
                     mutable_non_signers,
                     readonly_non_signers,
                     mutable_loaded,
                     readonly_loaded,
-                    &transaction,
+                    transaction,
                     idx,
                     loaded_addresses,
                 )
@@ -1223,6 +1218,7 @@ impl SurfnetSvmLocker {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn handle_execution_failure(
         &self,
         failed_transaction_metadata: FailedTransactionMetadata,
@@ -1340,6 +1336,7 @@ impl SurfnetSvmLocker {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn handle_execution_success(
         &self,
         transaction_metadata: TransactionMetadata,
@@ -1417,7 +1414,7 @@ impl SurfnetSvmLocker {
                 .zip(accounts_after.iter())
                 .enumerate()
             {
-                let token_account = svm_writer.token_accounts.get(&pubkey).cloned();
+                let token_account = svm_writer.token_accounts.get(pubkey).cloned();
                 post_execution_capture.insert(*pubkey, account.clone());
 
                 if let Some(token_account) = token_account {
@@ -1506,6 +1503,7 @@ impl SurfnetSvmLocker {
         ))
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn process_transaction_internal(
         &self,
         transaction: VersionedTransaction,
@@ -1530,7 +1528,7 @@ impl SurfnetSvmLocker {
                     transaction,
                     self.get_latest_absolute_slot(),
                     transaction_accounts,
-                    &loaded_addresses,
+                    loaded_addresses,
                     accounts_before,
                     token_accounts_before,
                     token_programs,
@@ -1555,7 +1553,7 @@ impl SurfnetSvmLocker {
                 accounts_before,
                 token_accounts_before,
                 token_programs,
-                &loaded_addresses,
+                loaded_addresses,
                 pre_execution_capture,
                 status_tx.clone(),
                 do_propagate,
@@ -1978,7 +1976,7 @@ impl SurfnetSvmLocker {
 
                 // acc_keys.append(&mut alt_pubkeys);
                 if let Some(loaded_addresses) = all_transaction_lookup_table_addresses {
-                    acc_keys.extend(loaded_addresses.into_iter());
+                    acc_keys.extend(loaded_addresses);
                 }
                 acc_keys
             }
@@ -2125,6 +2123,7 @@ impl SurfnetSvmLocker {
     /// # Returns
     /// A partial transaction containing the first `idx` instructions and the accounts used for
     /// the last instruction, or None if creation fails
+    #[allow(clippy::too_many_arguments)]
     fn create_partial_transaction(
         &self,
         instructions: &[CompiledInstruction],
@@ -2152,12 +2151,12 @@ impl SurfnetSvmLocker {
             // Some instructions don't need to read/write any accounts, so the account list is empty.
             // However, we're still using an account to sign, so we add that here.
             {
-                if all_required_accounts.len() == 0 {
+                if all_required_accounts.is_empty() {
                     let mut mutable_signers =
                         mutable_signers.iter().cloned().collect::<IndexSet<_>>();
                     all_required_accounts.append(&mut mutable_signers);
                 }
-                if all_required_accounts.len() == 0 {
+                if all_required_accounts.is_empty() {
                     let mut readonly_signers =
                         readonly_signers.iter().cloned().collect::<IndexSet<_>>();
                     all_required_accounts.append(&mut readonly_signers);
@@ -2176,11 +2175,11 @@ impl SurfnetSvmLocker {
             all_required_accounts_for_last_ix.insert(message_accounts[account_idx as usize]);
         }
         {
-            if all_required_accounts_for_last_ix.len() == 0 {
+            if all_required_accounts_for_last_ix.is_empty() {
                 let mut mutable_signers = mutable_signers.iter().cloned().collect::<IndexSet<_>>();
                 all_required_accounts_for_last_ix.append(&mut mutable_signers);
             }
-            if all_required_accounts_for_last_ix.len() == 0 {
+            if all_required_accounts_for_last_ix.is_empty() {
                 let mut readonly_signers =
                     readonly_signers.iter().cloned().collect::<IndexSet<_>>();
                 all_required_accounts_for_last_ix.append(&mut readonly_signers);
@@ -2412,7 +2411,7 @@ impl SurfnetSvmLocker {
             Some(uuids_or_sigs) => {
                 let mut profiles = Vec::new();
                 for id in uuids_or_sigs {
-                    let profile = self.get_profile_result(id.clone(), config)?;
+                    let profile = self.get_profile_result(id, config)?;
                     if profile.is_none() {
                         return Err(SurfpoolError::tag_not_found(&tag));
                     }
@@ -2551,7 +2550,7 @@ impl SurfnetSvmLocker {
                         )?;
 
                         get_account_result = GetAccountResult::FoundProgramAccount(
-                            (pubkey.clone(), program_account.clone()),
+                            (*pubkey, program_account.clone()),
                             (programdata_address, Some(programdata_account.clone())),
                         );
 
@@ -2568,7 +2567,7 @@ impl SurfnetSvmLocker {
             }
             GetAccountResult::FoundProgramAccount(_, (_, None)) => {
                 return Err(SurfpoolError::invalid_program_account(
-                    &program_id,
+                    program_id,
                     "Program data account does not exist",
                 ));
             }
@@ -2615,7 +2614,7 @@ impl SurfnetSvmLocker {
                     "Setting new authority for program {}",
                     program_id
                 )));
-                let _ = simnet_events_tx.send(SimnetEvent::info(format!("Old Authority: None")));
+                let _ = simnet_events_tx.send(SimnetEvent::info("Old Authority: None".to_string()));
                 let _ = simnet_events_tx.send(SimnetEvent::info(format!("New Authority: {}", new)));
             }
             (None, None) => {
@@ -2889,6 +2888,7 @@ impl SurfnetSvmLocker {
     }
 
     /// Executes an airdrop via the underlying SVM.
+    #[allow(clippy::result_large_err)]
     pub fn airdrop(&self, pubkey: &Pubkey, lamports: u64) -> TransactionResult {
         self.with_svm_writer(|svm_writer| svm_writer.airdrop(pubkey, lamports))
     }
@@ -3005,7 +3005,7 @@ fn update_programdata_account(
     let upgradeable_loader_state =
         bincode::deserialize::<UpgradeableLoaderState>(&programdata_account.data).map_err(|e| {
             SurfpoolError::invalid_program_account(
-                &program_id,
+                program_id,
                 format!("Failed to serialize program data: {}", e),
             )
         })?;
@@ -3027,7 +3027,7 @@ fn update_programdata_account(
         })
         .map_err(|e| {
             SurfpoolError::invalid_program_account(
-                &program_id,
+                program_id,
                 format!("Failed to serialize program data: {}", e),
             )
         })?;
@@ -3038,15 +3038,15 @@ fn update_programdata_account(
 
         Ok(upgrade_authority_address)
     } else {
-        return Err(SurfpoolError::invalid_program_account(
-            &program_id,
+        Err(SurfpoolError::invalid_program_account(
+            program_id,
             "Invalid program data account",
-        ));
+        ))
     }
 }
 
 pub fn format_ui_amount_string(amount: u64, decimals: u8) -> String {
-    let formatted_amount = if decimals > 0 {
+    if decimals > 0 {
         let divisor = 10u64.pow(decimals as u32);
         format!(
             "{:.decimals$}",
@@ -3055,8 +3055,7 @@ pub fn format_ui_amount_string(amount: u64, decimals: u8) -> String {
         )
     } else {
         amount.to_string()
-    };
-    formatted_amount
+    }
 }
 
 pub fn format_ui_amount(amount: u64, decimals: u8) -> f64 {

--- a/crates/core/src/surfnet/mod.rs
+++ b/crates/core/src/surfnet/mod.rs
@@ -32,6 +32,7 @@ pub const SLOTS_PER_EPOCH: u64 = 432000;
 
 pub type AccountFactory = Box<dyn Fn(SurfnetSvmLocker) -> GetAccountResult + Send + Sync>;
 
+#[allow(clippy::large_enum_variant)]
 pub enum GeyserEvent {
     NotifyTransaction(TransactionWithStatusMeta, Option<SanitizedTransaction>),
     UpdateAccount(GeyserAccountUpdate),
@@ -152,6 +153,7 @@ impl GetAccountResult {
         }
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn map_account_with_token_data(
         self,
     ) -> Option<((Pubkey, Account), Option<(Pubkey, Option<Account>)>)> {
@@ -203,6 +205,7 @@ impl SignatureSubscriptionType {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 pub enum GetTransactionResult {
     None(Signature),
     FoundTransaction(

--- a/crates/core/src/surfnet/remote.rs
+++ b/crates/core/src/surfnet/remote.rs
@@ -105,7 +105,7 @@ impl SurfnetRemoteClient {
             Some(account) => {
                 let mut result = None;
                 if is_supported_token_program(&account.owner) {
-                    if let Some(token_account) = TokenAccount::unpack(&account.data).ok() {
+                    if let Ok(token_account) = TokenAccount::unpack(&account.data) {
                         let mint = self
                             .client
                             .get_account_with_commitment(&token_account.mint(), commitment_config)
@@ -158,7 +158,7 @@ impl SurfnetRemoteClient {
         for (pubkey, remote_account) in pubkeys.iter().zip(remote_accounts) {
             if let Some(remote_account) = remote_account {
                 if is_supported_token_program(&remote_account.owner) {
-                    if let Some(token_account) = TokenAccount::unpack(&remote_account.data).ok() {
+                    if let Ok(token_account) = TokenAccount::unpack(&remote_account.data) {
                         // TODO: move the query out of the loop to prevent rate-limiting by `api.mainnet-beta.solana.com`
                         let mint = self
                             .client
@@ -310,7 +310,6 @@ impl SurfnetRemoteClient {
                     },
                 )
                 .await
-                .map(|res| res)
                 .map_err(|e| SurfpoolError::get_program_accounts(*program_id, e))
         })
         .await

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -287,6 +287,7 @@ impl SurfnetSvm {
     ///
     /// # Returns
     /// A `TransactionResult` indicating success or failure.
+    #[allow(clippy::result_large_err)]
     pub fn airdrop(&mut self, pubkey: &Pubkey, lamports: u64) -> TransactionResult {
         let res = self.inner.airdrop(pubkey, lamports);
         let (status_tx, _rx) = unbounded();
@@ -311,14 +312,14 @@ impl SurfnetSvm {
             // we need the airdrop tx to store in our transactions list,
             // but for it to be properly processed we need its signature to match
             // the actual underlying transaction
-            tx.signatures[0] = tx_result.signature.clone();
+            tx.signatures[0] = tx_result.signature;
 
             let system_lamports = self
                 .get_account(&system_program::id())
                 .map(|a| a.lamports())
                 .unwrap_or(1);
             self.transactions.insert(
-                tx.get_signature().clone(),
+                *tx.get_signature(),
                 SurfnetTransactionStatus::processed(
                     TransactionWithStatusMeta {
                         slot,
@@ -669,6 +670,7 @@ impl SurfnetSvm {
     ///
     /// # Returns
     /// `Ok(res)` if processed successfully, or `Err(tx_failure)` if failed.
+    #[allow(clippy::result_large_err)]
     pub fn send_transaction(
         &mut self,
         tx: VersionedTransaction,
@@ -777,6 +779,7 @@ impl SurfnetSvm {
     ///
     /// # Returns
     /// `Ok(SimulatedTransactionInfo)` if successful, or `Err(FailedTransactionMetadata)` if failed.
+    #[allow(clippy::result_large_err)]
     pub fn simulate_transaction(
         &self,
         tx: VersionedTransaction,
@@ -864,12 +867,12 @@ impl SurfnetSvm {
                 let signature = &tx.signatures[0];
                 self.notify_signature_subscribers(
                     SignatureSubscriptionType::finalized(),
-                    &signature,
+                    signature,
                     self.latest_epoch_info.absolute_slot,
                     None,
                 );
                 let Some(SurfnetTransactionStatus::Processed(tx_data)) =
-                    self.transactions.get(&signature)
+                    self.transactions.get(signature)
                 else {
                     continue;
                 };
@@ -983,7 +986,7 @@ impl SurfnetSvm {
             num_non_vote_transactions: None,
         });
 
-        self.updated_at = self.updated_at + self.slot_time;
+        self.updated_at += self.slot_time;
         self.latest_epoch_info.slot_index += 1;
         self.latest_epoch_info.block_height = self.chain_tip.index;
         self.latest_epoch_info.absolute_slot += 1;
@@ -1358,7 +1361,7 @@ impl SurfnetSvm {
         let tag = tag.unwrap_or_else(|| uuid.to_string());
         self.profile_tag_map
             .entry(tag)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(UuidOrSignature::Uuid(uuid));
     }
 
@@ -1371,7 +1374,7 @@ impl SurfnetSvm {
             .insert(signature, profile_result);
         self.profile_tag_map
             .entry(signature.to_string())
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(UuidOrSignature::Signature(signature));
     }
 
@@ -1382,7 +1385,7 @@ impl SurfnetSvm {
     ) -> Receiver<(Slot, RpcLogsResponse)> {
         let (tx, rx) = unbounded();
         self.logs_subscriptions
-            .push((commitment_level.clone(), filter.clone(), tx));
+            .push((*commitment_level, filter.clone(), tx));
         rx
     }
 
@@ -1406,11 +1409,11 @@ impl SurfnetSvm {
     }
 
     pub fn register_idl(&mut self, idl: Idl, slot: Option<Slot>) {
-        let slot = slot.unwrap_or_else(|| self.latest_epoch_info.absolute_slot);
+        let slot = slot.unwrap_or(self.latest_epoch_info.absolute_slot);
         let program_id = Pubkey::from_str_const(&idl.address);
         self.registered_idls
             .entry(program_id)
-            .or_insert_with(BinaryHeap::new)
+            .or_default()
             .push(VersionedIdl(slot, idl));
     }
 
@@ -1427,19 +1430,19 @@ impl SurfnetSvm {
             AccountProfileState::Writable(account_change) => {
                 let change = match account_change {
                     AccountChange::Create(account) => UiAccountChange::Create(
-                        self.encode_ui_account(&pubkey, &account, *encoding, additional_data, None),
+                        self.encode_ui_account(pubkey, &account, *encoding, additional_data, None),
                     ),
                     AccountChange::Update(account_before, account_after) => {
                         UiAccountChange::Update(
                             self.encode_ui_account(
-                                &pubkey,
+                                pubkey,
                                 &account_before,
                                 *encoding,
                                 additional_data,
                                 None,
                             ),
                             self.encode_ui_account(
-                                &pubkey,
+                                pubkey,
                                 &account_after,
                                 *encoding,
                                 additional_data,
@@ -1448,12 +1451,12 @@ impl SurfnetSvm {
                         )
                     }
                     AccountChange::Delete(account) => UiAccountChange::Delete(
-                        self.encode_ui_account(&pubkey, &account, *encoding, additional_data, None),
+                        self.encode_ui_account(pubkey, &account, *encoding, additional_data, None),
                     ),
                     AccountChange::Unchanged(account) => {
                         UiAccountChange::Unchanged(account.map(|account| {
                             self.encode_ui_account(
-                                &pubkey,
+                                pubkey,
                                 &account,
                                 *encoding,
                                 additional_data,
@@ -1483,7 +1486,7 @@ impl SurfnetSvm {
 
         let account_states = pre_execution_capture
             .into_iter()
-            .zip(post_execution_capture.into_iter())
+            .zip(post_execution_capture)
             .map(|((pubkey, pre_account), (_, post_account))| {
                 // if pubkey != post {
                 //     panic!(
@@ -1526,22 +1529,14 @@ impl SurfnetSvm {
         let readonly_accounts = readonly_account_states.keys().cloned().collect::<Vec<_>>();
 
         let default = RpcProfileDepth::default();
-        let instruction_profiles = match config.depth.as_ref().unwrap_or(&default) {
-            &RpcProfileDepth::Transaction => None,
-            &RpcProfileDepth::Instruction => {
-                if let Some(instruction_profiles) = instruction_profiles {
-                    Some(
-                        instruction_profiles
-                            .into_iter()
-                            .map(|p| {
-                                self.encode_ui_profile_result(p, &readonly_accounts, &encoding)
-                            })
-                            .collect(),
-                    )
-                } else {
-                    None
-                }
-            }
+        let instruction_profiles = match *config.depth.as_ref().unwrap_or(&default) {
+            RpcProfileDepth::Transaction => None,
+            RpcProfileDepth::Instruction => instruction_profiles.map(|instruction_profiles| {
+                instruction_profiles
+                    .into_iter()
+                    .map(|p| self.encode_ui_profile_result(p, &readonly_accounts, &encoding))
+                    .collect()
+            }),
         };
 
         let transaction_profile =
@@ -1575,75 +1570,75 @@ impl SurfnetSvm {
         let owner_program_id = account.owner();
 
         let filter_slot = self.latest_epoch_info.absolute_slot; // todo: consider if we should pass in a slot
-        match encoding {
-            UiAccountEncoding::JsonParsed => {
-                if let Some(registered_idls) = self.registered_idls.get(owner_program_id) {
-                    let ordered_available_idls = registered_idls
+        if encoding == UiAccountEncoding::JsonParsed {
+            if let Some(registered_idls) = self.registered_idls.get(owner_program_id) {
+                let ordered_available_idls = registered_idls
+                    .iter()
+                    // only get IDLs that are active (their slot is before the latest slot)
+                    .filter_map(|VersionedIdl(slot, idl)| {
+                        if *slot <= filter_slot {
+                            Some(idl)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>();
+                // if we have none in this loop, it means the only IDLs registered for this pubkey are for a
+                // future slot, for some reason. if we have some, we'll try each one in this loop, starting
+                // with the most recent one, to see if the account data can be parsed to the IDL type
+                for idl in &ordered_available_idls {
+                    // If we have a valid IDL, use it to parse the account data
+                    let data = account.data();
+                    let discriminator = &data[..8];
+                    if let Some(matching_account) = idl
+                        .accounts
                         .iter()
-                        // only get IDLs that are active (their slot is before the latest slot)
-                        .filter_map(|VersionedIdl(slot, idl)| {
-                            if *slot <= filter_slot {
-                                Some(idl)
-                            } else {
-                                None
-                            }
-                        })
-                        .collect::<Vec<_>>();
-                    // if we have none in this loop, it means the only IDLs registered for this pubkey are for a
-                    // future slot, for some reason. if we have some, we'll try each one in this loop, starting
-                    // with the most recent one, to see if the account data can be parsed to the IDL type
-                    for idl in &ordered_available_idls {
-                        // If we have a valid IDL, use it to parse the account data
-                        let data = account.data();
-                        let discriminator = &data[..8];
-                        if let Some(matching_account) = idl
-                            .accounts
-                            .iter()
-                            .find(|a| a.discriminator.eq(&discriminator))
+                        .find(|a| a.discriminator.eq(&discriminator))
+                    {
+                        // If we found a matching account, we can look up the type to parse the account
+                        if let Some(account_type) =
+                            idl.types.iter().find(|t| t.name == matching_account.name)
                         {
-                            // If we found a matching account, we can look up the type to parse the account
-                            if let Some(account_type) =
-                                idl.types.iter().find(|t| t.name == matching_account.name)
-                            {
-                                let empty_vec = vec![];
-                                let idl_type_def_generics = idl
-                                    .types
-                                    .iter()
-                                    .find(|t| t.name == account_type.name)
-                                    .map(|t| &t.generics);
+                            let empty_vec = vec![];
+                            let idl_type_def_generics = idl
+                                .types
+                                .iter()
+                                .find(|t| t.name == account_type.name)
+                                .map(|t| &t.generics);
 
-                                // If we found a matching account type, we can use it to parse the account data
-                                let rest = data[8..].as_ref();
-                                if let Ok(parsed_value) =
-                                    parse_bytes_to_value_with_expected_idl_type_def_ty(
-                                        &rest,
-                                        &account_type.ty,
-                                        &idl.types,
-                                        &vec![],
-                                        idl_type_def_generics.unwrap_or(&empty_vec),
-                                    )
-                                {
-                                    return UiAccount {
-                                        lamports: account.lamports(),
-                                        data: UiAccountData::Json(ParsedAccount {
-                                            program: format!("{}", idl.metadata.name)
-                                                .to_case(convert_case::Case::Kebab),
-                                            parsed: parsed_value
-                                                .to_json(Some(&get_txtx_value_json_converters())),
-                                            space: data.len() as u64,
-                                        }),
-                                        owner: account.owner().to_string(),
-                                        executable: account.executable(),
-                                        rent_epoch: account.rent_epoch(),
-                                        space: Some(account.data().len() as u64),
-                                    };
-                                }
+                            // If we found a matching account type, we can use it to parse the account data
+                            let rest = data[8..].as_ref();
+                            if let Ok(parsed_value) =
+                                parse_bytes_to_value_with_expected_idl_type_def_ty(
+                                    rest,
+                                    &account_type.ty,
+                                    &idl.types,
+                                    &vec![],
+                                    idl_type_def_generics.unwrap_or(&empty_vec),
+                                )
+                            {
+                                return UiAccount {
+                                    lamports: account.lamports(),
+                                    data: UiAccountData::Json(ParsedAccount {
+                                        program: idl
+                                            .metadata
+                                            .name
+                                            .to_string()
+                                            .to_case(convert_case::Case::Kebab),
+                                        parsed: parsed_value
+                                            .to_json(Some(&get_txtx_value_json_converters())),
+                                        space: data.len() as u64,
+                                    }),
+                                    owner: account.owner().to_string(),
+                                    executable: account.executable(),
+                                    rent_epoch: account.rent_epoch(),
+                                    space: Some(account.data().len() as u64),
+                                };
                             }
                         }
                     }
                 }
             }
-            _ => {}
         }
 
         // Fall back to the default encoding

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -75,6 +75,8 @@ impl TransactionWithStatusMeta {
             confirmation_status: Some(TransactionConfirmationStatus::Finalized),
         }
     }
+
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         slot: u64,
         transaction: VersionedTransaction,
@@ -312,6 +314,8 @@ impl TransactionWithStatusMeta {
             }
         }
     }
+
+    #[allow(clippy::too_many_arguments)]
     pub fn from_failure(
         slot: u64,
         transaction: VersionedTransaction,
@@ -690,9 +694,7 @@ impl TokenAccount {
                     "frozen" => spl_token_2022::state::AccountState::Frozen,
                     "initialized" => spl_token_2022::state::AccountState::Initialized,
                     _ => {
-                        return Err(SurfpoolError::invalid_token_account_state(
-                            &state.to_string(),
-                        ));
+                        return Err(SurfpoolError::invalid_token_account_state(state));
                     }
                 }
             }
@@ -702,9 +704,7 @@ impl TokenAccount {
                     "frozen" => spl_token::state::AccountState::Frozen,
                     "initialized" => spl_token::state::AccountState::Initialized,
                     _ => {
-                        return Err(SurfpoolError::invalid_token_account_state(
-                            &state.to_string(),
-                        ));
+                        return Err(SurfpoolError::invalid_token_account_state(state));
                     }
                 }
             }
@@ -721,7 +721,7 @@ pub enum MintAccount {
 
 impl MintAccount {
     pub fn unpack(bytes: &[u8]) -> SurfpoolResult<Self> {
-        if let Ok(mint) = StateWithExtensions::<spl_token_2022::state::Mint>::unpack(&bytes) {
+        if let Ok(mint) = StateWithExtensions::<spl_token_2022::state::Mint>::unpack(bytes) {
             Ok(Self::SplToken2022(mint.base))
         } else if let Ok(mint) = spl_token_2022::state::Mint::unpack(bytes) {
             Ok(Self::SplToken2022(mint))

--- a/crates/gql/src/query.rs
+++ b/crates/gql/src/query.rs
@@ -246,15 +246,14 @@ pub fn extract_graphql_features<'a>(
                             match value.item {
                                 juniper::LookAheadValue::Object(obj) => {
                                     for (predicate, predicate_value) in obj.iter() {
-                                        match predicate_value.item {
-                                            juniper::LookAheadValue::Scalar(value) => {
-                                                filters_specs.push((
-                                                    attribute.item,
-                                                    predicate.item,
-                                                    value,
-                                                ));
-                                            }
-                                            _ => {}
+                                        if let juniper::LookAheadValue::Scalar(value) =
+                                            predicate_value.item
+                                        {
+                                            filters_specs.push((
+                                                attribute.item,
+                                                predicate.item,
+                                                value,
+                                            ));
                                         }
                                     }
                                 }

--- a/crates/gql/src/types/collections.rs
+++ b/crates/gql/src/types/collections.rs
@@ -48,7 +48,7 @@ impl CollectionMetadata {
         Self {
             id: *uuid,
             name: name.clone(),
-            table_name: format!("entries_{}", uuid.simple().to_string()),
+            table_name: format!("entries_{}", uuid.simple()),
             workspace_slug: workspace_slug.to_string(),
             filters: SubgraphFilterSpec {
                 name: format!("{}Filter", name),
@@ -77,34 +77,29 @@ impl GraphQLType<DefaultScalarValue> for CollectionMetadata {
         let mut fields: Vec<Field<'r, DefaultScalarValue>> = vec![];
         for field in metadata.fields.iter() {
             let registration = {
-                let description = field
-                    .data
-                    .description
-                    .as_ref()
-                    .map(|d| d.as_str())
-                    .unwrap_or("");
+                let description = field.data.description.as_deref().unwrap_or("");
                 match &field.data.expected_type {
                     Type::String => registry
                         .field::<&String>(&field.data.display_name, &())
-                        .description(&description),
+                        .description(description),
                     Type::Integer => registry
                         .field::<&BigInt>(&field.data.display_name, &())
-                        .description(&description),
+                        .description(description),
                     Type::Bool => registry
                         .field::<&String>(&field.data.display_name, &())
-                        .description(&description),
+                        .description(description),
                     Type::Float => registry
                         .field::<&String>(&field.data.display_name, &())
-                        .description(&description),
+                        .description(description),
                     Type::Null => registry
                         .field::<&String>(&field.data.display_name, &())
-                        .description(&description),
+                        .description(description),
                     Type::Array(_array) => registry
                         .field::<&String>(&field.data.display_name, &())
-                        .description(&description),
+                        .description(description),
                     Type::Buffer => registry
                         .field::<&String>(&field.data.display_name, &())
-                        .description(&description),
+                        .description(description),
                     Type::Addon(addon_id) => match addon_id.as_str() {
                         SVM_PUBKEY => registry
                             .field::<&PublicKey>(&field.data.display_name, &())
@@ -130,10 +125,10 @@ impl GraphQLType<DefaultScalarValue> for CollectionMetadata {
                     },
                     Type::Object(_object) => registry
                         .field::<&String>(&field.data.display_name, &())
-                        .description(&description),
+                        .description(description),
                     Type::Map(_map) => registry
                         .field::<&String>(&field.data.display_name, &())
-                        .description(&description),
+                        .description(description),
                 }
             };
             fields.push(registration);

--- a/crates/gql/src/types/mod.rs
+++ b/crates/gql/src/types/mod.rs
@@ -72,7 +72,7 @@ impl GraphQLValue<DefaultScalarValue> for CollectionEntry {
             "id" => executor.resolve_with_ctx(&(), &entry.id.to_string()),
             field_name => {
                 if let Some(schema) = entry.values.get(field_name) {
-                    return Ok(schema.clone());
+                    Ok(schema.clone())
                 } else {
                     Err(FieldError::new(
                         format!("field {} not found", field_name),
@@ -188,7 +188,7 @@ fn convert_txtx_values_to_juniper_values(
                 SVM_I32 => {
                     let num =
                         SvmValue::to_number::<i32>(&old).expect("could not convert value to i32");
-                    Value::scalar(num as i32)
+                    Value::scalar(num)
                 }
                 SVM_I64 => {
                     let num =
@@ -198,7 +198,7 @@ fn convert_txtx_values_to_juniper_values(
                 SVM_I128 => {
                     let num =
                         SvmValue::to_number::<i128>(&old).expect("could not convert value to i128");
-                    BigInt(num as i128).to_output()
+                    BigInt(num).to_output()
                 }
                 SVM_I256 => {
                     let num =

--- a/crates/mcp/src/surfpool/set_token_account.rs
+++ b/crates/mcp/src/surfpool/set_token_account.rs
@@ -153,13 +153,13 @@ impl SetTokenAccountsResponse {
 /// # Arguments
 /// * `surfnet_address`: The HTTP RPC endpoint of the target Surfnet instance .
 /// * `wallet_address_opt`: An optional base58-encoded public key of the wallet to fund.
-///                         If `None`, a new keypair is generated, and its details are returned.
+///   If `None`, a new keypair is generated, and its details are returned.
 /// * `token_mint`: A string indicating the token to fund. If not provided, the token symbol will be inferred from the token mint address.
-///                          a base58-encoded SPL token mint address, or a known symbol.
+///   a base58-encoded SPL token mint address, or a known symbol.
 /// * `token_amount`: An optional amount of the token to set (in its smallest unit, e.g., lamports for SOL).
-///                       If `None`, a default amount is used.
+///   If `None`, a default amount is used.
 /// * `program_id_opt`: An optional base58-encoded public key of the token-issuing program.
-///                     If `None`, defaults to the standard SPL Token program ID.
+///   If `None`, defaults to the standard SPL Token program ID.
 ///
 /// # Returns
 /// * `SetTokenAccountResponse`: Contains either details of the successful account update (including new wallet details if generated) or an error message.                             

--- a/crates/types/src/types.rs
+++ b/crates/types/src/types.rs
@@ -258,6 +258,7 @@ pub struct UiProfileResult {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase", tag = "type", content = "accountChange")]
+#[allow(clippy::large_enum_variant)]
 pub enum UiAccountProfileState {
     Readonly,
     Writable(UiAccountChange),
@@ -282,7 +283,6 @@ pub enum UiAccountChange {
 ///
 /// Profile result 2 is from executing Ix 1 and Ix 2
 /// AccountProfileState::Writable(P, AccountChange::Update( UiAccount { lamports: 400, ...}, UiAccount { lamports: 500, ... }))
-
 pub mod profile_state_map {
     use super::*;
 
@@ -531,9 +531,7 @@ impl Default for SimnetConfig {
 
 impl SimnetConfig {
     pub fn get_sanitized_datasource_url(&self) -> Option<String> {
-        let Some(raw) = self.remote_rpc_url.as_ref() else {
-            return None;
-        };
+        let raw = self.remote_rpc_url.as_ref()?;
         let base = raw
             .split('?')
             .next()
@@ -797,7 +795,7 @@ impl<'de> Deserialize<'de> for UuidOrSignature {
     }
 }
 
-impl<'de> Serialize for UuidOrSignature {
+impl Serialize for UuidOrSignature {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -848,15 +846,16 @@ pub struct FifoMap<K, V> {
     map: IndexMap<K, V>,
 }
 
+impl<K: std::hash::Hash + Eq, V> Default for FifoMap<K, V> {
+    fn default() -> Self {
+        Self::new(DEFAULT_PROFILING_MAP_CAPACITY)
+    }
+}
 impl<K: std::hash::Hash + Eq, V> FifoMap<K, V> {
     pub fn new(capacity: usize) -> Self {
         Self {
             map: IndexMap::with_capacity(capacity),
         }
-    }
-
-    pub fn default() -> Self {
-        Self::new(DEFAULT_PROFILING_MAP_CAPACITY)
     }
 
     pub fn capacity(&self) -> usize {


### PR DESCRIPTION
### Problem

ci command `cargo clippy --all-targets` reports a lot of warnings

this is an initial step to more strict linting of the project, related to #352 

### Summary of Changes

- apply suggestions where this is pretty safe
- add `#[allow(clippy::await_holding_lock)]`, ` #[allow(clippy::too_many_arguments)]`, and `#[allow(clippy::large_enum_variant)]` to places that require extensive refactoring


