### PR TITLE
feat: add environment variables for public-facing URLs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY --from=build /out/ /bin/
 
 WORKDIR /workspace
 
-EXPOSE 8899 8900 8488
+EXPOSE 8899 8900 18488
 
 # Create a shell script that provides default behavior
 RUN echo '#!/bin/bash\n\

--- a/crates/cli/src/cli/simnet/mod.rs
+++ b/crates/cli/src/cli/simnet/mod.rs
@@ -79,9 +79,16 @@ pub async fn handle_start_local_surfnet_command(
     let config = cmd.surfpool_config(airdrop_addresses);
 
     let studio_binding_address = config.studio.get_studio_base_url();
-    let rpc_url = format!("http://{}", config.rpc.get_rpc_base_url());
-    let ws_url = format!("ws://{}", config.rpc.get_ws_base_url());
-    let studio_url = format!("http://{}", studio_binding_address);
+
+    // Allow overriding public-facing URLs via environment variables
+    // This is useful when running behind a reverse proxy (e.g., Caddy, nginx)
+    let rpc_url = std::env::var("SURFPOOL_PUBLIC_RPC_URL")
+        .unwrap_or_else(|_| format!("http://{}", config.rpc.get_rpc_base_url()));
+    let ws_url = std::env::var("SURFPOOL_PUBLIC_WS_URL")
+        .unwrap_or_else(|_| format!("ws://{}", config.rpc.get_ws_base_url()));
+    let studio_url = std::env::var("SURFPOOL_PUBLIC_STUDIO_URL")
+        .unwrap_or_else(|_| format!("http://{}", studio_binding_address));
+
     let graphql_query_route_url = format!("{}/workspace/v1/graphql", studio_url);
     let rpc_datasource_url = config.simnets[0].get_sanitized_datasource_url();
 


### PR DESCRIPTION
Allow overriding public URLs via environment variables when running behind a reverse proxy. This fixes an issue where the UI would try to connect to bind addresses (e.g., http://0.0.0.0:8899) instead of the public-facing URLs.

The UI runs in the browser (client-side) and needs to know the public URLs to connect back to the API, not the internal bind addresses used by the Docker container.

New environment variables:
- `SURFPOOL_PUBLIC_RPC_URL`: Public RPC endpoint URL
- `SURFPOOL_PUBLIC_WS_URL`: Public WebSocket endpoint URL
- `SURFPOOL_PUBLIC_STUDIO_URL`: Public Studio UI URL

Also fix Dockerfile to expose correct port 18488 instead of outdated 8488.