### PR TITLE
feat(scenarios): add native Jupiter v6 support & refactor registry

### DIFF
--- a/crates/core/src/scenarios/README.md
+++ b/crates/core/src/scenarios/README.md
@@ -10,7 +10,12 @@ There are a few components that allow a scenario to function.
 
 ### Program IDL
 For Surfpool to understand how to serialize and deserialize account data, it needs to have access to the program's IDL. 
-Protocol's that are natively supported by Surfpool will have their IDLs included by default. 
+Protocols that are natively supported by Surfpool will have their IDLs included by default.
+
+**Currently supported protocols:**
+- **Pyth v2** - Price oracle with 4 price feed templates (SOL/USD, BTC/USD, ETH/BTC, ETH/USD)
+- **Jupiter v6** - DEX aggregator with TokenLedger manipulation template
+
 For custom protocols, an IDL can be registered at runtime using the [`surfnet_registerIdl`](https://docs.surfpool.run/rpc/cheatcodes#surfnet-registeridl) RPC cheatcode.
 
 ### Scenario Registration
@@ -30,11 +35,11 @@ All accounts in a surfnet's account db that are owned by the protocol will inclu
 
 The following steps can be followed to natively support a protocol:
  1. Create a folder for the protocol in the `crates/core/src/scenarios/protocols` folder. For example, `crates/core/src/scenarios/protocols/pyth/v2`.
- 2. Add a file called `idl.json` containing the protocol's anchor IDL to the folder. For example, see [Pyth's IDL](./protocols/pyth/v2/idl.json)
- 3. Add a file called `overrides.yaml` to the folder. For example, see [Pyth's Override File](./protocols/pyth/v2/overrides.yaml).
+ 2. Add a file called `idl.json` containing the protocol's anchor IDL to the folder. For example, see [Pyth's IDL](./protocols/pyth/v2/idl.json) or [Jupiter's IDL](./protocols/jupiter/v6/idl.json)
+ 3. Add a file called `overrides.yaml` to the folder. For example, see [Pyth's Override File](./protocols/pyth/v2/overrides.yaml) or [Jupiter's Override File](./protocols/jupiter/v6/overrides.yaml).
     1. This file is what will populate Surfpool Studio's UI with the protocol details. The Pyth override file linked above produces the following in the UI:
    ![Pyth Overrides](../../../..//doc/assets/pyth-overrides.png)
- 4. Update the [registry.rs](./registry.rs) file. A small amount of code has to be written to wire together the template registry, the `overrides.yaml`, and the `idl.json`. See the `load_pyth_overrides` function for example.
+ 4. Update the [registry.rs](./registry.rs) file. A small amount of code has to be written to wire together the template registry, the `overrides.yaml`, and the `idl.json`. See the `load_pyth_overrides` and `load_jupiter_overrides` functions for examples.
 
 If any part of these instructions are beyond your skill level or availability, but you'd like to see a specific protocol supported, feel free to [Open an Issue to Support a new Protocol](https://github.com/txtx/surfpool/issues/new?template=native-scenario-support-for-protocol.md)!
 Opening an issue to signal interest is a big help.

--- a/crates/core/src/scenarios/protocols/jupiter/v6/idl.json
+++ b/crates/core/src/scenarios/protocols/jupiter/v6/idl.json
@@ -1,0 +1,1353 @@
+{
+    "address": "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
+    "metadata": {
+        "name": "jupiter",
+        "version": "0.1.0",
+        "spec": "0.1.0",
+        "description": "Jupiter aggregator program"
+    },
+    "instructions": [
+        {
+            "name": "claim",
+            "discriminator": [
+                62,
+                199,
+                215,
+                190,
+                212,
+                142,
+                113,
+                10
+            ],
+            "accounts": [
+                {
+                    "name": "wallet",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "programAuthority",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "systemProgram",
+                    "isMut": false,
+                    "isSigner": false
+                }
+            ],
+            "args": [
+                {
+                    "name": "id",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "claimToken",
+            "discriminator": [
+                138,
+                246,
+                159,
+                14,
+                183,
+                24,
+                181,
+                121
+            ],
+            "accounts": [
+                {
+                    "name": "payer",
+                    "isMut": true,
+                    "isSigner": true
+                },
+                {
+                    "name": "wallet",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "programAuthority",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "programTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "destinationTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "pda",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "mint",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "tokenProgram",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "associatedTokenProgram",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "systemProgram",
+                    "isMut": false,
+                    "isSigner": false
+                }
+            ],
+            "args": [
+                {
+                    "name": "id",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "closeToken",
+            "discriminator": [
+                123,
+                17,
+                156,
+                18,
+                110,
+                128,
+                13,
+                134
+            ],
+            "accounts": [
+                {
+                    "name": "operator",
+                    "isMut": false,
+                    "isSigner": true
+                },
+                {
+                    "name": "wallet",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "programAuthority",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "programTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "mint",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "tokenProgram",
+                    "isMut": false,
+                    "isSigner": false
+                }
+            ],
+            "args": [
+                {
+                    "name": "id",
+                    "type": "u8"
+                },
+                {
+                    "name": "burnAll",
+                    "type": "bool"
+                }
+            ]
+        },
+        {
+            "name": "createTokenLedger",
+            "discriminator": [
+                107,
+                110,
+                10,
+                17,
+                104,
+                195,
+                124,
+                11
+            ],
+            "accounts": [
+                {
+                    "name": "tokenLedger",
+                    "isMut": true,
+                    "isSigner": true
+                },
+                {
+                    "name": "payer",
+                    "isMut": true,
+                    "isSigner": true
+                },
+                {
+                    "name": "systemProgram",
+                    "isMut": false,
+                    "isSigner": false
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "exactOutRoute",
+            "discriminator": [
+                185,
+                162,
+                181,
+                105,
+                116,
+                128,
+                114,
+                147
+            ],
+            "accounts": [
+                {
+                    "name": "tokenProgram",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "userTransferAuthority",
+                    "isMut": false,
+                    "isSigner": true
+                },
+                {
+                    "name": "destinationTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "destinationMint",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "programDestinationTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "programAuthority",
+                    "isMut": false,
+                    "isSigner": false
+                }
+            ],
+            "args": [
+                {
+                    "name": "routePlan",
+                    "type": {
+                        "vec": {
+                            "defined": {
+                                "name": "RoutePlanStep"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "outAmount",
+                    "type": "u64"
+                },
+                {
+                    "name": "slippageBps",
+                    "type": "u16"
+                },
+                {
+                    "name": "platformFeeBps",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "route",
+            "discriminator": [
+                229,
+                23,
+                203,
+                119,
+                221,
+                11,
+                109,
+                12
+            ],
+            "accounts": [
+                {
+                    "name": "tokenProgram",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "userTransferAuthority",
+                    "isMut": false,
+                    "isSigner": true
+                },
+                {
+                    "name": "destinationTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "programDestinationTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "programAuthority",
+                    "isMut": false,
+                    "isSigner": false
+                }
+            ],
+            "args": [
+                {
+                    "name": "routePlan",
+                    "type": {
+                        "vec": {
+                            "defined": {
+                                "name": "RoutePlanStep"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "inAmount",
+                    "type": "u64"
+                },
+                {
+                    "name": "quotedOutAmount",
+                    "type": "u64"
+                },
+                {
+                    "name": "slippageBps",
+                    "type": "u16"
+                },
+                {
+                    "name": "platformFeeBps",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "routeV2",
+            "discriminator": [
+                185,
+                141,
+                110,
+                197,
+                211,
+                182,
+                108,
+                209
+            ],
+            "accounts": [
+                {
+                    "name": "tokenProgram",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "userTransferAuthority",
+                    "isMut": false,
+                    "isSigner": true
+                },
+                {
+                    "name": "destinationTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "programDestinationTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "programAuthority",
+                    "isMut": false,
+                    "isSigner": false
+                }
+            ],
+            "args": [
+                {
+                    "name": "routePlan",
+                    "type": {
+                        "vec": {
+                            "defined": {
+                                "name": "RoutePlanStep"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "inAmount",
+                    "type": "u64"
+                },
+                {
+                    "name": "quotedOutAmount",
+                    "type": "u64"
+                },
+                {
+                    "name": "slippageBps",
+                    "type": "u16"
+                },
+                {
+                    "name": "platformFeeBps",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "exactOutRouteV2",
+            "discriminator": [
+                169,
+                183,
+                140,
+                162,
+                191,
+                115,
+                19,
+                15
+            ],
+            "accounts": [
+                {
+                    "name": "tokenProgram",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "userTransferAuthority",
+                    "isMut": false,
+                    "isSigner": true
+                },
+                {
+                    "name": "destinationTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "destinationMint",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "programDestinationTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "programAuthority",
+                    "isMut": false,
+                    "isSigner": false
+                }
+            ],
+            "args": [
+                {
+                    "name": "routePlan",
+                    "type": {
+                        "vec": {
+                            "defined": {
+                                "name": "RoutePlanStep"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "outAmount",
+                    "type": "u64"
+                },
+                {
+                    "name": "slippageBps",
+                    "type": "u16"
+                },
+                {
+                    "name": "platformFeeBps",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "setTokenLedger",
+            "discriminator": [
+                21,
+                143,
+                141,
+                195,
+                120,
+                111,
+                120,
+                114
+            ],
+            "accounts": [
+                {
+                    "name": "tokenLedger",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "tokenAccount",
+                    "isMut": false,
+                    "isSigner": false
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "sharedAccountsRoute",
+            "discriminator": [
+                121,
+                238,
+                166,
+                11,
+                110,
+                146,
+                129,
+                137
+            ],
+            "accounts": [
+                {
+                    "name": "tokenProgram",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "programAuthority",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "userTransferAuthority",
+                    "isMut": false,
+                    "isSigner": true
+                },
+                {
+                    "name": "sourceTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "programSourceTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "programDestinationTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "destinationTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "sourceMint",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "destinationMint",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "platformFeeAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "token2022Program",
+                    "isMut": false,
+                    "isSigner": false
+                }
+            ],
+            "args": [
+                {
+                    "name": "id",
+                    "type": "u8"
+                },
+                {
+                    "name": "routePlan",
+                    "type": {
+                        "vec": {
+                            "defined": {
+                                "name": "RoutePlanStep"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "inAmount",
+                    "type": "u64"
+                },
+                {
+                    "name": "quotedOutAmount",
+                    "type": "u64"
+                },
+                {
+                    "name": "slippageBps",
+                    "type": "u16"
+                },
+                {
+                    "name": "platformFeeBps",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "sharedAccountsRouteV2",
+            "discriminator": [
+                123,
+                141,
+                210,
+                115,
+                241,
+                229,
+                15,
+                101
+            ],
+            "accounts": [
+                {
+                    "name": "tokenProgram",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "programAuthority",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "userTransferAuthority",
+                    "isMut": false,
+                    "isSigner": true
+                },
+                {
+                    "name": "sourceTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "programSourceTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "programDestinationTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "destinationTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "sourceMint",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "destinationMint",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "platformFeeAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "token2022Program",
+                    "isMut": false,
+                    "isSigner": false
+                }
+            ],
+            "args": [
+                {
+                    "name": "id",
+                    "type": "u8"
+                },
+                {
+                    "name": "routePlan",
+                    "type": {
+                        "vec": {
+                            "defined": {
+                                "name": "RoutePlanStep"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "inAmount",
+                    "type": "u64"
+                },
+                {
+                    "name": "quotedOutAmount",
+                    "type": "u64"
+                },
+                {
+                    "name": "slippageBps",
+                    "type": "u16"
+                },
+                {
+                    "name": "platformFeeBps",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "sharedAccountsExactOutRoute",
+            "discriminator": [
+                62,
+                240,
+                229,
+                237,
+                146,
+                110,
+                12,
+                121
+            ],
+            "accounts": [
+                {
+                    "name": "tokenProgram",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "programAuthority",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "userTransferAuthority",
+                    "isMut": false,
+                    "isSigner": true
+                },
+                {
+                    "name": "sourceTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "programSourceTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "programDestinationTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "destinationTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "sourceMint",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "destinationMint",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "platformFeeAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "token2022Program",
+                    "isMut": false,
+                    "isSigner": false
+                }
+            ],
+            "args": [
+                {
+                    "name": "id",
+                    "type": "u8"
+                },
+                {
+                    "name": "routePlan",
+                    "type": {
+                        "vec": {
+                            "defined": {
+                                "name": "RoutePlanStep"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "outAmount",
+                    "type": "u64"
+                },
+                {
+                    "name": "quotedInAmount",
+                    "type": "u64"
+                },
+                {
+                    "name": "slippageBps",
+                    "type": "u16"
+                },
+                {
+                    "name": "platformFeeBps",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "sharedAccountsExactOutRouteV2",
+            "discriminator": [
+                138,
+                18,
+                12,
+                110,
+                155,
+                13,
+                113,
+                217
+            ],
+            "accounts": [
+                {
+                    "name": "tokenProgram",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "programAuthority",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "userTransferAuthority",
+                    "isMut": false,
+                    "isSigner": true
+                },
+                {
+                    "name": "sourceTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "programSourceTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "programDestinationTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "destinationTokenAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "sourceMint",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "destinationMint",
+                    "isMut": false,
+                    "isSigner": false
+                },
+                {
+                    "name": "platformFeeAccount",
+                    "isMut": true,
+                    "isSigner": false
+                },
+                {
+                    "name": "token2022Program",
+                    "isMut": false,
+                    "isSigner": false
+                }
+            ],
+            "args": [
+                {
+                    "name": "id",
+                    "type": "u8"
+                },
+                {
+                    "name": "routePlan",
+                    "type": {
+                        "vec": {
+                            "defined": {
+                                "name": "RoutePlanStep"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "outAmount",
+                    "type": "u64"
+                },
+                {
+                    "name": "quotedInAmount",
+                    "type": "u64"
+                },
+                {
+                    "name": "slippageBps",
+                    "type": "u16"
+                },
+                {
+                    "name": "platformFeeBps",
+                    "type": "u8"
+                }
+            ]
+        }
+    ],
+    "accounts": [
+        {
+            "name": "TokenLedger",
+            "discriminator": [
+                107,
+                110,
+                10,
+                17,
+                104,
+                195,
+                124,
+                11
+            ]
+        }
+    ],
+    "events": [
+        {
+            "name": "FeeEvent",
+            "discriminator": [
+                176,
+                228,
+                206,
+                50,
+                183,
+                217,
+                114,
+                174
+            ],
+            "fields": [
+                {
+                    "name": "fee",
+                    "type": {
+                        "defined": {
+                            "name": "Fee"
+                        }
+                    },
+                    "index": false
+                }
+            ]
+        },
+        {
+            "name": "RouteEvent",
+            "discriminator": [
+                152,
+                172,
+                199,
+                141,
+                68,
+                170,
+                154,
+                1
+            ],
+            "fields": [
+                {
+                    "name": "routePlan",
+                    "type": {
+                        "vec": {
+                            "defined": {
+                                "name": "RoutePlanStep"
+                            }
+                        }
+                    },
+                    "index": false
+                },
+                {
+                    "name": "inAmount",
+                    "type": "u64",
+                    "index": false
+                },
+                {
+                    "name": "outAmount",
+                    "type": "u64",
+                    "index": false
+                }
+            ]
+        },
+        {
+            "name": "SwapEvent",
+            "discriminator": [
+                187,
+                148,
+                175,
+                34,
+                155,
+                148,
+                175,
+                186
+            ],
+            "fields": [
+                {
+                    "name": "amm",
+                    "type": "pubkey",
+                    "index": false
+                },
+                {
+                    "name": "inputMint",
+                    "type": "pubkey",
+                    "index": false
+                },
+                {
+                    "name": "inputAmount",
+                    "type": "u64",
+                    "index": false
+                },
+                {
+                    "name": "outputMint",
+                    "type": "pubkey",
+                    "index": false
+                },
+                {
+                    "name": "outputAmount",
+                    "type": "u64",
+                    "index": false
+                }
+            ]
+        }
+    ],
+    "errors": [
+        {
+            "code": 6000,
+            "name": "EmptyRoute",
+            "msg": "Empty route"
+        },
+        {
+            "code": 6001,
+            "name": "InvalidRoute",
+            "msg": "Invalid route"
+        },
+        {
+            "code": 6002,
+            "name": "InvalidSlippage",
+            "msg": "Invalid slippage"
+        },
+        {
+            "code": 6003,
+            "name": "SlippageToleranceExceeded",
+            "msg": "Slippage tolerance exceeded"
+        },
+        {
+            "code": 6004,
+            "name": "InvalidCalculation",
+            "msg": "Invalid calculation"
+        },
+        {
+            "code": 6005,
+            "name": "InvalidTokenLedger",
+            "msg": "Invalid token ledger"
+        },
+        {
+            "code": 6006,
+            "name": "InvalidTokenAccount",
+            "msg": "Invalid token account"
+        },
+        {
+            "code": 6007,
+            "name": "InvalidInstruction",
+            "msg": "Invalid instruction"
+        },
+        {
+            "code": 6008,
+            "name": "InvalidPlatformFee",
+            "msg": "Invalid platform fee"
+        },
+        {
+            "code": 6009,
+            "name": "InvalidRemainingAccounts",
+            "msg": "Invalid remaining accounts"
+        },
+        {
+            "code": 6010,
+            "name": "NotEnoughAmount",
+            "msg": "Not enough amount"
+        },
+        {
+            "code": 6011,
+            "name": "InvalidTokenMint",
+            "msg": "Invalid token mint"
+        }
+    ],
+    "types": [
+        {
+            "name": "Fee",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "amount",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "RoutePlanStep",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "swap",
+                        "type": {
+                            "defined": {
+                                "name": "Swap"
+                            }
+                        }
+                    },
+                    {
+                        "name": "percent",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "inputIndex",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "outputIndex",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Side",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "Bid"
+                    },
+                    {
+                        "name": "Ask"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Swap",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "Saber"
+                    },
+                    {
+                        "name": "SaberAddDecimalsDeposit"
+                    },
+                    {
+                        "name": "SaberAddDecimalsWithdraw"
+                    },
+                    {
+                        "name": "TokenSwap"
+                    },
+                    {
+                        "name": "Sencha"
+                    },
+                    {
+                        "name": "Step"
+                    },
+                    {
+                        "name": "Cropper"
+                    },
+                    {
+                        "name": "Raydium"
+                    },
+                    {
+                        "name": "RaydiumClmm"
+                    },
+                    {
+                        "name": "Crema"
+                    },
+                    {
+                        "name": "Lifinity"
+                    },
+                    {
+                        "name": "LifinityV2"
+                    },
+                    {
+                        "name": "Mercurial"
+                    },
+                    {
+                        "name": "Cykura"
+                    },
+                    {
+                        "name": "Serum",
+                        "fields": [
+                            {
+                                "name": "side",
+                                "type": {
+                                    "defined": {
+                                        "name": "Side"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "MarinadeDeposit"
+                    },
+                    {
+                        "name": "MarinadeUnstake"
+                    },
+                    {
+                        "name": "Aldrin"
+                    },
+                    {
+                        "name": "AldrinV2"
+                    },
+                    {
+                        "name": "Whirl"
+                    },
+                    {
+                        "name": "Invariant"
+                    },
+                    {
+                        "name": "Meteora"
+                    },
+                    {
+                        "name": "GooseFX"
+                    },
+                    {
+                        "name": "DeltaFi",
+                        "fields": [
+                            {
+                                "name": "stable",
+                                "type": "bool"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "Balansol"
+                    },
+                    {
+                        "name": "MarcoPolo"
+                    },
+                    {
+                        "name": "Dradex"
+                    },
+                    {
+                        "name": "LifinityV2Token2022"
+                    },
+                    {
+                        "name": "RaydiumClmmV2"
+                    },
+                    {
+                        "name": "Openbook",
+                        "fields": [
+                            {
+                                "name": "side",
+                                "type": {
+                                    "defined": {
+                                        "name": "Side"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "Phoenix",
+                        "fields": [
+                            {
+                                "name": "side",
+                                "type": {
+                                    "defined": {
+                                        "name": "Side"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "Symmetry"
+                    },
+                    {
+                        "name": "TokenSwapV2"
+                    },
+                    {
+                        "name": "HeliumTreasuryManagementRedeemV0"
+                    },
+                    {
+                        "name": "StakeDexStakeWrappedSol"
+                    },
+                    {
+                        "name": "StakeDexSwapViaStake"
+                    },
+                    {
+                        "name": "GooseFXV2"
+                    },
+                    {
+                        "name": "Perps"
+                    },
+                    {
+                        "name": "PerpsAddLiquidity"
+                    },
+                    {
+                        "name": "PerpsRemoveLiquidity"
+                    },
+                    {
+                        "name": "MeteoraDlmm"
+                    },
+                    {
+                        "name": "OpenBookV2",
+                        "fields": [
+                            {
+                                "name": "side",
+                                "type": {
+                                    "defined": {
+                                        "name": "Side"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "RaydiumV3"
+                    },
+                    {
+                        "name": "RaydiumClmmV3"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "TokenLedger",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "tokenAccount",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "amount",
+                        "type": "u64"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/crates/core/src/scenarios/protocols/jupiter/v6/overrides.yaml
+++ b/crates/core/src/scenarios/protocols/jupiter/v6/overrides.yaml
@@ -1,0 +1,18 @@
+protocol: Jupiter
+version: v6
+idl_file_path: jupiter_v6.json
+
+tags:
+  - dex
+  - aggregator
+  - swap
+  - defi
+
+templates:
+  - id: jupiter-token-ledger-override
+    name: Override Jupiter Token Ledger
+    description: Override intermediate token amounts in multi-hop Jupiter swaps for edge case testing
+    idl_account_name: TokenLedger
+    properties: ["tokenAccount", "amount"]
+    address:
+      type: pubkey

--- a/crates/core/src/scenarios/registry.rs
+++ b/crates/core/src/scenarios/registry.rs
@@ -5,6 +5,9 @@ use surfpool_types::{OverrideTemplate, YamlOverrideTemplateCollection};
 pub const PYTH_V2_IDL_CONTENT: &str = include_str!("./protocols/pyth/v2/idl.json");
 pub const PYTH_V2_OVERRIDES_CONTENT: &str = include_str!("./protocols/pyth/v2/overrides.yaml");
 
+pub const JUPITER_V6_IDL_CONTENT: &str = include_str!("./protocols/jupiter/v6/idl.json");
+pub const JUPITER_V6_OVERRIDES_CONTENT: &str = include_str!("./protocols/jupiter/v6/overrides.yaml");
+
 /// Registry for managing override templates loaded from YAML files
 #[derive(Clone, Debug, Default)]
 pub struct TemplateRegistry {
@@ -17,19 +20,36 @@ impl TemplateRegistry {
     pub fn new() -> Self {
         let mut default = Self::default();
         default.load_pyth_overrides();
+        default.load_jupiter_overrides();
         default
     }
 
     pub fn load_pyth_overrides(&mut self) {
-        let idl = match serde_json::from_str(PYTH_V2_IDL_CONTENT) {
+        self.load_protocol_overrides(
+            PYTH_V2_IDL_CONTENT,
+            PYTH_V2_OVERRIDES_CONTENT,
+            "pyth",
+        );
+    }
+
+    pub fn load_jupiter_overrides(&mut self) {
+        self.load_protocol_overrides(
+            JUPITER_V6_IDL_CONTENT,
+            JUPITER_V6_OVERRIDES_CONTENT,
+            "jupiter",
+        );
+    }
+
+    fn load_protocol_overrides(&mut self, idl_content: &str, overrides_content: &str, protocol_name: &str) {
+        let idl = match serde_json::from_str(idl_content) {
             Ok(idl) => idl,
-            Err(e) => panic!("unable to load pyth idl: {}", e),
+            Err(e) => panic!("unable to load {} idl: {}", protocol_name, e),
         };
 
         let Ok(collection) =
-            serde_yaml::from_str::<YamlOverrideTemplateCollection>(PYTH_V2_OVERRIDES_CONTENT)
+            serde_yaml::from_str::<YamlOverrideTemplateCollection>(overrides_content)
         else {
-            panic!("unable to load pyth overrides");
+            panic!("unable to load {} overrides", protocol_name);
         };
 
         // Convert all templates in the collection
@@ -81,5 +101,91 @@ impl TemplateRegistry {
     /// List all template IDs
     pub fn list_ids(&self) -> Vec<String> {
         self.templates.keys().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_registry_loads_both_protocols() {
+        let registry = TemplateRegistry::new();
+        
+        // Should have Pyth (4 templates) + Jupiter (1 template) = 5 total
+        assert_eq!(registry.count(), 5, "Registry should load 5 templates total");
+        
+        assert!(registry.contains("pyth-sol-usd-v2"));
+        assert!(registry.contains("pyth-btc-usd-v2"));
+        assert!(registry.contains("pyth-eth-btc-v2"));
+        assert!(registry.contains("pyth-eth-usd-v2"));
+        
+        assert!(registry.contains("jupiter-token-ledger-override"));
+    }
+
+    #[test]
+    fn test_jupiter_template_loads_correctly() {
+        let registry = TemplateRegistry::new();
+        
+        let jupiter_template = registry.get("jupiter-token-ledger-override")
+            .expect("Jupiter template should exist");
+        
+        assert_eq!(jupiter_template.protocol, "Jupiter");
+        assert_eq!(jupiter_template.account_type, "TokenLedger");
+        assert_eq!(jupiter_template.name, "Override Jupiter Token Ledger");
+        assert_eq!(jupiter_template.properties.len(), 2);
+        
+        assert!(jupiter_template.properties.contains(&"tokenAccount".to_string()));
+        assert!(jupiter_template.properties.contains(&"amount".to_string()));
+        assert!(jupiter_template.tags.contains(&"dex".to_string()));
+        assert!(jupiter_template.tags.contains(&"aggregator".to_string()));
+        assert!(jupiter_template.tags.contains(&"swap".to_string()));
+        assert!(jupiter_template.tags.contains(&"defi".to_string()));
+    }
+
+    #[test]
+    fn test_filter_by_protocol() {
+        let registry = TemplateRegistry::new();
+        
+        let pyth_templates = registry.by_protocol("Pyth");
+        assert_eq!(pyth_templates.len(), 4, "Should have 4 Pyth templates");
+        
+        let jupiter_templates = registry.by_protocol("Jupiter");
+        assert_eq!(jupiter_templates.len(), 1, "Should have 1 Jupiter template");
+    }
+
+    #[test]
+    fn test_filter_by_tags() {
+        let registry = TemplateRegistry::new();
+        
+        let oracle_templates = registry.by_tags(&[vec!["oracle".to_string()]].concat());
+        assert_eq!(oracle_templates.len(), 4, "Should find 4 oracle templates (Pyth)");
+        
+        let dex_templates = registry.by_tags(&[vec!["dex".to_string()]].concat());
+        assert_eq!(dex_templates.len(), 1, "Should find 1 dex template (Jupiter)");
+        
+        let aggregator_templates = registry.by_tags(&[vec!["aggregator".to_string()]].concat());
+        assert_eq!(aggregator_templates.len(), 1, "Should find 1 aggregator template (Jupiter)");
+    }
+
+    #[test]
+    fn test_jupiter_idl_has_token_ledger_account() {
+        let registry = TemplateRegistry::new();
+        let jupiter_template = registry.get("jupiter-token-ledger-override").unwrap();
+        let has_token_ledger = jupiter_template.idl.accounts
+            .iter()
+            .any(|acc| acc.name == "TokenLedger");
+        
+        assert!(has_token_ledger, "IDL should contain TokenLedger account");
+    }
+
+    #[test]
+    fn test_list_all_template_ids() {
+        let registry = TemplateRegistry::new();
+        let ids = registry.list_ids();
+        
+        assert_eq!(ids.len(), 5);
+        assert!(ids.contains(&"jupiter-token-ledger-override".to_string()));
+        assert!(ids.contains(&"pyth-sol-usd-v2".to_string()));
     }
 }


### PR DESCRIPTION
Problem Surfpool lacked native scenario support for Jupiter v6, preventing users from easily overriding swap states (e.g., TokenLedger). Additionally, the template registry contained duplicated logic for loading protocol overrides.

