### PR TITLE
fix: representation of timestamp in getTransaction rpc method

### DIFF
--- a/crates/core/src/rpc/full.rs
+++ b/crates/core/src/rpc/full.rs
@@ -1821,7 +1821,7 @@ impl Full for SurfpoolFullRpc {
                 svm_reader
                     .blocks
                     .get(&slot)
-                    .map(|block| (block.block_time / 1000) as UnixTimestamp)
+                    .map(|block| (block.block_time / 1_000) as UnixTimestamp)
             });
             Ok(block_time)
         })

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -30,7 +30,7 @@ use solana_client::{
         RpcLogsResponse, RpcTokenAccountBalance,
     },
 };
-use solana_clock::{Clock, Slot};
+use solana_clock::{Clock, Slot, UnixTimestamp};
 use solana_commitment_config::{CommitmentConfig, CommitmentLevel};
 use solana_epoch_info::EpochInfo;
 use solana_hash::Hash;
@@ -737,7 +737,7 @@ impl SurfnetSvmLocker {
             let block_time = svm_reader
                 .blocks
                 .get(&slot)
-                .map(|b| b.block_time)
+                .map(|b| (b.block_time / 1_000) as UnixTimestamp)
                 .unwrap_or(0);
             let encoded = transaction_with_status_meta.encode(
                 config.encoding.unwrap_or(UiTransactionEncoding::JsonParsed),


### PR DESCRIPTION
### Problem

Internally, a millisecond timestamp is in use, but UI representation requires a timestamp represented in seconds, which leads to weird results in the explorer

### Solution

cast milliseconds to seconds in the RPC response