### PR TITLE
fix: use block height instead of slot for `lastValidBlockHeight` in `getLatestBlockhash`

### DIFF
--- a/crates/core/src/rpc/full.rs
+++ b/crates/core/src/rpc/full.rs
@@ -2152,8 +2152,8 @@ impl Full for SurfpoolFullRpc {
             .get_latest_blockhash(&commitment)
             .unwrap_or_else(|| svm_locker.latest_absolute_blockhash());
 
-        let last_valid_block_height =
-            committed_latest_slot + MAX_RECENT_BLOCKHASHES_STANDARD as u64;
+        let current_block_height = svm_locker.get_epoch_info().block_height;
+        let last_valid_block_height = current_block_height + MAX_RECENT_BLOCKHASHES_STANDARD as u64;
         Ok(RpcResponse {
             context: RpcResponseContext::new(svm_locker.get_latest_absolute_slot()),
             value: RpcBlockhash {
@@ -3243,12 +3243,9 @@ mod tests {
                 .get_latest_blockhash(&commitment)
                 .unwrap();
 
-            let committed_slot = setup
-                .context
-                .svm_locker
-                .get_slot_for_commitment(&commitment);
+            let current_block_height = setup.context.svm_locker.get_epoch_info().block_height;
             let expected_last_valid_block_height =
-                committed_slot + MAX_RECENT_BLOCKHASHES_STANDARD as u64;
+                current_block_height + MAX_RECENT_BLOCKHASHES_STANDARD as u64;
 
             assert_eq!(
                 res.value.blockhash,
@@ -3280,12 +3277,9 @@ mod tests {
                 .get_latest_blockhash(&commitment)
                 .unwrap();
 
-            let committed_slot = setup
-                .context
-                .svm_locker
-                .get_slot_for_commitment(&commitment);
+            let current_block_height = setup.context.svm_locker.get_epoch_info().block_height;
             let expected_last_valid_block_height =
-                committed_slot + MAX_RECENT_BLOCKHASHES_STANDARD as u64;
+                current_block_height + MAX_RECENT_BLOCKHASHES_STANDARD as u64;
 
             assert_eq!(
                 res.value.blockhash,
@@ -3317,12 +3311,9 @@ mod tests {
                 .get_latest_blockhash(&commitment)
                 .unwrap();
 
-            let committed_slot = setup
-                .context
-                .svm_locker
-                .get_slot_for_commitment(&commitment);
+            let current_block_height = setup.context.svm_locker.get_epoch_info().block_height;
             let expected_last_valid_block_height =
-                committed_slot + MAX_RECENT_BLOCKHASHES_STANDARD as u64;
+                current_block_height + MAX_RECENT_BLOCKHASHES_STANDARD as u64;
 
             assert_eq!(
                 res.value.blockhash,


### PR DESCRIPTION
The `getLatestBlockhash` RPC endpoint was incorrectly calculating `lastValidBlockHeight` using the slot number instead of the actual block height. This caused the returned value to be orders of magnitude larger than expected.

For example, with slot 375,249,725 and block height 561,160, it was returning `lastValidBlockHeight` as 375,249,994 instead of the correct ~561,460.

Changes:
- Updated `get_latest_blockhash` to use `svm_locker.get_epoch_info().block_height` instead of `committed_latest_slot` when calculating `lastValidBlockHeight`
- Updated all related test cases to use the correct block height calculation
- Removed unused committed_slot variables from tests