### PR TITLE
fix: preserve account order in `get_multiple_accounts_with_remote_fallback`

### DIFF
--- a/crates/core/src/rpc/accounts_data.rs
+++ b/crates/core/src/rpc/accounts_data.rs
@@ -1,16 +1,9 @@
-use super::{RunloopContext, SurfnetRpcContext};
-use crate::{
-    error::{SurfpoolError, SurfpoolResult},
-    rpc::{utils::verify_pubkey, State},
-    surfnet::locker::{is_supported_token_program, SvmAccessContext},
-    types::{MintAccount, TokenAccount},
-};
 use jsonrpc_core::{BoxFuture, Result};
 use jsonrpc_derive::rpc;
 use solana_account_decoder::{
-    parse_account_data::SplTokenAdditionalDataV2,
-    parse_token::{parse_token_v3, TokenAccountType, UiTokenAmount},
     UiAccount,
+    parse_account_data::SplTokenAdditionalDataV2,
+    parse_token::{TokenAccountType, UiTokenAmount, parse_token_v3},
 };
 use solana_client::{
     rpc_config::RpcAccountInfoConfig,
@@ -20,6 +13,14 @@ use solana_clock::Slot;
 use solana_commitment_config::CommitmentConfig;
 use solana_rpc_client_api::response::Response as RpcResponse;
 use solana_runtime::commitment::BlockCommitmentArray;
+
+use super::{RunloopContext, SurfnetRpcContext};
+use crate::{
+    error::{SurfpoolError, SurfpoolResult},
+    rpc::{State, utils::verify_pubkey},
+    surfnet::locker::{SvmAccessContext, is_supported_token_program},
+    types::{MintAccount, TokenAccount},
+};
 
 #[rpc]
 pub trait AccountsData {
@@ -679,7 +680,7 @@ mod tests {
     use solana_keypair::Keypair;
     use solana_program_option::COption;
     use solana_program_pack::Pack;
-    use solana_pubkey::{new_rand, Pubkey};
+    use solana_pubkey::{Pubkey, new_rand};
     use solana_signer::Signer;
     use solana_system_interface::instruction::create_account;
     use solana_transaction::Transaction;
@@ -691,7 +692,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        surfnet::{remote::SurfnetRemoteClient, GetAccountResult},
+        surfnet::{GetAccountResult, remote::SurfnetRemoteClient},
         tests::helpers::TestSetup,
         types::SyntheticBlockhash,
     };
@@ -1563,17 +1564,25 @@ mod tests {
 
         // First account should be account1 with 1M lamports
         assert!(response.value[0].is_some());
-        assert_eq!(response.value[0].as_ref().unwrap().lamports, 1_000_000,
-            "First element should be account1");
+        assert_eq!(
+            response.value[0].as_ref().unwrap().lamports,
+            1_000_000,
+            "First element should be account1"
+        );
 
         // Second account should be None (pk2 doesn't exist locally or remotely)
-        assert!(response.value[1].is_none(),
-            "Second element should be None for missing pk2");
+        assert!(
+            response.value[1].is_none(),
+            "Second element should be None for missing pk2"
+        );
 
         // Third account should be account3 with 3M lamports
         assert!(response.value[2].is_some());
-        assert_eq!(response.value[2].as_ref().unwrap().lamports, 3_000_000,
-            "Third element should be account3");
+        assert_eq!(
+            response.value[2].as_ref().unwrap().lamports,
+            3_000_000,
+            "Third element should be account3"
+        );
 
         println!("✅ Account order preserved with remote: [1M lamports, None, 3M lamports]");
     }

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -413,8 +413,12 @@ impl SurfnetSvmLocker {
         factory: Option<AccountFactory>,
     ) -> SurfpoolContextualizedResult<Vec<GetAccountResult>> {
         let results = if let Some((remote_client, commitment_config)) = remote_ctx {
-            self.get_multiple_accounts_with_remote_fallback(remote_client, pubkeys, *commitment_config)
-                .await?
+            self.get_multiple_accounts_with_remote_fallback(
+                remote_client,
+                pubkeys,
+                *commitment_config,
+            )
+            .await?
         } else {
             self.get_multiple_accounts_local(pubkeys)
         };


### PR DESCRIPTION
The `getMultipleAccounts` RPC endpoint was returning accounts in incorrect order when mixing local and remote results. The bug was in the underlying `get_multiple_accounts_local_then_remote` method, which was appending all found accounts first, then all remote accounts, breaking the original request order.

Root cause:
- `get_multiple_accounts_local_then_remote` split results into found/missing arrays
- Combined results as `[all_found, all_remote]` instead of preserving original order
- Example: requesting [pk1, pk2, pk3] with pk2 missing would return [pk1, pk3, pk2]

Changes:
- Renamed `get_multiple_accounts_local_then_remote → get_multiple_accounts_with_remote_fallback`
- Fixed order preservation by explicitly iterating through original pubkeys array
- Optimized to avoid cloning accounts: only clone remote results, move found accounts
- Simplified RPC handler by removing HashMap workaround (no longer needed)
- Updated documentation to clarify order preservation guarantee

Implementation:
- Build remote_map only for missing accounts
- Zip through (pubkeys, local_results) to merge in correct order
- Early return path when all found locally now has zero clones

This fixes the issue at the source, benefiting all callers of the method, and ensures the response array matches the request array order exactly as required by the Solana RPC specification.