### PR TITLE
feat(core): revert get_account_local and get_multiple_accounts_local

### DIFF
--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -230,28 +230,17 @@ impl SurfnetSvmLocker {
     pub fn get_account_local(&self, pubkey: &Pubkey) -> SvmAccessContext<GetAccountResult> {
         self.with_contextualized_svm_reader(|svm_reader| {
             match svm_reader.inner.get_account(pubkey) {
-                Some(account) => {
-                    // Treat zero-lamports or default accounts as deleted
-                    if account.eq(&Account::default()) || account.lamports == 0 {
-                        return GetAccountResult::None(*pubkey);
-                    }
-                    GetAccountResult::FoundAccount(
+                Some(account) => GetAccountResult::FoundAccount(
+                    *pubkey, account,
+                    // mark as not an account that should be updated in the SVM, since this is a local read and it already exists
+                    false,
+                ),
+                None => match svm_reader.get_account_from_feature_set(pubkey) {
+                    Some(account) => GetAccountResult::FoundAccount(
                         *pubkey, account,
                         // mark as not an account that should be updated in the SVM, since this is a local read and it already exists
                         false,
-                    )
-                }
-                None => match svm_reader.get_account_from_feature_set(pubkey) {
-                    Some(account) => {
-                        if account.eq(&Account::default()) || account.lamports == 0 {
-                            return GetAccountResult::None(*pubkey);
-                        }
-                        GetAccountResult::FoundAccount(
-                            *pubkey, account,
-                            // mark as not an account that should be updated in the SVM, since this is a local read and it already exists
-                            false,
-                        )
-                    }
+                    ),
                     None => GetAccountResult::None(*pubkey),
                 },
             }
@@ -307,29 +296,17 @@ impl SurfnetSvmLocker {
 
             for pubkey in pubkeys {
                 let res = match svm_reader.inner.get_account(pubkey) {
-                    Some(account) => {
-                        if account.eq(&Account::default()) || account.lamports == 0 {
-                            GetAccountResult::None(*pubkey)
-                        } else {
-                            GetAccountResult::FoundAccount(
-                                *pubkey, account,
-                                // mark as not an account that should be updated in the SVM, since this is a local read and it already exists
-                                false,
-                            )
-                        }
-                    }
+                    Some(account) => GetAccountResult::FoundAccount(
+                        *pubkey, account,
+                        // mark as not an account that should be updated in the SVM, since this is a local read and it already exists
+                        false,
+                    ),
                     None => match svm_reader.get_account_from_feature_set(pubkey) {
-                        Some(account) => {
-                            if account.eq(&Account::default()) || account.lamports == 0 {
-                                GetAccountResult::None(*pubkey)
-                            } else {
-                                GetAccountResult::FoundAccount(
-                                    *pubkey, account,
-                                    // mark as not an account that should be updated in the SVM, since this is a local read and it already exists
-                                    false,
-                                )
-                            }
-                        }
+                        Some(account) => GetAccountResult::FoundAccount(
+                            *pubkey, account,
+                            // mark as not an account that should be updated in the SVM, since this is a local read and it already exists
+                            false,
+                        ),
                         None => GetAccountResult::None(*pubkey),
                     },
                 };


### PR DESCRIPTION
LiteSVM got merged to update set_account to remove 0 lamports accounts. So get_account_local and get_multiple_accounts_local were reverted to the previous implementation. Re-ran surfpool-core integration tests that validate reset behavior:
- tests::integration::test_reset_account
- tests::integration::test_reset_account_cascade

Both passed successfully.

 LiteSVM reference: https://github.com/LiteSVM/litesvm/pull/218

Fixes #332 
 