### PR TITLE
feat: introduce the `surfnet_exportSnapshot` cheatcode

### DIFF
--- a/crates/core/src/rpc/surfnet_cheatcodes.rs
+++ b/crates/core/src/rpc/surfnet_cheatcodes.rs
@@ -4,7 +4,6 @@ use base64::{Engine as _, engine::general_purpose::STANDARD};
 use jsonrpc_core::{BoxFuture, Error, Result, futures::future};
 use jsonrpc_derive::rpc;
 use solana_account::Account;
-use solana_account_decoder::UiAccountEncoding;
 use solana_client::rpc_response::{RpcLogsResponse, RpcResponseContext};
 use solana_clock::Slot;
 use solana_commitment_config::CommitmentConfig;
@@ -15,8 +14,9 @@ use solana_system_interface::program as system_program;
 use solana_transaction::versioned::VersionedTransaction;
 use spl_associated_token_account_interface::address::get_associated_token_address_with_program_id;
 use surfpool_types::{
-    ClockCommand, GetSurfnetInfoResponse, Idl, ResetAccountConfig, RpcProfileResultConfig,
-    SimnetCommand, SimnetEvent, StreamAccountConfig, UiKeyedProfileResult,
+    AccountSnapshot, ClockCommand, ExportSnapshotConfig, GetSurfnetInfoResponse, Idl,
+    ResetAccountConfig, RpcProfileResultConfig, SimnetCommand, SimnetEvent, StreamAccountConfig,
+    UiKeyedProfileResult,
     types::{AccountUpdate, SetSomeAccount, SupplyUpdate, TokenAccountUpdate, UuidOrSignature},
 };
 
@@ -27,7 +27,7 @@ use crate::{
         State,
         utils::{verify_pubkey, verify_pubkeys},
     },
-    surfnet::{GetAccountResult, locker::SvmAccessContext, svm::AccountFixture},
+    surfnet::{GetAccountResult, locker::SvmAccessContext},
     types::{TimeTravelConfig, TokenAccount},
 };
 
@@ -749,25 +749,32 @@ pub trait SurfnetCheatcodes {
         config: Option<ResetAccountConfig>,
     ) -> Result<RpcResponse<()>>;
 
-    /// A cheat code to export all accounts as fixtures for testing.
+    /// A cheat code to export a snapshot of all accounts in the Surfnet SVM.
+    ///
+    /// This method retrieves the current state of all accounts stored in the Surfnet Virtual Machine (SVM)
+    /// and returns them as a mapping of account public keys to their respective account snapshots.
     ///
     /// ## Parameters
-    /// - `encoding` (optional): The encoding to use for account data. Defaults to `"base64"`.
-    ///   - `"base64"`: Returns raw account data as base64 encoded strings
-    ///   - `"jsonParsed"`: Attempts to parse known account types (tokens, programs with IDLs, etc.)
+    /// - `config`: An optional `ExportSnapshotConfig` to customize the export behavior. The config fields are:
+    ///     - `includeParsedAccounts`: If true, includes parsed account data in the snapshot.
+    ///     - `filter`: An optional filter config to limit which accounts are included in the snapshot. Fields include:
+    ///         - `includeProgramAccounts`: A list of program IDs to include accounts for.
+    ///         - `includeAccounts`: A list of specific account public keys to include.
+    ///         - `excludeAccounts`: A list of specific account public keys to exclude.
+    ///
     ///
     /// ## Returns
-    /// A `HashMap<String, AccountFixture>` where:
-    /// - Key: The account's public key as a base-58 string
-    /// - Value: An `AccountFixture` containing the account's full state
+    /// An `RpcResponse<BTreeMap<String, AccountSnapshot>>` containing the exported account snapshots.
+    ///
+    /// The keys of the map are the base-58 encoded public keys of the accounts,
+    /// and the values are the corresponding `AccountSnapshot` objects.
     ///
     /// ## Example Request
     /// ```json
     /// {
     ///   "jsonrpc": "2.0",
     ///   "id": 1,
-    ///   "method": "surfnet_exportSnapshot",
-    ///   "params": ["base64"]
+    ///   "method": "surfnet_exportSnapshot"
     /// }
     /// ```
     ///
@@ -777,12 +784,18 @@ pub trait SurfnetCheatcodes {
     ///   "jsonrpc": "2.0",
     ///   "result": {
     ///     "4EXSeLGxVBpAZwq7vm6evLdewpcvE2H56fpqL2pPiLFa": {
-    ///       "pubkey": "4EXSeLGxVBpAZwq7vm6evLdewpcvE2H56fpqL2pPiLFa",
     ///       "lamports": 1000000,
     ///       "owner": "11111111111111111111111111111111",
     ///       "executable": false,
-    ///       "rentEpoch": 0,
-    ///       "data": ["...", "base64"]
+    ///       "rent_epoch": 0,
+    ///       "data": "base64_encoded_data_string"
+    ///     },
+    ///     "AnotherAccountPubkeyBase58": {
+    ///       "lamports": 500000,
+    ///       "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    ///       "executable": false,
+    ///       "rent_epoch": 0,
+    ///       "data": "base64_encoded_data_string"
     ///     }
     ///   },
     ///   "id": 1
@@ -790,11 +803,11 @@ pub trait SurfnetCheatcodes {
     /// ```
     ///
     #[rpc(meta, name = "surfnet_exportSnapshot")]
-    fn export_account_fixtures(
+    fn export_snapshot(
         &self,
         meta: Self::Metadata,
-        encoding: Option<UiAccountEncoding>,
-    ) -> Result<BTreeMap<String, AccountFixture>>;
+        config: Option<ExportSnapshotConfig>,
+    ) -> Result<RpcResponse<BTreeMap<String, AccountSnapshot>>>;
 
     /// A cheat code to simulate account streaming.
     /// When a transaction is processed, the accounts that are accessed are downloaded from the datasource and cached in the SVM.
@@ -1438,14 +1451,18 @@ impl SurfnetCheatcodes for SurfnetCheatcodesRpc {
         })
     }
 
-    fn export_account_fixtures(
+    fn export_snapshot(
         &self,
         meta: Self::Metadata,
-        encoding: Option<UiAccountEncoding>,
-    ) -> Result<BTreeMap<String, AccountFixture>> {
-        let encoding = encoding.unwrap_or(UiAccountEncoding::Base64);
-        meta.with_svm_reader(|svm_reader| svm_reader.export_accounts_as_fixtures(encoding))
-            .map_err(Into::into)
+        config: Option<ExportSnapshotConfig>,
+    ) -> Result<RpcResponse<BTreeMap<String, AccountSnapshot>>> {
+        let config = config.unwrap_or_default();
+        let svm_locker = meta.get_svm_locker()?;
+        let snapshot = svm_locker.export_snapshot(config);
+        Ok(RpcResponse {
+            context: RpcResponseContext::new(svm_locker.get_latest_absolute_slot()),
+            value: snapshot,
+        })
     }
 }
 
@@ -1456,6 +1473,7 @@ mod tests {
     };
     use solana_keypair::Keypair;
     use solana_program_pack::Pack;
+    use solana_pubkey::Pubkey;
     use solana_signer::Signer;
     use solana_system_interface::instruction::create_account;
     use solana_transaction::Transaction;
@@ -1465,7 +1483,9 @@ mod tests {
     };
     use spl_token_2022_interface::instruction::{initialize_mint2, mint_to, transfer_checked};
     use spl_token_interface::state::Mint;
-    use surfpool_types::{RpcProfileDepth, UiAccountChange, UiAccountProfileState};
+    use surfpool_types::{
+        ExportSnapshotFilter, RpcProfileDepth, UiAccountChange, UiAccountProfileState,
+    };
 
     use super::*;
     use crate::{rpc::surfnet_cheatcodes::SurfnetCheatcodesRpc, tests::helpers::TestSetup};
@@ -2269,5 +2289,271 @@ mod tests {
                 account_states
             );
         }
+    }
+
+    fn set_account(client: &TestSetup<SurfnetCheatcodesRpc>, pubkey: &Pubkey, account: &Account) {
+        client
+            .context
+            .svm_locker
+            .with_svm_writer(|svm| svm.inner.set_account(*pubkey, account.clone()))
+            .expect("Failed to set account");
+    }
+
+    fn verify_snapshot_account(
+        snapshot: &BTreeMap<String, AccountSnapshot>,
+        expected_account_pubkey: &Pubkey,
+        expected_account: &Account,
+    ) {
+        let account = snapshot
+            .get(&expected_account_pubkey.to_string())
+            .unwrap_or_else(|| {
+                panic!(
+                    "Account fixture not found for pubkey {}",
+                    expected_account_pubkey
+                )
+            });
+        assert_eq!(expected_account.lamports, account.lamports);
+        assert_eq!(
+            base64::engine::general_purpose::STANDARD.encode(&expected_account.data),
+            account.data
+        );
+        assert_eq!(expected_account.owner.to_string(), account.owner);
+        assert_eq!(expected_account.executable, account.executable);
+        assert_eq!(expected_account.rent_epoch, account.rent_epoch);
+    }
+
+    #[test]
+    fn test_export_snapshot() {
+        let client = TestSetup::new(SurfnetCheatcodesRpc);
+
+        let pubkey1 = Pubkey::new_unique();
+        let account1 = Account {
+            lamports: 1_000_000,
+            data: vec![1, 2, 3, 4],
+            owner: system_program::id(),
+            executable: false,
+            rent_epoch: 0,
+        };
+
+        set_account(&client, &pubkey1, &account1);
+
+        let pubkey2 = Pubkey::new_unique();
+        let account2 = Account {
+            lamports: 2_000_000,
+            data: vec![5, 6, 7, 8, 9],
+            owner: system_program::id(),
+            executable: false,
+            rent_epoch: 0,
+        };
+
+        set_account(&client, &pubkey2, &account2);
+
+        let snapshot = client
+            .rpc
+            .export_snapshot(Some(client.context.clone()), None)
+            .expect("Failed to export snapshot")
+            .value;
+
+        verify_snapshot_account(&snapshot, &pubkey1, &account1);
+        verify_snapshot_account(&snapshot, &pubkey2, &account2);
+    }
+
+    #[test]
+    fn test_export_snapshot_json_parsed() {
+        let client = TestSetup::new(SurfnetCheatcodesRpc);
+
+        let pubkey1 = Pubkey::new_unique();
+        println!("Pubkey1: {}", pubkey1);
+        let account1 = Account {
+            lamports: 1_000_000,
+            data: vec![1, 2, 3, 4],
+            owner: system_program::id(),
+            executable: false,
+            rent_epoch: 0,
+        };
+
+        set_account(&client, &pubkey1, &account1);
+
+        let mint_pubkey = Pubkey::new_unique();
+        println!("Mint Pubkey: {}", mint_pubkey);
+        let mint_authority = Pubkey::new_unique();
+
+        let mut mint_data = [0u8; Mint::LEN];
+        let mint = Mint {
+            mint_authority: COption::Some(mint_authority),
+            supply: 1000,
+            decimals: 6,
+            is_initialized: true,
+            freeze_authority: COption::None,
+        };
+        mint.pack_into_slice(&mut mint_data);
+
+        let mint_account = Account {
+            lamports: 1_000_000,
+            data: mint_data.to_vec(),
+            owner: spl_token_interface::id(),
+            executable: false,
+            rent_epoch: 0,
+        };
+
+        set_account(&client, &mint_pubkey, &mint_account);
+
+        let snapshot = client
+            .rpc
+            .export_snapshot(
+                Some(client.context.clone()),
+                Some(ExportSnapshotConfig {
+                    include_parsed_accounts: Some(true),
+                    filter: None,
+                }),
+            )
+            .expect("Failed to export snapshot")
+            .value;
+
+        verify_snapshot_account(&snapshot, &pubkey1, &account1);
+        let actual_account1 = snapshot
+            .get(&pubkey1.to_string())
+            .expect("Account fixture not found");
+        assert!(
+            actual_account1.parsed_data.is_none(),
+            "Account1 should not have parsed data"
+        );
+
+        verify_snapshot_account(&snapshot, &mint_pubkey, &mint_account);
+        let mint_snapshot = snapshot
+            .get(&mint_pubkey.to_string())
+            .expect("Mint account snapshot not found");
+        let parsed = mint_snapshot
+            .parsed_data
+            .as_ref()
+            .expect("Parsed data should be present");
+
+        assert_eq!(parsed.program, "spl-token");
+        assert_eq!(parsed.space, Mint::LEN as u64);
+
+        let parsed_info = parsed
+            .parsed
+            .as_object()
+            .expect("Parsed data should be an object");
+        let info = parsed_info
+            .get("info")
+            .expect("Parsed data should have info field")
+            .as_object()
+            .expect("Info field should be an object");
+        assert_eq!(
+            info.get("mintAuthority")
+                .and_then(|v| v.as_str())
+                .expect("mintAuthority should be a string"),
+            mint_authority.to_string()
+        );
+    }
+
+    #[test]
+    fn test_export_snapshot_filtering() {
+        let system_account_pubkey = Pubkey::new_unique();
+        println!("System Account Pubkey: {}", system_account_pubkey);
+        let excluded_system_account_pubkey = Pubkey::new_unique();
+        println!(
+            "Excluded System Account Pubkey: {}",
+            excluded_system_account_pubkey
+        );
+        let program_account_pubkey = Pubkey::new_unique();
+        println!("Program Account Pubkey: {}", program_account_pubkey);
+        let included_program_account_pubkey = Pubkey::new_unique();
+        println!(
+            "Included Program Account Pubkey: {}",
+            included_program_account_pubkey
+        );
+
+        let client = TestSetup::new(SurfnetCheatcodesRpc);
+
+        let system_account = Account {
+            lamports: 1_000_000,
+            data: vec![1, 2, 3, 4],
+            owner: system_program::id(),
+            executable: false,
+            rent_epoch: 0,
+        };
+        set_account(&client, &system_account_pubkey, &system_account);
+        set_account(&client, &excluded_system_account_pubkey, &system_account);
+
+        let program_account = Account {
+            lamports: 2_000_000,
+            data: vec![5, 6, 7, 8, 9],
+            owner: solana_sdk_ids::bpf_loader_upgradeable::id(),
+            executable: false,
+            rent_epoch: 0,
+        };
+        set_account(&client, &program_account_pubkey, &program_account);
+        set_account(&client, &included_program_account_pubkey, &program_account);
+
+        let snapshot = client
+            .rpc
+            .export_snapshot(Some(client.context.clone()), None)
+            .expect("Failed to export snapshot")
+            .value;
+        assert!(
+            !snapshot.contains_key(&program_account_pubkey.to_string()),
+            "Program account should be excluded by default"
+        );
+        assert!(
+            !snapshot.contains_key(&included_program_account_pubkey.to_string()),
+            "Program account should be excluded by default"
+        );
+        let snapshot = client
+            .rpc
+            .export_snapshot(
+                Some(client.context.clone()),
+                Some(ExportSnapshotConfig {
+                    filter: Some(ExportSnapshotFilter {
+                        include_accounts: Some(vec![included_program_account_pubkey.to_string()]),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+            )
+            .expect("Failed to export snapshot")
+            .value;
+        assert!(
+            !snapshot.contains_key(&program_account_pubkey.to_string()),
+            "Program account should be excluded by default"
+        );
+        assert!(
+            snapshot.contains_key(&included_program_account_pubkey.to_string()),
+            "Program account should be included when explicitly listed"
+        );
+
+        let snapshot = client
+            .rpc
+            .export_snapshot(
+                Some(client.context.clone()),
+                Some(ExportSnapshotConfig {
+                    filter: Some(ExportSnapshotFilter {
+                        include_program_accounts: Some(true),
+                        exclude_accounts: Some(vec![excluded_system_account_pubkey.to_string()]),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+            )
+            .expect("Failed to export snapshot")
+            .value;
+
+        assert!(
+            snapshot.contains_key(&program_account_pubkey.to_string()),
+            "Program account should be included when filter is set"
+        );
+        assert!(
+            snapshot.contains_key(&included_program_account_pubkey.to_string()),
+            "Included program account should be present"
+        );
+        assert!(
+            snapshot.contains_key(&system_account_pubkey.to_string()),
+            "System account should be present"
+        );
+        assert!(
+            !snapshot.contains_key(&excluded_system_account_pubkey.to_string()),
+            "Excluded system account should not be present"
+        );
     }
 }

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -53,10 +53,10 @@ use solana_transaction_status::{
     UiTransactionEncoding,
 };
 use surfpool_types::{
-    ComputeUnitsEstimationResult, ExecutionCapture, Idl, KeyedProfileResult, ProfileResult,
-    RpcProfileResultConfig, RunbookExecutionStatusReport, SimnetCommand, SimnetEvent,
-    TransactionConfirmationStatus, TransactionStatusEvent, UiKeyedProfileResult, UuidOrSignature,
-    VersionedIdl,
+    AccountSnapshot, ComputeUnitsEstimationResult, ExecutionCapture, ExportSnapshotConfig, Idl,
+    KeyedProfileResult, ProfileResult, RpcProfileResultConfig, RunbookExecutionStatusReport,
+    SimnetCommand, SimnetEvent, TransactionConfirmationStatus, TransactionStatusEvent,
+    UiKeyedProfileResult, UuidOrSignature, VersionedIdl,
 };
 use tokio::sync::RwLock;
 use txtx_addon_kit::indexmap::IndexSet;
@@ -3008,6 +3008,13 @@ impl SurfnetSvmLocker {
                 svm_writer.instruction_profiling_enabled = true;
             }
         });
+    }
+
+    pub fn export_snapshot(
+        &self,
+        config: ExportSnapshotConfig,
+    ) -> BTreeMap<String, AccountSnapshot> {
+        self.with_svm_reader(|svm_reader| svm_reader.export_snapshot(config))
     }
 }
 

--- a/crates/types/src/types.rs
+++ b/crates/types/src/types.rs
@@ -12,7 +12,7 @@ use crossbeam_channel::{Receiver, Sender};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Visitor};
 use serde_with::{BytesOrString, serde_as};
 use solana_account::Account;
-use solana_account_decoder_client_types::{UiAccount, UiAccountEncoding};
+use solana_account_decoder_client_types::{ParsedAccount, UiAccount, UiAccountEncoding};
 use solana_clock::{Clock, Epoch, Slot};
 use solana_epoch_info::EpochInfo;
 use solana_message::inner_instruction::InnerInstructionsList;
@@ -953,6 +953,54 @@ impl<K: std::hash::Hash + Eq, V> FifoMap<K, V> {
     pub fn iter(&self) -> impl ExactSizeIterator<Item = (&K, &V)> {
         self.map.iter()
     }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountSnapshot {
+    pub lamports: u64,
+    pub owner: String,
+    pub executable: bool,
+    pub rent_epoch: u64,
+    /// Base64 encoded data
+    pub data: String,
+    /// Parsed account data if available
+    pub parsed_data: Option<ParsedAccount>,
+}
+
+impl AccountSnapshot {
+    pub fn new(
+        lamports: u64,
+        owner: String,
+        executable: bool,
+        rent_epoch: u64,
+        data: String,
+        parsed_data: Option<ParsedAccount>,
+    ) -> Self {
+        Self {
+            lamports,
+            owner,
+            executable,
+            rent_epoch,
+            data,
+            parsed_data,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportSnapshotConfig {
+    pub include_parsed_accounts: Option<bool>,
+    pub filter: Option<ExportSnapshotFilter>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportSnapshotFilter {
+    pub include_program_accounts: Option<bool>,
+    pub include_accounts: Option<Vec<String>>,
+    pub exclude_accounts: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
## Changes

## Flat Key/Value Dump with Slot Tracking

- Added `account_update_slots: HashMap<Pubkey, Slot>` field to **SurfnetSvm** to track when each account was last modified.  
- Updated `set_account()` method to record the modification slot for each account update.  
- Implemented `export_accounts_as_fixtures()` method that exports all accounts as a flat map with slot information.  
- Added `AccountFixture` struct with the following fields:  
  - **pubkey**: Account public key  
  - **lamports**: Account balance  
  - **owner**: Program owner  
  - **executable**: Executable flag  
  - **rent_epoch**: Rent epoch  
  - **data**: Account data (encoded based on specified encoding)  
  - **parsed_data**: Optional parsed data (when using `JsonParsed` encoding)  
  - **slot**: Absolute slot index when the account was last updated 

## RPC Method

- Added `surfnet_exportSnapshot` RPC method to **SurfnetCheatcodes** trait.  
- Accepts optional `encoding` parameter (defaults to `Base64`).  
- Returns `HashMap<String, AccountFixture>` with all accounts.  

---

## Test Coverage

-  `test_export_accounts_as_fixtures` — Basic export with Base64 encoding  
-  `test_export_accounts_as_fixtures_with_json_parsed` — Export with JsonParsed encoding for token accounts  
-  `test_export_accounts_at_different_slots` — Verify slot tracking across multiple slot updates  
