### PR TITLE
fix: parse inner instructions with proper account keys in `simulateTransaction`

### DIFF
--- a/crates/core/src/rpc/utils.rs
+++ b/crates/core/src/rpc/utils.rs
@@ -16,9 +16,10 @@ use solana_hash::Hash;
 use solana_packet::PACKET_DATA_SIZE;
 use solana_pubkey::{ParsePubkeyError, Pubkey};
 use solana_signature::Signature;
+use solana_message::{AccountKeys, VersionedMessage};
 use solana_transaction_status::{
-    InnerInstruction, InnerInstructions, TransactionBinaryEncoding, UiInnerInstructions,
-    UiTransactionEncoding,
+    parse_ui_inner_instructions, InnerInstruction, InnerInstructions, TransactionBinaryEncoding,
+    UiInnerInstructions, UiTransactionEncoding,
 };
 
 use crate::error::{SurfpoolError, SurfpoolResult};
@@ -179,7 +180,14 @@ where
         .map(|output| (wire_output, output))
 }
 
-pub fn transform_tx_metadata_to_ui_accounts(meta: TransactionMetadata) -> Vec<UiInnerInstructions> {
+pub fn transform_tx_metadata_to_ui_accounts(
+    meta: TransactionMetadata,
+    message: &VersionedMessage,
+    loaded_addresses: Option<&solana_message::v0::LoadedAddresses>,
+) -> Vec<UiInnerInstructions> {
+    // Create AccountKeys from the transaction message with loaded addresses from ALTs
+    let account_keys = AccountKeys::new(message.static_account_keys(), loaded_addresses);
+
     meta.inner_instructions
         .into_iter()
         .enumerate()
@@ -194,13 +202,13 @@ pub fn transform_tx_metadata_to_ui_accounts(meta: TransactionMetadata) -> Vec<Ui
             if instructions.is_empty() {
                 None
             } else {
-                Some(
-                    InnerInstructions {
-                        index: i as u8,
-                        instructions,
-                    }
-                    .into(),
-                )
+                // Create InnerInstructions and then parse it into UiInnerInstructions
+                // This will properly convert CompiledInstruction to UiInstruction format
+                let inner_instructions = InnerInstructions {
+                    index: i as u8,
+                    instructions,
+                };
+                Some(parse_ui_inner_instructions(inner_instructions, &account_keys))
             }
         })
         .collect()

--- a/crates/core/src/rpc/utils.rs
+++ b/crates/core/src/rpc/utils.rs
@@ -13,13 +13,13 @@ use solana_client::{
 };
 use solana_commitment_config::CommitmentConfig;
 use solana_hash::Hash;
+use solana_message::{AccountKeys, VersionedMessage};
 use solana_packet::PACKET_DATA_SIZE;
 use solana_pubkey::{ParsePubkeyError, Pubkey};
 use solana_signature::Signature;
-use solana_message::{AccountKeys, VersionedMessage};
 use solana_transaction_status::{
-    parse_ui_inner_instructions, InnerInstruction, InnerInstructions, TransactionBinaryEncoding,
-    UiInnerInstructions, UiTransactionEncoding,
+    InnerInstruction, InnerInstructions, TransactionBinaryEncoding, UiInnerInstructions,
+    UiTransactionEncoding, parse_ui_inner_instructions,
 };
 
 use crate::error::{SurfpoolError, SurfpoolResult};
@@ -208,7 +208,10 @@ pub fn transform_tx_metadata_to_ui_accounts(
                     index: i as u8,
                     instructions,
                 };
-                Some(parse_ui_inner_instructions(inner_instructions, &account_keys))
+                Some(parse_ui_inner_instructions(
+                    inner_instructions,
+                    &account_keys,
+                ))
             }
         })
         .collect()


### PR DESCRIPTION
The `simulateTransaction` RPC endpoint was returning inner instructions in raw `CompiledInstruction` format instead of the parsed `UiInstruction` format expected by Web3.js clients. This caused deserialization errors when clients tried to process the response.

See for more details:
https://github.com/solana-foundation/solana-com/issues/844

### Changes:
- Updated `transform_tx_metadata_to_ui_accounts` to accept transaction message and loaded addresses for proper account key resolution
- Used `parse_ui_inner_instructions` to convert `CompiledInstruction` to `UiInstruction` format with account keys from both static accounts and ALTs
- Updated `get_simulate_transaction_result` to pass message and loaded addresses
- Ensured proper handling of Address Lookup Tables in v0 transactions

This matches the behavior of the official Solana validator and fixes compatibility with Web3.js TypeScript client.