### PR TITLE
feat(scenario): add drift on-chain perp dex V2 scenario

### DIFF
--- a/crates/core/src/scenarios/README.md
+++ b/crates/core/src/scenarios/README.md
@@ -15,6 +15,7 @@ Protocols that are natively supported by Surfpool will have their IDLs included 
 **Currently supported protocols:**
 - **Pyth v2** - Price oracle with 4 price feed templates (SOL/USD, BTC/USD, ETH/BTC, ETH/USD)
 - **Jupiter v6** - DEX aggregator with TokenLedger manipulation template
+- **Drift v2** - Perp and spot markets, user state, and global state
 
 For custom protocols, an IDL can be registered at runtime using the [`surfnet_registerIdl`](https://docs.surfpool.run/rpc/cheatcodes#surfnet-registeridl) RPC cheatcode.
 

--- a/crates/core/src/scenarios/protocols/drift/v2/idl.json
+++ b/crates/core/src/scenarios/protocols/drift/v2/idl.json
@@ -1,0 +1,7393 @@
+{
+  "address": "dRiftyHA39MWEi3m9aunc5MzRF1JYuBsbn6VPcn33UH",
+  "metadata": {
+    "name": "drift",
+    "version": "2.145.1",
+    "spec": "0.1.0"
+  },
+  "instructions": [],
+  "accounts": [
+    {
+      "name": "AmmCache",
+      "discriminator": [
+        213,
+        114,
+        161,
+        56,
+        20,
+        22,
+        2,
+        59
+      ]
+    },
+    {
+      "name": "OpenbookV2FulfillmentConfig",
+      "discriminator": [
+        3,
+        43,
+        58,
+        106,
+        131,
+        132,
+        199,
+        171
+      ]
+    },
+    {
+      "name": "PhoenixV1FulfillmentConfig",
+      "discriminator": [
+        233,
+        45,
+        62,
+        40,
+        35,
+        129,
+        48,
+        72
+      ]
+    },
+    {
+      "name": "SerumV3FulfillmentConfig",
+      "discriminator": [
+        65,
+        160,
+        197,
+        112,
+        239,
+        168,
+        103,
+        185
+      ]
+    },
+    {
+      "name": "HighLeverageModeConfig",
+      "discriminator": [
+        3,
+        196,
+        90,
+        189,
+        193,
+        64,
+        228,
+        234
+      ]
+    },
+    {
+      "name": "IfRebalanceConfig",
+      "discriminator": [
+        214,
+        84,
+        40,
+        251,
+        107,
+        144,
+        173,
+        239
+      ]
+    },
+    {
+      "name": "InsuranceFundStake",
+      "discriminator": [
+        110,
+        202,
+        14,
+        42,
+        95,
+        73,
+        90,
+        95
+      ]
+    },
+    {
+      "name": "ProtocolIfSharesTransferConfig",
+      "discriminator": [
+        188,
+        1,
+        213,
+        98,
+        23,
+        148,
+        30,
+        1
+      ]
+    },
+    {
+      "name": "LPPool",
+      "discriminator": [
+        228,
+        152,
+        141,
+        224,
+        161,
+        170,
+        11,
+        89
+      ]
+    },
+    {
+      "name": "Constituent",
+      "discriminator": [
+        0,
+        61,
+        36,
+        35,
+        177,
+        76,
+        216,
+        205
+      ]
+    },
+    {
+      "name": "AmmConstituentMapping",
+      "discriminator": [
+        254,
+        89,
+        5,
+        173,
+        66,
+        54,
+        214,
+        247
+      ]
+    },
+    {
+      "name": "ConstituentTargetBase",
+      "discriminator": [
+        255,
+        142,
+        134,
+        71,
+        125,
+        66,
+        198,
+        99
+      ]
+    },
+    {
+      "name": "ConstituentCorrelations",
+      "discriminator": [
+        124,
+        203,
+        115,
+        33,
+        18,
+        162,
+        67,
+        216
+      ]
+    },
+    {
+      "name": "PrelaunchOracle",
+      "discriminator": [
+        92,
+        14,
+        139,
+        234,
+        72,
+        244,
+        68,
+        26
+      ]
+    },
+    {
+      "name": "PerpMarket",
+      "discriminator": [
+        10,
+        223,
+        12,
+        44,
+        107,
+        245,
+        55,
+        247
+      ]
+    },
+    {
+      "name": "ProtectedMakerModeConfig",
+      "discriminator": [
+        47,
+        86,
+        90,
+        9,
+        224,
+        255,
+        10,
+        69
+      ]
+    },
+    {
+      "name": "PythLazerOracle",
+      "discriminator": [
+        159,
+        7,
+        161,
+        249,
+        34,
+        81,
+        121,
+        133
+      ]
+    },
+    {
+      "name": "RevenueShare",
+      "discriminator": [
+        55,
+        40,
+        228,
+        7,
+        139,
+        52,
+        180,
+        110
+      ]
+    },
+    {
+      "name": "RevenueShareEscrow",
+      "discriminator": [
+        98,
+        167,
+        3,
+        46,
+        74,
+        177,
+        173,
+        252
+      ]
+    },
+    {
+      "name": "SignedMsgUserOrders",
+      "discriminator": [
+        70,
+        6,
+        50,
+        248,
+        222,
+        1,
+        143,
+        49
+      ]
+    },
+    {
+      "name": "SignedMsgWsDelegates",
+      "discriminator": [
+        190,
+        115,
+        111,
+        44,
+        216,
+        252,
+        108,
+        85
+      ]
+    },
+    {
+      "name": "SpotMarket",
+      "discriminator": [
+        100,
+        177,
+        8,
+        107,
+        168,
+        65,
+        65,
+        39
+      ]
+    },
+    {
+      "name": "State",
+      "discriminator": [
+        216,
+        146,
+        107,
+        94,
+        104,
+        75,
+        182,
+        177
+      ]
+    },
+    {
+      "name": "User",
+      "discriminator": [
+        159,
+        117,
+        95,
+        227,
+        239,
+        151,
+        58,
+        236
+      ]
+    },
+    {
+      "name": "UserStats",
+      "discriminator": [
+        176,
+        223,
+        136,
+        27,
+        122,
+        79,
+        32,
+        227
+      ]
+    },
+    {
+      "name": "ReferrerName",
+      "discriminator": [
+        105,
+        133,
+        170,
+        110,
+        52,
+        42,
+        28,
+        182
+      ]
+    },
+    {
+      "name": "FuelOverflow",
+      "discriminator": [
+        182,
+        64,
+        231,
+        177,
+        226,
+        142,
+        69,
+        58
+      ]
+    }
+  ],
+  "types": [
+    {
+      "name": "UpdatePerpMarketSummaryStatsParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "quote_asset_amount_with_unsettled_lp",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "net_unsettled_funding_pnl",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "update_amm_summary_stats",
+            "type": {
+              "option": "bool"
+            }
+          },
+          {
+            "name": "exclude_total_liq_fee",
+            "type": {
+              "option": "bool"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConstituentParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "max_weight_deviation",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "swap_fee_min",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "swap_fee_max",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "max_borrow_token_amount",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "oracle_staleness_threshold",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "cost_to_trade_bps",
+            "type": {
+              "option": "i32"
+            }
+          },
+          {
+            "name": "constituent_derivative_index",
+            "type": {
+              "option": "i16"
+            }
+          },
+          {
+            "name": "derivative_weight",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "volatility",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "gamma_execution",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "gamma_inventory",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "xi",
+            "type": {
+              "option": "u8"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LpPoolParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "max_settle_quote_amount",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "volatility",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "gamma_execution",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "xi",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "max_aum",
+            "type": {
+              "option": "u128"
+            }
+          },
+          {
+            "name": "whitelist_mint",
+            "type": {
+              "option": "pubkey"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "OverrideAmmCacheParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "quote_owed_from_lp_pool",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "last_settle_slot",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "last_fee_pool_token_amount",
+            "type": {
+              "option": "u128"
+            }
+          },
+          {
+            "name": "last_net_pnl_pool_token_amount",
+            "type": {
+              "option": "i128"
+            }
+          },
+          {
+            "name": "amm_position_scalar",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "amm_inventory_limit",
+            "type": {
+              "option": "i64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AddAmmConstituentMappingDatum",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "constituent_index",
+            "type": "u16"
+          },
+          {
+            "name": "perp_market_index",
+            "type": "u16"
+          },
+          {
+            "name": "weight",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CacheInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "last_fee_pool_token_amount",
+            "type": "u128"
+          },
+          {
+            "name": "last_net_pnl_pool_token_amount",
+            "type": "i128"
+          },
+          {
+            "name": "last_exchange_fees",
+            "type": "u128"
+          },
+          {
+            "name": "last_settle_amm_ex_fees",
+            "type": "u128"
+          },
+          {
+            "name": "last_settle_amm_pnl",
+            "type": "i128"
+          },
+          {
+            "name": "position",
+            "docs": [
+              "BASE PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "slot",
+            "type": "u64"
+          },
+          {
+            "name": "last_settle_amount",
+            "type": "u64"
+          },
+          {
+            "name": "last_settle_slot",
+            "type": "u64"
+          },
+          {
+            "name": "last_settle_ts",
+            "type": "i64"
+          },
+          {
+            "name": "quote_owed_from_lp_pool",
+            "type": "i64"
+          },
+          {
+            "name": "amm_inventory_limit",
+            "type": "i64"
+          },
+          {
+            "name": "oracle_price",
+            "type": "i64"
+          },
+          {
+            "name": "oracle_slot",
+            "type": "u64"
+          },
+          {
+            "name": "market_index",
+            "type": "u16"
+          },
+          {
+            "name": "oracle_source",
+            "type": "u8"
+          },
+          {
+            "name": "oracle_validity",
+            "type": "u8"
+          },
+          {
+            "name": "lp_status_for_perp_market",
+            "type": "u8"
+          },
+          {
+            "name": "amm_position_scalar",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                34
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AmmCacheFixed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "pad",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "len",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidatePerpRecord",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "market_index",
+            "type": "u16"
+          },
+          {
+            "name": "oracle_price",
+            "type": "i64"
+          },
+          {
+            "name": "base_asset_amount",
+            "type": "i64"
+          },
+          {
+            "name": "quote_asset_amount",
+            "type": "i64"
+          },
+          {
+            "name": "lp_shares",
+            "docs": [
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "fill_record_id",
+            "type": "u64"
+          },
+          {
+            "name": "user_order_id",
+            "type": "u32"
+          },
+          {
+            "name": "liquidator_order_id",
+            "type": "u32"
+          },
+          {
+            "name": "liquidator_fee",
+            "docs": [
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "if_fee",
+            "docs": [
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidateSpotRecord",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "asset_market_index",
+            "type": "u16"
+          },
+          {
+            "name": "asset_price",
+            "type": "i64"
+          },
+          {
+            "name": "asset_transfer",
+            "type": "u128"
+          },
+          {
+            "name": "liability_market_index",
+            "type": "u16"
+          },
+          {
+            "name": "liability_price",
+            "type": "i64"
+          },
+          {
+            "name": "liability_transfer",
+            "docs": [
+              "precision: token mint precision"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "if_fee",
+            "docs": [
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidateBorrowForPerpPnlRecord",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "perp_market_index",
+            "type": "u16"
+          },
+          {
+            "name": "market_oracle_price",
+            "type": "i64"
+          },
+          {
+            "name": "pnl_transfer",
+            "type": "u128"
+          },
+          {
+            "name": "liability_market_index",
+            "type": "u16"
+          },
+          {
+            "name": "liability_price",
+            "type": "i64"
+          },
+          {
+            "name": "liability_transfer",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidatePerpPnlForDepositRecord",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "perp_market_index",
+            "type": "u16"
+          },
+          {
+            "name": "market_oracle_price",
+            "type": "i64"
+          },
+          {
+            "name": "pnl_transfer",
+            "type": "u128"
+          },
+          {
+            "name": "asset_market_index",
+            "type": "u16"
+          },
+          {
+            "name": "asset_price",
+            "type": "i64"
+          },
+          {
+            "name": "asset_transfer",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PerpBankruptcyRecord",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "market_index",
+            "type": "u16"
+          },
+          {
+            "name": "pnl",
+            "type": "i128"
+          },
+          {
+            "name": "if_payment",
+            "type": "u128"
+          },
+          {
+            "name": "clawback_user",
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "clawback_user_payment",
+            "type": {
+              "option": "u128"
+            }
+          },
+          {
+            "name": "cumulative_funding_rate_delta",
+            "type": "i128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpotBankruptcyRecord",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "market_index",
+            "type": "u16"
+          },
+          {
+            "name": "borrow_amount",
+            "type": "u128"
+          },
+          {
+            "name": "if_payment",
+            "type": "u128"
+          },
+          {
+            "name": "cumulative_deposit_interest_delta",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "IfRebalanceConfigParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "total_in_amount",
+            "type": "u64"
+          },
+          {
+            "name": "epoch_max_in_amount",
+            "type": "u64"
+          },
+          {
+            "name": "epoch_duration",
+            "type": "i64"
+          },
+          {
+            "name": "out_market_index",
+            "type": "u16"
+          },
+          {
+            "name": "in_market_index",
+            "type": "u16"
+          },
+          {
+            "name": "max_slippage_bps",
+            "type": "u16"
+          },
+          {
+            "name": "swap_mode",
+            "type": "u8"
+          },
+          {
+            "name": "status",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConstituentSpotBalance",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "scaled_balance",
+            "docs": [
+              "The scaled balance of the position. To get the token amount, multiply by the cumulative deposit/borrow",
+              "interest of corresponding market.",
+              "precision: token precision"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "cumulative_deposits",
+            "docs": [
+              "The cumulative deposits/borrows a user has made into a market",
+              "precision: token mint precision"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "market_index",
+            "docs": [
+              "The market index of the corresponding spot market"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "balance_type",
+            "docs": [
+              "Whether the position is deposit or borrow"
+            ],
+            "type": {
+              "defined": {
+                "name": "SpotBalanceType"
+              }
+            }
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AmmConstituentDatum",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "perp_market_index",
+            "type": "u16"
+          },
+          {
+            "name": "constituent_index",
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          },
+          {
+            "name": "last_slot",
+            "type": "u64"
+          },
+          {
+            "name": "weight",
+            "docs": [
+              "PERCENTAGE_PRECISION. The weight this constituent has on the perp market"
+            ],
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AmmConstituentMappingFixed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "pad",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "len",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TargetsDatum",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "cost_to_trade_bps",
+            "type": "i32"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          },
+          {
+            "name": "target_base",
+            "type": "i64"
+          },
+          {
+            "name": "last_oracle_slot",
+            "type": "u64"
+          },
+          {
+            "name": "last_position_slot",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConstituentTargetBaseFixed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "pad",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "len",
+            "docs": [
+              "total elements in the flattened `data` vec"
+            ],
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConstituentCorrelationsFixed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "pad",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "len",
+            "docs": [
+              "total elements in the flattened `data` vec"
+            ],
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarketIdentifier",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "market_type",
+            "type": {
+              "defined": {
+                "name": "MarketType"
+              }
+            }
+          },
+          {
+            "name": "market_index",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "HistoricalOracleData",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "last_oracle_price",
+            "docs": [
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "last_oracle_conf",
+            "docs": [
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_oracle_delay",
+            "docs": [
+              "number of slots since last update"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "last_oracle_price_twap",
+            "docs": [
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "last_oracle_price_twap5min",
+            "docs": [
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "last_oracle_price_twap_ts",
+            "docs": [
+              "unix_timestamp of last snapshot"
+            ],
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "HistoricalIndexData",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "last_index_bid_price",
+            "docs": [
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_index_ask_price",
+            "docs": [
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_index_price_twap",
+            "docs": [
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_index_price_twap5min",
+            "docs": [
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_index_price_twap_ts",
+            "docs": [
+              "unix_timestamp of last snapshot"
+            ],
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PrelaunchOracleParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "perp_market_index",
+            "type": "u16"
+          },
+          {
+            "name": "price",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "max_price",
+            "type": {
+              "option": "i64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "OrderParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "order_type",
+            "type": {
+              "defined": {
+                "name": "OrderType"
+              }
+            }
+          },
+          {
+            "name": "market_type",
+            "type": {
+              "defined": {
+                "name": "MarketType"
+              }
+            }
+          },
+          {
+            "name": "direction",
+            "type": {
+              "defined": {
+                "name": "PositionDirection"
+              }
+            }
+          },
+          {
+            "name": "user_order_id",
+            "type": "u8"
+          },
+          {
+            "name": "base_asset_amount",
+            "type": "u64"
+          },
+          {
+            "name": "price",
+            "type": "u64"
+          },
+          {
+            "name": "market_index",
+            "type": "u16"
+          },
+          {
+            "name": "reduce_only",
+            "type": "bool"
+          },
+          {
+            "name": "post_only",
+            "type": {
+              "defined": {
+                "name": "PostOnlyParam"
+              }
+            }
+          },
+          {
+            "name": "bit_flags",
+            "type": "u8"
+          },
+          {
+            "name": "max_ts",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "trigger_price",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "trigger_condition",
+            "type": {
+              "defined": {
+                "name": "OrderTriggerCondition"
+              }
+            }
+          },
+          {
+            "name": "oracle_price_offset",
+            "type": {
+              "option": "i32"
+            }
+          },
+          {
+            "name": "auction_duration",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "auction_start_price",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "auction_end_price",
+            "type": {
+              "option": "i64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SignedMsgOrderParamsMessage",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "signed_msg_order_params",
+            "type": {
+              "defined": {
+                "name": "OrderParams"
+              }
+            }
+          },
+          {
+            "name": "sub_account_id",
+            "type": "u16"
+          },
+          {
+            "name": "slot",
+            "type": "u64"
+          },
+          {
+            "name": "uuid",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "take_profit_order_params",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "SignedMsgTriggerOrderParams"
+                }
+              }
+            }
+          },
+          {
+            "name": "stop_loss_order_params",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "SignedMsgTriggerOrderParams"
+                }
+              }
+            }
+          },
+          {
+            "name": "max_margin_ratio",
+            "type": {
+              "option": "u16"
+            }
+          },
+          {
+            "name": "builder_idx",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "builder_fee_tenth_bps",
+            "type": {
+              "option": "u16"
+            }
+          },
+          {
+            "name": "isolated_position_deposit",
+            "type": {
+              "option": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SignedMsgOrderParamsDelegateMessage",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "signed_msg_order_params",
+            "type": {
+              "defined": {
+                "name": "OrderParams"
+              }
+            }
+          },
+          {
+            "name": "taker_pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "slot",
+            "type": "u64"
+          },
+          {
+            "name": "uuid",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "take_profit_order_params",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "SignedMsgTriggerOrderParams"
+                }
+              }
+            }
+          },
+          {
+            "name": "stop_loss_order_params",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "SignedMsgTriggerOrderParams"
+                }
+              }
+            }
+          },
+          {
+            "name": "max_margin_ratio",
+            "type": {
+              "option": "u16"
+            }
+          },
+          {
+            "name": "builder_idx",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "builder_fee_tenth_bps",
+            "type": {
+              "option": "u16"
+            }
+          },
+          {
+            "name": "isolated_position_deposit",
+            "type": {
+              "option": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SignedMsgTriggerOrderParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trigger_price",
+            "type": "u64"
+          },
+          {
+            "name": "base_asset_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ModifyOrderParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "direction",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "PositionDirection"
+                }
+              }
+            }
+          },
+          {
+            "name": "base_asset_amount",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "price",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "reduce_only",
+            "type": {
+              "option": "bool"
+            }
+          },
+          {
+            "name": "post_only",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "PostOnlyParam"
+                }
+              }
+            }
+          },
+          {
+            "name": "bit_flags",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "max_ts",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "trigger_price",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "trigger_condition",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "OrderTriggerCondition"
+                }
+              }
+            }
+          },
+          {
+            "name": "oracle_price_offset",
+            "type": {
+              "option": "i32"
+            }
+          },
+          {
+            "name": "auction_duration",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "auction_start_price",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "auction_end_price",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "policy",
+            "type": {
+              "option": "u8"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "InsuranceClaim",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "revenue_withdraw_since_last_settle",
+            "docs": [
+              "The amount of revenue last settled",
+              "Positive if funds left the perp market,",
+              "negative if funds were pulled into the perp market",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "max_revenue_withdraw_per_period",
+            "docs": [
+              "The max amount of revenue that can be withdrawn per period",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "quote_max_insurance",
+            "docs": [
+              "The max amount of insurance that perp market can use to resolve bankruptcy and pnl deficits",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "quote_settled_insurance",
+            "docs": [
+              "The amount of insurance that has been used to resolve bankruptcy and pnl deficits",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_revenue_withdraw_ts",
+            "docs": [
+              "The last time revenue was settled in/out of market"
+            ],
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolBalance",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "scaled_balance",
+            "docs": [
+              "To get the pool's token amount, you must multiply the scaled balance by the market's cumulative",
+              "deposit interest",
+              "precision: SPOT_BALANCE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "market_index",
+            "docs": [
+              "The spot market the pool is for"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AMM",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle",
+            "docs": [
+              "oracle price data public key"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "historical_oracle_data",
+            "docs": [
+              "stores historically witnessed oracle data"
+            ],
+            "type": {
+              "defined": {
+                "name": "HistoricalOracleData"
+              }
+            }
+          },
+          {
+            "name": "base_asset_amount_per_lp",
+            "docs": [
+              "accumulated base asset amount since inception per lp share",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "quote_asset_amount_per_lp",
+            "docs": [
+              "accumulated quote asset amount since inception per lp share",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "fee_pool",
+            "docs": [
+              "partition of fees from perp market trading moved from pnl settlements"
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolBalance"
+              }
+            }
+          },
+          {
+            "name": "base_asset_reserve",
+            "docs": [
+              "`x` reserves for constant product mm formula (x * y = k)",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "quote_asset_reserve",
+            "docs": [
+              "`y` reserves for constant product mm formula (x * y = k)",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "concentration_coef",
+            "docs": [
+              "determines how close the min/max base asset reserve sit vs base reserves",
+              "allow for decreasing slippage without increasing liquidity and v.v.",
+              "precision: PERCENTAGE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "min_base_asset_reserve",
+            "docs": [
+              "minimum base_asset_reserve allowed before AMM is unavailable",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "max_base_asset_reserve",
+            "docs": [
+              "maximum base_asset_reserve allowed before AMM is unavailable",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_k",
+            "docs": [
+              "`sqrt(k)` in constant product mm formula (x * y = k). stored to avoid drift caused by integer math issues",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "peg_multiplier",
+            "docs": [
+              "normalizing numerical factor for y, its use offers lowest slippage in cp-curve when market is balanced",
+              "precision: PEG_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "terminal_quote_asset_reserve",
+            "docs": [
+              "y when market is balanced. stored to save computation",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "base_asset_amount_long",
+            "docs": [
+              "always non-negative. tracks number of total longs in market (regardless of counterparty)",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "base_asset_amount_short",
+            "docs": [
+              "always non-positive. tracks number of total shorts in market (regardless of counterparty)",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "base_asset_amount_with_amm",
+            "docs": [
+              "tracks net position (longs-shorts) in market with AMM as counterparty",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "base_asset_amount_with_unsettled_lp",
+            "docs": [
+              "tracks net position (longs-shorts) in market with LPs as counterparty",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "max_open_interest",
+            "docs": [
+              "max allowed open interest, blocks trades that breach this value",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "quote_asset_amount",
+            "docs": [
+              "sum of all user's perp quote_asset_amount in market",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "quote_entry_amount_long",
+            "docs": [
+              "sum of all long user's quote_entry_amount in market",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "quote_entry_amount_short",
+            "docs": [
+              "sum of all short user's quote_entry_amount in market",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "quote_break_even_amount_long",
+            "docs": [
+              "sum of all long user's quote_break_even_amount in market",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "quote_break_even_amount_short",
+            "docs": [
+              "sum of all short user's quote_break_even_amount in market",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "user_lp_shares",
+            "docs": [
+              "total user lp shares of sqrt_k (protocol owned liquidity = sqrt_k - last_funding_rate)",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "last_funding_rate",
+            "docs": [
+              "last funding rate in this perp market (unit is quote per base)",
+              "precision: FUNDING_RATE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "last_funding_rate_long",
+            "docs": [
+              "last funding rate for longs in this perp market (unit is quote per base)",
+              "precision: FUNDING_RATE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "last_funding_rate_short",
+            "docs": [
+              "last funding rate for shorts in this perp market (unit is quote per base)",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "last24h_avg_funding_rate",
+            "docs": [
+              "estimate of last 24h of funding rate perp market (unit is quote per base)",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "total_fee",
+            "docs": [
+              "total fees collected by this perp market",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "total_mm_fee",
+            "docs": [
+              "total fees collected by the vAMM's bid/ask spread",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "total_exchange_fee",
+            "docs": [
+              "total fees collected by exchange fee schedule",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "total_fee_minus_distributions",
+            "docs": [
+              "total fees minus any recognized upnl and pool withdraws",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "total_fee_withdrawn",
+            "docs": [
+              "sum of all fees from fee pool withdrawn to revenue pool",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "total_liquidation_fee",
+            "docs": [
+              "all fees collected by market for liquidations",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "cumulative_funding_rate_long",
+            "docs": [
+              "accumulated funding rate for longs since inception in market"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "cumulative_funding_rate_short",
+            "docs": [
+              "accumulated funding rate for shorts since inception in market"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "total_social_loss",
+            "docs": [
+              "accumulated social loss paid by users since inception in market"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "ask_base_asset_reserve",
+            "docs": [
+              "transformed base_asset_reserve for users going long",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "ask_quote_asset_reserve",
+            "docs": [
+              "transformed quote_asset_reserve for users going long",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "bid_base_asset_reserve",
+            "docs": [
+              "transformed base_asset_reserve for users going short",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "bid_quote_asset_reserve",
+            "docs": [
+              "transformed quote_asset_reserve for users going short",
+              "precision: AMM_RESERVE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "last_oracle_normalised_price",
+            "docs": [
+              "the last seen oracle price partially shrunk toward the amm reserve price",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "last_oracle_reserve_price_spread_pct",
+            "docs": [
+              "the gap between the oracle price and the reserve price = y * peg_multiplier / x"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "last_bid_price_twap",
+            "docs": [
+              "average estimate of bid price over funding_period",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_ask_price_twap",
+            "docs": [
+              "average estimate of ask price over funding_period",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_mark_price_twap",
+            "docs": [
+              "average estimate of (bid+ask)/2 price over funding_period",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_mark_price_twap5min",
+            "docs": [
+              "average estimate of (bid+ask)/2 price over FIVE_MINUTES"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_update_slot",
+            "docs": [
+              "the last blockchain slot the amm was updated"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_oracle_conf_pct",
+            "docs": [
+              "the pct size of the oracle confidence interval",
+              "precision: PERCENTAGE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "net_revenue_since_last_funding",
+            "docs": [
+              "the total_fee_minus_distribution change since the last funding update",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "last_funding_rate_ts",
+            "docs": [
+              "the last funding rate update unix_timestamp"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "funding_period",
+            "docs": [
+              "the peridocity of the funding rate updates"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "order_step_size",
+            "docs": [
+              "the base step size (increment) of orders",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "order_tick_size",
+            "docs": [
+              "the price tick size of orders",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "min_order_size",
+            "docs": [
+              "the minimum base size of an order",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "mm_oracle_slot",
+            "docs": [
+              "the max base size a single user can have",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "volume24h",
+            "docs": [
+              "estimated total of volume in market",
+              "QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "long_intensity_volume",
+            "docs": [
+              "the volume intensity of long fills against AMM"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "short_intensity_volume",
+            "docs": [
+              "the volume intensity of short fills against AMM"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_trade_ts",
+            "docs": [
+              "the blockchain unix timestamp at the time of the last trade"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "mark_std",
+            "docs": [
+              "estimate of standard deviation of the fill (mark) prices",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "oracle_std",
+            "docs": [
+              "estimate of standard deviation of the oracle price at each update",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_mark_price_twap_ts",
+            "docs": [
+              "the last unix_timestamp the mark twap was updated"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "base_spread",
+            "docs": [
+              "the minimum spread the AMM can quote. also used as step size for some spread logic increases."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_spread",
+            "docs": [
+              "the maximum spread the AMM can quote"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "long_spread",
+            "docs": [
+              "the spread for asks vs the reserve price"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "short_spread",
+            "docs": [
+              "the spread for bids vs the reserve price"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "mm_oracle_price",
+            "docs": [
+              "MM oracle price"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "max_fill_reserve_fraction",
+            "docs": [
+              "the fraction of total available liquidity a single fill on the AMM can consume"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "max_slippage_ratio",
+            "docs": [
+              "the maximum slippage a single fill on the AMM can push"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "curve_update_intensity",
+            "docs": [
+              "the update intensity of AMM formulaic updates (adjusting k). 0-100"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "amm_jit_intensity",
+            "docs": [
+              "the jit intensity of AMM. larger intensity means larger participation in jit. 0 means no jit participation.",
+              "(0, 100] is intensity for protocol-owned AMM. (100, 200] is intensity for user LP-owned AMM."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "oracle_source",
+            "docs": [
+              "the oracle provider information. used to decode/scale the oracle public key"
+            ],
+            "type": {
+              "defined": {
+                "name": "OracleSource"
+              }
+            }
+          },
+          {
+            "name": "last_oracle_valid",
+            "docs": [
+              "tracks whether the oracle was considered valid at the last AMM update"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "target_base_asset_amount_per_lp",
+            "docs": [
+              "the target value for `base_asset_amount_per_lp`, used during AMM JIT with LP split",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "per_lp_base",
+            "docs": [
+              "expo for unit of per_lp, base 10 (if per_lp_base=X, then per_lp unit is 10^X)"
+            ],
+            "type": "i8"
+          },
+          {
+            "name": "oracle_low_risk_slot_delay_override",
+            "docs": [
+              "the override for the state.min_perp_auction_duration",
+              "0 is no override, -1 is disable speed bump, 1-100 is literal speed bump"
+            ],
+            "type": "i8"
+          },
+          {
+            "name": "amm_spread_adjustment",
+            "docs": [
+              "signed scale amm_spread similar to fee_adjustment logic (-100 = 0, 100 = double)"
+            ],
+            "type": "i8"
+          },
+          {
+            "name": "oracle_slot_delay_override",
+            "type": "i8"
+          },
+          {
+            "name": "mm_oracle_sequence_id",
+            "type": "u64"
+          },
+          {
+            "name": "net_unsettled_funding_pnl",
+            "type": "i64"
+          },
+          {
+            "name": "quote_asset_amount_with_unsettled_lp",
+            "type": "i64"
+          },
+          {
+            "name": "reference_price_offset",
+            "type": "i32"
+          },
+          {
+            "name": "amm_inventory_spread_adjustment",
+            "docs": [
+              "signed scale amm_spread similar to fee_adjustment logic (-100 = 0, 100 = double)"
+            ],
+            "type": "i8"
+          },
+          {
+            "name": "reference_price_offset_deadband_pct",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          },
+          {
+            "name": "last_funding_oracle_twap",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RevenueShareOrder",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "fees_accrued",
+            "docs": [
+              "fees accrued so far for this order slot. This is not exclusively fees from this order_id",
+              "and may include fees from other orders in the same market. This may be swept to the",
+              "builder's SpotPosition during settle_pnl."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "order_id",
+            "docs": [
+              "the order_id of the current active order in this slot. It's only relevant while bit_flag = Open"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "fee_tenth_bps",
+            "docs": [
+              "the builder fee on this order, in tenths of a bps, e.g. 100 = 0.01%"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "market_index",
+            "type": "u16"
+          },
+          {
+            "name": "sub_account_id",
+            "docs": [
+              "the subaccount_id of the user who created this order. It's only relevant while bit_flag = Open"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "builder_idx",
+            "docs": [
+              "the index of the RevenueShareEscrow.approved_builders list, that this order's fee will settle to. Ignored",
+              "if bit_flag = Referral."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "bit_flags",
+            "docs": [
+              "bitflags that describe the state of the order.",
+              "[`RevenueShareOrderBitFlag::Init`]: this order slot is available for use.",
+              "[`RevenueShareOrderBitFlag::Open`]: this order slot is occupied, `order_id` is the `sub_account_id`'s active order.",
+              "[`RevenueShareOrderBitFlag::Completed`]: this order has been filled or canceled, and is waiting to be settled into.",
+              "the builder's account order_id and sub_account_id are no longer relevant, it may be merged with other orders.",
+              "[`RevenueShareOrderBitFlag::Referral`]: this order stores referral rewards waiting to be settled for this market.",
+              "If it is set, no other bitflag should be set."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "user_order_index",
+            "docs": [
+              "the index into the User's orders list when this RevenueShareOrder was created, make sure to verify that order_id matches."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "market_type",
+            "type": {
+              "defined": {
+                "name": "MarketType"
+              }
+            }
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                10
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BuilderInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "max_fee_tenth_bps",
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "RevenueShareEscrowFixed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "referrer",
+            "type": "pubkey"
+          },
+          {
+            "name": "referrer_boost_expire_ts",
+            "type": "u32"
+          },
+          {
+            "name": "referrer_reward_offset",
+            "type": "i8"
+          },
+          {
+            "name": "referee_fee_numerator_offset",
+            "type": "i8"
+          },
+          {
+            "name": "referrer_boost_numerator",
+            "type": "i8"
+          },
+          {
+            "name": "reserved_fixed",
+            "type": {
+              "array": [
+                "u8",
+                17
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SignedMsgOrderId",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "uuid",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "max_slot",
+            "type": "u64"
+          },
+          {
+            "name": "order_id",
+            "type": "u32"
+          },
+          {
+            "name": "padding",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SignedMsgUserOrdersFixed",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "user_pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "padding",
+            "type": "u32"
+          },
+          {
+            "name": "len",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InsuranceFund",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "total_shares",
+            "type": "u128"
+          },
+          {
+            "name": "user_shares",
+            "type": "u128"
+          },
+          {
+            "name": "shares_base",
+            "type": "u128"
+          },
+          {
+            "name": "unstaking_period",
+            "type": "i64"
+          },
+          {
+            "name": "last_revenue_settle_ts",
+            "type": "i64"
+          },
+          {
+            "name": "revenue_settle_period",
+            "type": "i64"
+          },
+          {
+            "name": "total_factor",
+            "type": "u32"
+          },
+          {
+            "name": "user_factor",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OracleGuardRails",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "price_divergence",
+            "type": {
+              "defined": {
+                "name": "PriceDivergenceGuardRails"
+              }
+            }
+          },
+          {
+            "name": "validity",
+            "type": {
+              "defined": {
+                "name": "ValidityGuardRails"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PriceDivergenceGuardRails",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mark_oracle_percent_divergence",
+            "type": "u64"
+          },
+          {
+            "name": "oracle_twap5min_percent_divergence",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ValidityGuardRails",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "slots_before_stale_for_amm",
+            "type": "i64"
+          },
+          {
+            "name": "slots_before_stale_for_margin",
+            "type": "i64"
+          },
+          {
+            "name": "confidence_interval_max_size",
+            "type": "u64"
+          },
+          {
+            "name": "too_volatile_ratio",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeeStructure",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "fee_tiers",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "FeeTier"
+                  }
+                },
+                10
+              ]
+            }
+          },
+          {
+            "name": "filler_reward_structure",
+            "type": {
+              "defined": {
+                "name": "OrderFillerRewardStructure"
+              }
+            }
+          },
+          {
+            "name": "referrer_reward_epoch_upper_bound",
+            "type": "u64"
+          },
+          {
+            "name": "flat_filler_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeeTier",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "fee_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "fee_denominator",
+            "type": "u32"
+          },
+          {
+            "name": "maker_rebate_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "maker_rebate_denominator",
+            "type": "u32"
+          },
+          {
+            "name": "referrer_reward_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "referrer_reward_denominator",
+            "type": "u32"
+          },
+          {
+            "name": "referee_fee_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "referee_fee_denominator",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OrderFillerRewardStructure",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "reward_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "reward_denominator",
+            "type": "u32"
+          },
+          {
+            "name": "time_based_reward_lower_bound",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UserFees",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "total_fee_paid",
+            "docs": [
+              "Total taker fee paid",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_fee_rebate",
+            "docs": [
+              "Total maker fee rebate",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_token_discount",
+            "docs": [
+              "Total discount from holding token",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_referee_discount",
+            "docs": [
+              "Total discount from being referred",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_referrer_reward",
+            "docs": [
+              "Total reward to referrer",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "current_epoch_referrer_reward",
+            "docs": [
+              "Total reward to referrer this epoch",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpotPosition",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "scaled_balance",
+            "docs": [
+              "The scaled balance of the position. To get the token amount, multiply by the cumulative deposit/borrow",
+              "interest of corresponding market.",
+              "precision: SPOT_BALANCE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "open_bids",
+            "docs": [
+              "How many spot non reduce only trigger orders the user has open",
+              "precision: token mint precision"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "open_asks",
+            "docs": [
+              "How many spot non reduce only trigger orders the user has open",
+              "precision: token mint precision"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "cumulative_deposits",
+            "docs": [
+              "The cumulative deposits/borrows a user has made into a market",
+              "precision: token mint precision"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "market_index",
+            "docs": [
+              "The market index of the corresponding spot market"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "balance_type",
+            "docs": [
+              "Whether the position is deposit or borrow"
+            ],
+            "type": {
+              "defined": {
+                "name": "SpotBalanceType"
+              }
+            }
+          },
+          {
+            "name": "open_orders",
+            "docs": [
+              "Number of open orders"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PerpPosition",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "last_cumulative_funding_rate",
+            "docs": [
+              "The perp market's last cumulative funding rate. Used to calculate the funding payment owed to user",
+              "precision: FUNDING_RATE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "base_asset_amount",
+            "docs": [
+              "the size of the users perp position",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "quote_asset_amount",
+            "docs": [
+              "Used to calculate the users pnl. Upon entry, is equal to base_asset_amount * avg entry price - fees",
+              "Updated when the user open/closes position or settles pnl. Includes fees/funding",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "quote_break_even_amount",
+            "docs": [
+              "The amount of quote the user would need to exit their position at to break even",
+              "Updated when the user open/closes position or settles pnl. Includes fees/funding",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "quote_entry_amount",
+            "docs": [
+              "The amount quote the user entered the position with. Equal to base asset amount * avg entry price",
+              "Updated when the user open/closes position. Excludes fees/funding",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "open_bids",
+            "docs": [
+              "The amount of non reduce only trigger orders the user has open",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "open_asks",
+            "docs": [
+              "The amount of non reduce only trigger orders the user has open",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "settled_pnl",
+            "docs": [
+              "The amount of pnl settled in this market since opening the position",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "lp_shares",
+            "docs": [
+              "The number of lp (liquidity provider) shares the user has in this perp market",
+              "LP shares allow users to provide liquidity via the AMM",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_base_asset_amount_per_lp",
+            "docs": [
+              "The last base asset amount per lp the amm had",
+              "Used to settle the users lp position",
+              "precision: BASE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "last_quote_asset_amount_per_lp",
+            "docs": [
+              "The last quote asset amount per lp the amm had",
+              "Used to settle the users lp position",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          },
+          {
+            "name": "max_margin_ratio",
+            "type": "u16"
+          },
+          {
+            "name": "market_index",
+            "docs": [
+              "The market index for the perp market"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "open_orders",
+            "docs": [
+              "The number of open orders"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "per_lp_base",
+            "type": "i8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Order",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "slot",
+            "docs": [
+              "The slot the order was placed"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "price",
+            "docs": [
+              "The limit price for the order (can be 0 for market orders)",
+              "For orders with an auction, this price isn't used until the auction is complete",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "base_asset_amount",
+            "docs": [
+              "The size of the order",
+              "precision for perps: BASE_PRECISION",
+              "precision for spot: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "base_asset_amount_filled",
+            "docs": [
+              "The amount of the order filled",
+              "precision for perps: BASE_PRECISION",
+              "precision for spot: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "quote_asset_amount_filled",
+            "docs": [
+              "The amount of quote filled for the order",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "trigger_price",
+            "docs": [
+              "At what price the order will be triggered. Only relevant for trigger orders",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "auction_start_price",
+            "docs": [
+              "The start price for the auction. Only relevant for market/oracle orders",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "auction_end_price",
+            "docs": [
+              "The end price for the auction. Only relevant for market/oracle orders",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "max_ts",
+            "docs": [
+              "The time when the order will expire"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "oracle_price_offset",
+            "docs": [
+              "If set, the order limit price is the oracle price + this offset",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "order_id",
+            "docs": [
+              "The id for the order. Each users has their own order id space"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "market_index",
+            "docs": [
+              "The perp/spot market index"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "status",
+            "docs": [
+              "Whether the order is open or unused"
+            ],
+            "type": {
+              "defined": {
+                "name": "OrderStatus"
+              }
+            }
+          },
+          {
+            "name": "order_type",
+            "docs": [
+              "The type of order"
+            ],
+            "type": {
+              "defined": {
+                "name": "OrderType"
+              }
+            }
+          },
+          {
+            "name": "market_type",
+            "docs": [
+              "Whether market is spot or perp"
+            ],
+            "type": {
+              "defined": {
+                "name": "MarketType"
+              }
+            }
+          },
+          {
+            "name": "user_order_id",
+            "docs": [
+              "User generated order id. Can make it easier to place/cancel orders"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "existing_position_direction",
+            "docs": [
+              "What the users position was when the order was placed"
+            ],
+            "type": {
+              "defined": {
+                "name": "PositionDirection"
+              }
+            }
+          },
+          {
+            "name": "direction",
+            "docs": [
+              "Whether the user is going long or short. LONG = bid, SHORT = ask"
+            ],
+            "type": {
+              "defined": {
+                "name": "PositionDirection"
+              }
+            }
+          },
+          {
+            "name": "reduce_only",
+            "docs": [
+              "Whether the order is allowed to only reduce position size"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "post_only",
+            "docs": [
+              "Whether the order must be a maker"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "immediate_or_cancel",
+            "docs": [
+              "Whether the order must be canceled the same slot it is placed"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "trigger_condition",
+            "docs": [
+              "Whether the order is triggered above or below the trigger price. Only relevant for trigger orders"
+            ],
+            "type": {
+              "defined": {
+                "name": "OrderTriggerCondition"
+              }
+            }
+          },
+          {
+            "name": "auction_duration",
+            "docs": [
+              "How many slots the auction lasts"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "posted_slot_tail",
+            "docs": [
+              "Last 8 bits of the slot the order was posted on-chain (not order slot for signed msg orders)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "bit_flags",
+            "docs": [
+              "Bitflags for further classification",
+              "0: is_signed_message"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                1
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapDirection",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Add"
+          },
+          {
+            "name": "Remove"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ModifyOrderId",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "UserOrderId",
+            "fields": [
+              "u8"
+            ]
+          },
+          {
+            "name": "OrderId",
+            "fields": [
+              "u32"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "PositionDirection",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Long"
+          },
+          {
+            "name": "Short"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpotFulfillmentType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "SerumV3"
+          },
+          {
+            "name": "Match"
+          },
+          {
+            "name": "PhoenixV1"
+          },
+          {
+            "name": "OpenbookV2"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapReduceOnly",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "In"
+          },
+          {
+            "name": "Out"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TwapPeriod",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "FundingPeriod"
+          },
+          {
+            "name": "FiveMin"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidationMultiplierType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Discount"
+          },
+          {
+            "name": "Premium"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SettlementDirection",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "ToLpPool"
+          },
+          {
+            "name": "FromLpPool"
+          },
+          {
+            "name": "None"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarginRequirementType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Initial"
+          },
+          {
+            "name": "Fill"
+          },
+          {
+            "name": "Maintenance"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OracleValidity",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "NonPositive"
+          },
+          {
+            "name": "TooVolatile"
+          },
+          {
+            "name": "TooUncertain"
+          },
+          {
+            "name": "StaleForMargin"
+          },
+          {
+            "name": "InsufficientDataPoints"
+          },
+          {
+            "name": "StaleForAMM",
+            "fields": [
+              {
+                "name": "immediate",
+                "type": "bool"
+              },
+              {
+                "name": "low_risk",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "Valid"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DriftAction",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "UpdateFunding"
+          },
+          {
+            "name": "SettlePnl"
+          },
+          {
+            "name": "TriggerOrder"
+          },
+          {
+            "name": "FillOrderMatch"
+          },
+          {
+            "name": "FillOrderAmmLowRisk"
+          },
+          {
+            "name": "FillOrderAmmImmediate"
+          },
+          {
+            "name": "Liquidate"
+          },
+          {
+            "name": "MarginCalc"
+          },
+          {
+            "name": "UpdateTwap"
+          },
+          {
+            "name": "UpdateAMMCurve"
+          },
+          {
+            "name": "OracleOrderPrice"
+          },
+          {
+            "name": "UseMMOraclePrice"
+          },
+          {
+            "name": "UpdateAmmCache"
+          },
+          {
+            "name": "UpdateLpPoolAum"
+          },
+          {
+            "name": "LpPoolSwap"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LogMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "ExchangeOracle"
+          },
+          {
+            "name": "MMOracle"
+          },
+          {
+            "name": "SafeMMOracle"
+          },
+          {
+            "name": "Margin"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PositionUpdateType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Open"
+          },
+          {
+            "name": "Increase"
+          },
+          {
+            "name": "Reduce"
+          },
+          {
+            "name": "Close"
+          },
+          {
+            "name": "Flip"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DepositExplanation",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "Transfer"
+          },
+          {
+            "name": "Borrow"
+          },
+          {
+            "name": "RepayBorrow"
+          },
+          {
+            "name": "Reward"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DepositDirection",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Deposit"
+          },
+          {
+            "name": "Withdraw"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OrderAction",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Place"
+          },
+          {
+            "name": "Cancel"
+          },
+          {
+            "name": "Fill"
+          },
+          {
+            "name": "Trigger"
+          },
+          {
+            "name": "Expire"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OrderActionExplanation",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "InsufficientFreeCollateral"
+          },
+          {
+            "name": "OraclePriceBreachedLimitPrice"
+          },
+          {
+            "name": "MarketOrderFilledToLimitPrice"
+          },
+          {
+            "name": "OrderExpired"
+          },
+          {
+            "name": "Liquidation"
+          },
+          {
+            "name": "OrderFilledWithAMM"
+          },
+          {
+            "name": "OrderFilledWithAMMJit"
+          },
+          {
+            "name": "OrderFilledWithMatch"
+          },
+          {
+            "name": "OrderFilledWithMatchJit"
+          },
+          {
+            "name": "MarketExpired"
+          },
+          {
+            "name": "RiskingIncreasingOrder"
+          },
+          {
+            "name": "ReduceOnlyOrderIncreasedPosition"
+          },
+          {
+            "name": "OrderFillWithSerum"
+          },
+          {
+            "name": "NoBorrowLiquidity"
+          },
+          {
+            "name": "OrderFillWithPhoenix"
+          },
+          {
+            "name": "OrderFilledWithAMMJitLPSplit"
+          },
+          {
+            "name": "OrderFilledWithLPJit"
+          },
+          {
+            "name": "DeriskLp"
+          },
+          {
+            "name": "OrderFilledWithOpenbookV2"
+          },
+          {
+            "name": "TransferPerpPosition"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LPAction",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "AddLiquidity"
+          },
+          {
+            "name": "RemoveLiquidity"
+          },
+          {
+            "name": "SettleLiquidity"
+          },
+          {
+            "name": "RemoveLiquidityDerisk"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidationType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "LiquidatePerp"
+          },
+          {
+            "name": "LiquidateSpot"
+          },
+          {
+            "name": "LiquidateBorrowForPerpPnl"
+          },
+          {
+            "name": "LiquidatePerpPnlForDeposit"
+          },
+          {
+            "name": "PerpBankruptcy"
+          },
+          {
+            "name": "SpotBankruptcy"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SettlePnlExplanation",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "ExpiredPosition"
+          }
+        ]
+      }
+    },
+    {
+      "name": "StakeAction",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Stake"
+          },
+          {
+            "name": "UnstakeRequest"
+          },
+          {
+            "name": "UnstakeCancelRequest"
+          },
+          {
+            "name": "Unstake"
+          },
+          {
+            "name": "UnstakeTransfer"
+          },
+          {
+            "name": "StakeTransfer"
+          },
+          {
+            "name": "AdminDeposit"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FillMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Fill"
+          },
+          {
+            "name": "PlaceAndMake"
+          },
+          {
+            "name": "PlaceAndTake",
+            "fields": [
+              "bool",
+              "u8"
+            ]
+          },
+          {
+            "name": "Liquidation"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PerpFulfillmentMethod",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "AMM",
+            "fields": [
+              {
+                "option": "u64"
+              }
+            ]
+          },
+          {
+            "name": "Match",
+            "fields": [
+              "pubkey",
+              "u16",
+              "u64"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpotFulfillmentMethod",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "ExternalMarket"
+          },
+          {
+            "name": "Match",
+            "fields": [
+              "pubkey",
+              "u16"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConstituentStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "ReduceOnly"
+          },
+          {
+            "name": "Decommissioned"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarginCalculationMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Standard",
+            "fields": [
+              {
+                "name": "track_open_orders_fraction",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "Liquidation",
+            "fields": [
+              {
+                "name": "market_to_track_margin_requirement",
+                "type": {
+                  "option": {
+                    "defined": {
+                      "name": "MarketIdentifier"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "OracleSource",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Pyth"
+          },
+          {
+            "name": "Switchboard"
+          },
+          {
+            "name": "QuoteAsset"
+          },
+          {
+            "name": "Pyth1K"
+          },
+          {
+            "name": "Pyth1M"
+          },
+          {
+            "name": "PythStableCoin"
+          },
+          {
+            "name": "Prelaunch"
+          },
+          {
+            "name": "PythPull"
+          },
+          {
+            "name": "Pyth1KPull"
+          },
+          {
+            "name": "Pyth1MPull"
+          },
+          {
+            "name": "PythStableCoinPull"
+          },
+          {
+            "name": "SwitchboardOnDemand"
+          },
+          {
+            "name": "PythLazer"
+          },
+          {
+            "name": "PythLazer1K"
+          },
+          {
+            "name": "PythLazer1M"
+          },
+          {
+            "name": "PythLazerStableCoin"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OrderParamsBitFlag",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "ImmediateOrCancel"
+          },
+          {
+            "name": "UpdateHighLeverageMode"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PostOnlyParam",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "MustPostOnly"
+          },
+          {
+            "name": "TryPostOnly"
+          },
+          {
+            "name": "Slide"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ModifyOrderPolicy",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "MustModify"
+          },
+          {
+            "name": "ExcludePreviousFill"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PlaceAndTakeOrderSuccessCondition",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "PartialFill"
+          },
+          {
+            "name": "FullFill"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PerpOperation",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "UpdateFunding"
+          },
+          {
+            "name": "AmmFill"
+          },
+          {
+            "name": "Fill"
+          },
+          {
+            "name": "SettlePnl"
+          },
+          {
+            "name": "SettlePnlWithPosition"
+          },
+          {
+            "name": "Liquidation"
+          },
+          {
+            "name": "AmmImmediateFill"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpotOperation",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "UpdateCumulativeInterest"
+          },
+          {
+            "name": "Fill"
+          },
+          {
+            "name": "Deposit"
+          },
+          {
+            "name": "Withdraw"
+          },
+          {
+            "name": "Liquidation"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InsuranceFundOperation",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Init"
+          },
+          {
+            "name": "Add"
+          },
+          {
+            "name": "RequestRemove"
+          },
+          {
+            "name": "Remove"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PerpLpOperation",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "TrackAmmRevenue"
+          },
+          {
+            "name": "SettleQuoteOwed"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConstituentLpOperation",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Swap"
+          },
+          {
+            "name": "Deposit"
+          },
+          {
+            "name": "Withdraw"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarketStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Initialized"
+          },
+          {
+            "name": "Active"
+          },
+          {
+            "name": "FundingPaused"
+          },
+          {
+            "name": "AmmPaused"
+          },
+          {
+            "name": "FillPaused"
+          },
+          {
+            "name": "WithdrawPaused"
+          },
+          {
+            "name": "ReduceOnly"
+          },
+          {
+            "name": "Settlement"
+          },
+          {
+            "name": "Delisted"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LpStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Uncollateralized"
+          },
+          {
+            "name": "Active"
+          },
+          {
+            "name": "Decommissioning"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ContractType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Perpetual"
+          },
+          {
+            "name": "Future"
+          },
+          {
+            "name": "Prediction"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ContractTier",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "A"
+          },
+          {
+            "name": "B"
+          },
+          {
+            "name": "C"
+          },
+          {
+            "name": "Speculative"
+          },
+          {
+            "name": "HighlySpeculative"
+          },
+          {
+            "name": "Isolated"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RevenueShareOrderBitFlag",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Init"
+          },
+          {
+            "name": "Open"
+          },
+          {
+            "name": "Completed"
+          },
+          {
+            "name": "Referral"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SettlePnlMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "MustSettle"
+          },
+          {
+            "name": "TrySettle"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpotBalanceType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Deposit"
+          },
+          {
+            "name": "Borrow"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpotFulfillmentConfigStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Enabled"
+          },
+          {
+            "name": "Disabled"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AssetTier",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Collateral"
+          },
+          {
+            "name": "Protected"
+          },
+          {
+            "name": "Cross"
+          },
+          {
+            "name": "Isolated"
+          },
+          {
+            "name": "Unlisted"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenProgramFlag",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Token2022"
+          },
+          {
+            "name": "TransferHook"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ExchangeStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "DepositPaused"
+          },
+          {
+            "name": "WithdrawPaused"
+          },
+          {
+            "name": "AmmPaused"
+          },
+          {
+            "name": "FillPaused"
+          },
+          {
+            "name": "LiqPaused"
+          },
+          {
+            "name": "FundingPaused"
+          },
+          {
+            "name": "SettlePnlPaused"
+          },
+          {
+            "name": "AmmImmediateFillPaused"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeatureBitFlags",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "MmOracleUpdate"
+          },
+          {
+            "name": "MedianTriggerPrice"
+          },
+          {
+            "name": "BuilderCodes"
+          },
+          {
+            "name": "BuilderReferral"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LpPoolFeatureBitFlags",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "SettleLpPool"
+          },
+          {
+            "name": "SwapLpPool"
+          },
+          {
+            "name": "MintRedeemLpPool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UserStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "BeingLiquidated"
+          },
+          {
+            "name": "Bankrupt"
+          },
+          {
+            "name": "ReduceOnly"
+          },
+          {
+            "name": "AdvancedLp"
+          },
+          {
+            "name": "ProtectedMakerOrders"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AssetType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Base"
+          },
+          {
+            "name": "Quote"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OrderStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Init"
+          },
+          {
+            "name": "Open"
+          },
+          {
+            "name": "Filled"
+          },
+          {
+            "name": "Canceled"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OrderType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Market"
+          },
+          {
+            "name": "Limit"
+          },
+          {
+            "name": "TriggerMarket"
+          },
+          {
+            "name": "TriggerLimit"
+          },
+          {
+            "name": "Oracle"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OrderTriggerCondition",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Above"
+          },
+          {
+            "name": "Below"
+          },
+          {
+            "name": "TriggeredAbove"
+          },
+          {
+            "name": "TriggeredBelow"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarketType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Spot"
+          },
+          {
+            "name": "Perp"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OrderBitFlag",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "SignedMessage"
+          },
+          {
+            "name": "OracleTriggerMarket"
+          },
+          {
+            "name": "SafeTriggerOrder"
+          },
+          {
+            "name": "NewTriggerReduceOnly"
+          },
+          {
+            "name": "HasBuilder"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReferrerStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "IsReferrer"
+          },
+          {
+            "name": "IsReferred"
+          },
+          {
+            "name": "BuilderReferral"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarginMode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Default"
+          },
+          {
+            "name": "HighLeverage"
+          },
+          {
+            "name": "HighLeverageMaintenance"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FuelOverflowStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Exists"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SignatureVerificationError",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "InvalidEd25519InstructionProgramId"
+          },
+          {
+            "name": "InvalidEd25519InstructionDataLength"
+          },
+          {
+            "name": "InvalidSignatureIndex"
+          },
+          {
+            "name": "InvalidSignatureOffset"
+          },
+          {
+            "name": "InvalidPublicKeyOffset"
+          },
+          {
+            "name": "InvalidMessageOffset"
+          },
+          {
+            "name": "InvalidMessageDataSize"
+          },
+          {
+            "name": "InvalidInstructionIndex"
+          },
+          {
+            "name": "MessageOffsetOverflow"
+          },
+          {
+            "name": "InvalidMessageHex"
+          },
+          {
+            "name": "InvalidMessageData"
+          },
+          {
+            "name": "LoadInstructionAtFailed"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AmmCache",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "cache",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "CacheInfo"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "OpenbookV2FulfillmentConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "openbook_v2_program_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "openbook_v2_market",
+            "type": "pubkey"
+          },
+          {
+            "name": "openbook_v2_market_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "openbook_v2_event_heap",
+            "type": "pubkey"
+          },
+          {
+            "name": "openbook_v2_bids",
+            "type": "pubkey"
+          },
+          {
+            "name": "openbook_v2_asks",
+            "type": "pubkey"
+          },
+          {
+            "name": "openbook_v2_base_vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "openbook_v2_quote_vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "market_index",
+            "type": "u16"
+          },
+          {
+            "name": "fulfillment_type",
+            "type": {
+              "defined": {
+                "name": "SpotFulfillmentType"
+              }
+            }
+          },
+          {
+            "name": "status",
+            "type": {
+              "defined": {
+                "name": "SpotFulfillmentConfigStatus"
+              }
+            }
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PhoenixV1FulfillmentConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "phoenix_program_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "phoenix_log_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "phoenix_market",
+            "type": "pubkey"
+          },
+          {
+            "name": "phoenix_base_vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "phoenix_quote_vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "market_index",
+            "type": "u16"
+          },
+          {
+            "name": "fulfillment_type",
+            "type": {
+              "defined": {
+                "name": "SpotFulfillmentType"
+              }
+            }
+          },
+          {
+            "name": "status",
+            "type": {
+              "defined": {
+                "name": "SpotFulfillmentConfigStatus"
+              }
+            }
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SerumV3FulfillmentConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "serum_program_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "serum_market",
+            "type": "pubkey"
+          },
+          {
+            "name": "serum_request_queue",
+            "type": "pubkey"
+          },
+          {
+            "name": "serum_event_queue",
+            "type": "pubkey"
+          },
+          {
+            "name": "serum_bids",
+            "type": "pubkey"
+          },
+          {
+            "name": "serum_asks",
+            "type": "pubkey"
+          },
+          {
+            "name": "serum_base_vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "serum_quote_vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "serum_open_orders",
+            "type": "pubkey"
+          },
+          {
+            "name": "serum_signer_nonce",
+            "type": "u64"
+          },
+          {
+            "name": "market_index",
+            "type": "u16"
+          },
+          {
+            "name": "fulfillment_type",
+            "type": {
+              "defined": {
+                "name": "SpotFulfillmentType"
+              }
+            }
+          },
+          {
+            "name": "status",
+            "type": {
+              "defined": {
+                "name": "SpotFulfillmentConfigStatus"
+              }
+            }
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "HighLeverageModeConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "max_users",
+            "type": "u32"
+          },
+          {
+            "name": "current_users",
+            "type": "u32"
+          },
+          {
+            "name": "reduce_only",
+            "type": "u8"
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "current_maintenance_users",
+            "type": "u32"
+          },
+          {
+            "name": "padding2",
+            "type": {
+              "array": [
+                "u8",
+                24
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "IfRebalanceConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "total_in_amount",
+            "docs": [
+              "total amount to be sold"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "current_in_amount",
+            "docs": [
+              "amount already sold"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "current_out_amount",
+            "docs": [
+              "amount already bought"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "current_out_amount_transferred",
+            "docs": [
+              "amount already transferred to revenue pool"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "current_in_amount_since_last_transfer",
+            "docs": [
+              "amount already bought in epoch"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "epoch_start_ts",
+            "docs": [
+              "start time of epoch"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "epoch_in_amount",
+            "docs": [
+              "amount already bought in epoch"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "epoch_max_in_amount",
+            "docs": [
+              "max amount to swap in epoch"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "epoch_duration",
+            "docs": [
+              "duration of epoch"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "out_market_index",
+            "docs": [
+              "market index to sell"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "in_market_index",
+            "docs": [
+              "market index to buy"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "max_slippage_bps",
+            "type": "u16"
+          },
+          {
+            "name": "swap_mode",
+            "type": "u8"
+          },
+          {
+            "name": "status",
+            "type": "u8"
+          },
+          {
+            "name": "padding2",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "InsuranceFundStake",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "if_shares",
+            "type": "u128"
+          },
+          {
+            "name": "last_withdraw_request_shares",
+            "type": "u128"
+          },
+          {
+            "name": "if_base",
+            "type": "u128"
+          },
+          {
+            "name": "last_valid_ts",
+            "type": "i64"
+          },
+          {
+            "name": "last_withdraw_request_value",
+            "type": "u64"
+          },
+          {
+            "name": "last_withdraw_request_ts",
+            "type": "i64"
+          },
+          {
+            "name": "cost_basis",
+            "type": "i64"
+          },
+          {
+            "name": "market_index",
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                14
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProtocolIfSharesTransferConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "whitelisted_signers",
+            "type": {
+              "array": [
+                "pubkey",
+                4
+              ]
+            }
+          },
+          {
+            "name": "max_transfer_per_epoch",
+            "type": "u128"
+          },
+          {
+            "name": "current_epoch_transfer",
+            "type": "u128"
+          },
+          {
+            "name": "next_epoch_ts",
+            "type": "i64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u128",
+                8
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LPPool",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "docs": [
+              "address of the vault."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "whitelist_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "constituent_target_base",
+            "type": "pubkey"
+          },
+          {
+            "name": "constituent_correlations",
+            "type": "pubkey"
+          },
+          {
+            "name": "max_aum",
+            "docs": [
+              "The current number of VaultConstituents in the vault, each constituent is pda(LPPool.address, constituent_index)",
+              "which constituent is the quote, receives revenue pool distributions. (maybe this should just be implied idx 0)",
+              "pub quote_constituent_index: u16,",
+              "QUOTE_PRECISION: Max AUM, Prohibit minting new DLP beyond this"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "last_aum",
+            "docs": [
+              "QUOTE_PRECISION: AUM of the vault in USD, updated lazily"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "cumulative_quote_sent_to_perp_markets",
+            "docs": [
+              "QUOTE PRECISION: Cumulative quotes from settles"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "cumulative_quote_received_from_perp_markets",
+            "type": "u128"
+          },
+          {
+            "name": "total_mint_redeem_fees_paid",
+            "docs": [
+              "QUOTE_PRECISION: Total fees paid for minting and redeeming LP tokens"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "last_aum_slot",
+            "docs": [
+              "timestamp of last AUM slot"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "max_settle_quote_amount",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "timestamp of last vAMM revenue rebalance"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "mint_redeem_id",
+            "docs": [
+              "Every mint/redeem has a monotonically increasing id. This is the next id to use"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "settle_id",
+            "type": "u64"
+          },
+          {
+            "name": "min_mint_fee",
+            "docs": [
+              "PERCENTAGE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "token_supply",
+            "type": "u64"
+          },
+          {
+            "name": "volatility",
+            "type": "u64"
+          },
+          {
+            "name": "constituents",
+            "type": "u16"
+          },
+          {
+            "name": "quote_consituent_index",
+            "type": "u16"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "gamma_execution",
+            "type": "u8"
+          },
+          {
+            "name": "xi",
+            "type": "u8"
+          },
+          {
+            "name": "target_oracle_delay_fee_bps_per10_slots",
+            "type": "u8"
+          },
+          {
+            "name": "target_position_delay_fee_bps_per10_slots",
+            "type": "u8"
+          },
+          {
+            "name": "lp_pool_id",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                174
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Constituent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "docs": [
+              "address of the constituent"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "lp_pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "total_swap_fees",
+            "docs": [
+              "total fees received by the constituent. Positive = fees received, Negative = fees paid"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "spot_balance",
+            "docs": [
+              "spot borrow-lend balance for constituent"
+            ],
+            "type": {
+              "defined": {
+                "name": "ConstituentSpotBalance"
+              }
+            }
+          },
+          {
+            "name": "last_spot_balance_token_amount",
+            "type": "i64"
+          },
+          {
+            "name": "cumulative_spot_interest_accrued_token_amount",
+            "type": "i64"
+          },
+          {
+            "name": "max_weight_deviation",
+            "docs": [
+              "max deviation from target_weight allowed for the constituent",
+              "precision: PERCENTAGE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "swap_fee_min",
+            "docs": [
+              "min fee charged on swaps to/from this constituent",
+              "precision: PERCENTAGE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "swap_fee_max",
+            "docs": [
+              "max fee charged on swaps to/from this constituent",
+              "precision: PERCENTAGE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "max_borrow_token_amount",
+            "docs": [
+              "Max Borrow amount:",
+              "precision: token precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "vault_token_balance",
+            "docs": [
+              "ata token balance in token precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_oracle_price",
+            "type": "i64"
+          },
+          {
+            "name": "last_oracle_slot",
+            "type": "u64"
+          },
+          {
+            "name": "oracle_staleness_threshold",
+            "docs": [
+              "Delay allowed for valid AUM calculation"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "flash_loan_initial_token_amount",
+            "type": "u64"
+          },
+          {
+            "name": "next_swap_id",
+            "docs": [
+              "Every swap to/from this constituent has a monotonically increasing id. This is the next id to use"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "derivative_weight",
+            "docs": [
+              "percentable of derivatve weight to go to this specific derivative PERCENTAGE_PRECISION. Zero if no derivative weight"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "volatility",
+            "type": "u64"
+          },
+          {
+            "name": "constituent_derivative_depeg_threshold",
+            "type": "u64"
+          },
+          {
+            "name": "constituent_derivative_index",
+            "docs": [
+              "The `constituent_index` of the parent constituent. -1 if it is a parent index",
+              "Example: if in a pool with SOL (parent) and dSOL (derivative),",
+              "SOL.constituent_index = 1, SOL.constituent_derivative_index = -1,",
+              "dSOL.constituent_index = 2, dSOL.constituent_derivative_index = 1"
+            ],
+            "type": "i16"
+          },
+          {
+            "name": "spot_market_index",
+            "type": "u16"
+          },
+          {
+            "name": "constituent_index",
+            "type": "u16"
+          },
+          {
+            "name": "decimals",
+            "type": "u8"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "vault_bump",
+            "type": "u8"
+          },
+          {
+            "name": "gamma_inventory",
+            "type": "u8"
+          },
+          {
+            "name": "gamma_execution",
+            "type": "u8"
+          },
+          {
+            "name": "xi",
+            "type": "u8"
+          },
+          {
+            "name": "status",
+            "type": "u8"
+          },
+          {
+            "name": "paused_operations",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                162
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AmmConstituentMapping",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "weights",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "AmmConstituentDatum"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConstituentTargetBase",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "targets",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "TargetsDatum"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConstituentCorrelations",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "correlations",
+            "type": {
+              "vec": "i64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PrelaunchOracle",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "price",
+            "type": "i64"
+          },
+          {
+            "name": "max_price",
+            "type": "i64"
+          },
+          {
+            "name": "confidence",
+            "type": "u64"
+          },
+          {
+            "name": "last_update_slot",
+            "type": "u64"
+          },
+          {
+            "name": "amm_last_update_slot",
+            "type": "u64"
+          },
+          {
+            "name": "perp_market_index",
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                70
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PerpMarket",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "docs": [
+              "The perp market's address. It is a pda of the market index"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "amm",
+            "docs": [
+              "The automated market maker"
+            ],
+            "type": {
+              "defined": {
+                "name": "AMM"
+              }
+            }
+          },
+          {
+            "name": "pnl_pool",
+            "docs": [
+              "The market's pnl pool. When users settle negative pnl, the balance increases.",
+              "When users settle positive pnl, the balance decreases. Can not go negative."
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolBalance"
+              }
+            }
+          },
+          {
+            "name": "name",
+            "docs": [
+              "Encoded display name for the perp market e.g. SOL-PERP"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "insurance_claim",
+            "docs": [
+              "The perp market's claim on the insurance fund"
+            ],
+            "type": {
+              "defined": {
+                "name": "InsuranceClaim"
+              }
+            }
+          },
+          {
+            "name": "unrealized_pnl_max_imbalance",
+            "docs": [
+              "The max pnl imbalance before positive pnl asset weight is discounted",
+              "pnl imbalance is the difference between long and short pnl. When it's greater than 0,",
+              "the amm has negative pnl and the initial asset weight for positive pnl is discounted",
+              "precision = QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "expiry_ts",
+            "docs": [
+              "The ts when the market will be expired. Only set if market is in reduce only mode"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "expiry_price",
+            "docs": [
+              "The price at which positions will be settled. Only set if market is expired",
+              "precision = PRICE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "next_fill_record_id",
+            "docs": [
+              "Every trade has a fill record id. This is the next id to be used"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "next_funding_rate_record_id",
+            "docs": [
+              "Every funding rate update has a record id. This is the next id to be used"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "next_curve_record_id",
+            "docs": [
+              "Every amm k updated has a record id. This is the next id to be used"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "imf_factor",
+            "docs": [
+              "The initial margin fraction factor. Used to increase margin ratio for large positions",
+              "precision: MARGIN_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "unrealized_pnl_imf_factor",
+            "docs": [
+              "The imf factor for unrealized pnl. Used to discount asset weight for large positive pnl",
+              "precision: MARGIN_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "liquidator_fee",
+            "docs": [
+              "The fee the liquidator is paid for taking over perp position",
+              "precision: LIQUIDATOR_FEE_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "if_liquidation_fee",
+            "docs": [
+              "The fee the insurance fund receives from liquidation",
+              "precision: LIQUIDATOR_FEE_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "margin_ratio_initial",
+            "docs": [
+              "The margin ratio which determines how much collateral is required to open a position",
+              "e.g. margin ratio of .1 means a user must have $100 of total collateral to open a $1000 position",
+              "precision: MARGIN_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "margin_ratio_maintenance",
+            "docs": [
+              "The margin ratio which determines when a user will be liquidated",
+              "e.g. margin ratio of .05 means a user must have $50 of total collateral to maintain a $1000 position",
+              "else they will be liquidated",
+              "precision: MARGIN_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "unrealized_pnl_initial_asset_weight",
+            "docs": [
+              "The initial asset weight for positive pnl. Negative pnl always has an asset weight of 1",
+              "precision: SPOT_WEIGHT_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "unrealized_pnl_maintenance_asset_weight",
+            "docs": [
+              "The maintenance asset weight for positive pnl. Negative pnl always has an asset weight of 1",
+              "precision: SPOT_WEIGHT_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "number_of_users_with_base",
+            "docs": [
+              "number of users in a position (base)"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "number_of_users",
+            "docs": [
+              "number of users in a position (pnl) or pnl (quote)"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "market_index",
+            "type": "u16"
+          },
+          {
+            "name": "status",
+            "docs": [
+              "Whether a market is active, reduce only, expired, etc",
+              "Affects whether users can open/close positions"
+            ],
+            "type": {
+              "defined": {
+                "name": "MarketStatus"
+              }
+            }
+          },
+          {
+            "name": "contract_type",
+            "docs": [
+              "Currently only Perpetual markets are supported"
+            ],
+            "type": {
+              "defined": {
+                "name": "ContractType"
+              }
+            }
+          },
+          {
+            "name": "contract_tier",
+            "docs": [
+              "The contract tier determines how much insurance a market can receive, with more speculative markets receiving less insurance",
+              "It also influences the order perp markets can be liquidated, with less speculative markets being liquidated first"
+            ],
+            "type": {
+              "defined": {
+                "name": "ContractTier"
+              }
+            }
+          },
+          {
+            "name": "paused_operations",
+            "type": "u8"
+          },
+          {
+            "name": "quote_spot_market_index",
+            "docs": [
+              "The spot market that pnl is settled in"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "fee_adjustment",
+            "docs": [
+              "Between -100 and 100, represents what % to increase/decrease the fee by",
+              "E.g. if this is -50 and the fee is 5bps, the new fee will be 2.5bps",
+              "if this is 50 and the fee is 5bps, the new fee will be 7.5bps"
+            ],
+            "type": "i16"
+          },
+          {
+            "name": "fuel_boost_position",
+            "docs": [
+              "fuel multiplier for perp funding",
+              "precision: 10"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fuel_boost_taker",
+            "docs": [
+              "fuel multiplier for perp taker",
+              "precision: 10"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fuel_boost_maker",
+            "docs": [
+              "fuel multiplier for perp maker",
+              "precision: 10"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "pool_id",
+            "type": "u8"
+          },
+          {
+            "name": "high_leverage_margin_ratio_initial",
+            "type": "u16"
+          },
+          {
+            "name": "high_leverage_margin_ratio_maintenance",
+            "type": "u16"
+          },
+          {
+            "name": "protected_maker_limit_price_divisor",
+            "type": "u8"
+          },
+          {
+            "name": "protected_maker_dynamic_divisor",
+            "type": "u8"
+          },
+          {
+            "name": "lp_fee_transfer_scalar",
+            "type": "u8"
+          },
+          {
+            "name": "lp_status",
+            "type": "u8"
+          },
+          {
+            "name": "lp_paused_operations",
+            "type": "u8"
+          },
+          {
+            "name": "lp_exchange_fee_excluscion_scalar",
+            "type": "u8"
+          },
+          {
+            "name": "last_fill_price",
+            "type": "u64"
+          },
+          {
+            "name": "lp_pool_id",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                23
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProtectedMakerModeConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "max_users",
+            "type": "u32"
+          },
+          {
+            "name": "current_users",
+            "type": "u32"
+          },
+          {
+            "name": "reduce_only",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                31
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PythLazerOracle",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "price",
+            "type": "i64"
+          },
+          {
+            "name": "publish_time",
+            "type": "u64"
+          },
+          {
+            "name": "posted_slot",
+            "type": "u64"
+          },
+          {
+            "name": "exponent",
+            "type": "i32"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          },
+          {
+            "name": "conf",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RevenueShare",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "docs": [
+              "the owner of this account, a builder or referrer"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "total_referrer_rewards",
+            "type": "u64"
+          },
+          {
+            "name": "total_builder_rewards",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                18
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "RevenueShareEscrow",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "docs": [
+              "the owner of this account, a user"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "referrer",
+            "type": "pubkey"
+          },
+          {
+            "name": "referrer_boost_expire_ts",
+            "type": "u32"
+          },
+          {
+            "name": "referrer_reward_offset",
+            "type": "i8"
+          },
+          {
+            "name": "referee_fee_numerator_offset",
+            "type": "i8"
+          },
+          {
+            "name": "referrer_boost_numerator",
+            "type": "i8"
+          },
+          {
+            "name": "reserved_fixed",
+            "type": {
+              "array": [
+                "u8",
+                17
+              ]
+            }
+          },
+          {
+            "name": "padding0",
+            "type": "u32"
+          },
+          {
+            "name": "orders",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "RevenueShareOrder"
+                }
+              }
+            }
+          },
+          {
+            "name": "padding1",
+            "type": "u32"
+          },
+          {
+            "name": "approved_builders",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "BuilderInfo"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SignedMsgUserOrders",
+      "docs": [
+        "* This struct is a duplicate of SignedMsgUserOrdersZeroCopy\n * It is used to give anchor an struct to generate the idl for clients\n * The struct SignedMsgUserOrdersZeroCopy is used to load the data in efficiently"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority_pubkey",
+            "type": "pubkey"
+          },
+          {
+            "name": "padding",
+            "type": "u32"
+          },
+          {
+            "name": "signed_msg_order_data",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "SignedMsgOrderId"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SignedMsgWsDelegates",
+      "docs": [
+        "* Used to store authenticated delegates for swift-like ws connections"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "delegates",
+            "type": {
+              "vec": "pubkey"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpotMarket",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkey",
+            "docs": [
+              "The address of the spot market. It is a pda of the market index"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "oracle",
+            "docs": [
+              "The oracle used to price the markets deposits/borrows"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
+            "docs": [
+              "The token mint of the market"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "vault",
+            "docs": [
+              "The vault used to store the market's deposits",
+              "The amount in the vault should be equal to or greater than deposits - borrows"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "name",
+            "docs": [
+              "The encoded display name for the market e.g. SOL"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "historical_oracle_data",
+            "type": {
+              "defined": {
+                "name": "HistoricalOracleData"
+              }
+            }
+          },
+          {
+            "name": "historical_index_data",
+            "type": {
+              "defined": {
+                "name": "HistoricalIndexData"
+              }
+            }
+          },
+          {
+            "name": "revenue_pool",
+            "docs": [
+              "Revenue the protocol has collected in this markets token",
+              "e.g. for SOL-PERP, funds can be settled in usdc and will flow into the USDC revenue pool"
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolBalance"
+              }
+            }
+          },
+          {
+            "name": "spot_fee_pool",
+            "docs": [
+              "The fees collected from swaps between this market and the quote market",
+              "Is settled to the quote markets revenue pool"
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolBalance"
+              }
+            }
+          },
+          {
+            "name": "insurance_fund",
+            "docs": [
+              "Details on the insurance fund covering bankruptcies in this markets token",
+              "Covers bankruptcies for borrows with this markets token and perps settling in this markets token"
+            ],
+            "type": {
+              "defined": {
+                "name": "InsuranceFund"
+              }
+            }
+          },
+          {
+            "name": "total_spot_fee",
+            "docs": [
+              "The total spot fees collected for this market",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "deposit_balance",
+            "docs": [
+              "The sum of the scaled balances for deposits across users and pool balances",
+              "To convert to the deposit token amount, multiply by the cumulative deposit interest",
+              "precision: SPOT_BALANCE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "borrow_balance",
+            "docs": [
+              "The sum of the scaled balances for borrows across users and pool balances",
+              "To convert to the borrow token amount, multiply by the cumulative borrow interest",
+              "precision: SPOT_BALANCE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "cumulative_deposit_interest",
+            "docs": [
+              "The cumulative interest earned by depositors",
+              "Used to calculate the deposit token amount from the deposit balance",
+              "precision: SPOT_CUMULATIVE_INTEREST_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "cumulative_borrow_interest",
+            "docs": [
+              "The cumulative interest earned by borrowers",
+              "Used to calculate the borrow token amount from the borrow balance",
+              "precision: SPOT_CUMULATIVE_INTEREST_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "total_social_loss",
+            "docs": [
+              "The total socialized loss from borrows, in the mint's token",
+              "precision: token mint precision"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "total_quote_social_loss",
+            "docs": [
+              "The total socialized loss from borrows, in the quote market's token",
+              "preicision: QUOTE_PRECISION"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "withdraw_guard_threshold",
+            "docs": [
+              "no withdraw limits/guards when deposits below this threshold",
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "max_token_deposits",
+            "docs": [
+              "The max amount of token deposits in this market",
+              "0 if there is no limit",
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "deposit_token_twap",
+            "docs": [
+              "24hr average of deposit token amount",
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "borrow_token_twap",
+            "docs": [
+              "24hr average of borrow token amount",
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "utilization_twap",
+            "docs": [
+              "24hr average of utilization",
+              "which is borrow amount over token amount",
+              "precision: SPOT_UTILIZATION_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_interest_ts",
+            "docs": [
+              "Last time the cumulative deposit and borrow interest was updated"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_twap_ts",
+            "docs": [
+              "Last time the deposit/borrow/utilization averages were updated"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "expiry_ts",
+            "docs": [
+              "The time the market is set to expire. Only set if market is in reduce only mode"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "order_step_size",
+            "docs": [
+              "Spot orders must be a multiple of the step size",
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "order_tick_size",
+            "docs": [
+              "Spot orders must be a multiple of the tick size",
+              "precision: PRICE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "min_order_size",
+            "docs": [
+              "The minimum order size",
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "max_position_size",
+            "docs": [
+              "The maximum spot position size",
+              "if the limit is 0, there is no limit",
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "next_fill_record_id",
+            "docs": [
+              "Every spot trade has a fill record id. This is the next id to use"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "next_deposit_record_id",
+            "docs": [
+              "Every deposit has a deposit record id. This is the next id to use"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "initial_asset_weight",
+            "docs": [
+              "The initial asset weight used to calculate a deposits contribution to a users initial total collateral",
+              "e.g. if the asset weight is .8, $100 of deposits contributes $80 to the users initial total collateral",
+              "precision: SPOT_WEIGHT_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "maintenance_asset_weight",
+            "docs": [
+              "The maintenance asset weight used to calculate a deposits contribution to a users maintenance total collateral",
+              "e.g. if the asset weight is .9, $100 of deposits contributes $90 to the users maintenance total collateral",
+              "precision: SPOT_WEIGHT_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "initial_liability_weight",
+            "docs": [
+              "The initial liability weight used to calculate a borrows contribution to a users initial margin requirement",
+              "e.g. if the liability weight is .9, $100 of borrows contributes $90 to the users initial margin requirement",
+              "precision: SPOT_WEIGHT_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "maintenance_liability_weight",
+            "docs": [
+              "The maintenance liability weight used to calculate a borrows contribution to a users maintenance margin requirement",
+              "e.g. if the liability weight is .8, $100 of borrows contributes $80 to the users maintenance margin requirement",
+              "precision: SPOT_WEIGHT_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "imf_factor",
+            "docs": [
+              "The initial margin fraction factor. Used to increase liability weight/decrease asset weight for large positions",
+              "precision: MARGIN_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "liquidator_fee",
+            "docs": [
+              "The fee the liquidator is paid for taking over borrow/deposit",
+              "precision: LIQUIDATOR_FEE_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "if_liquidation_fee",
+            "docs": [
+              "The fee the insurance fund receives from liquidation",
+              "precision: LIQUIDATOR_FEE_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "optimal_utilization",
+            "docs": [
+              "The optimal utilization rate for this market.",
+              "Used to determine the markets borrow rate",
+              "precision: SPOT_UTILIZATION_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "optimal_borrow_rate",
+            "docs": [
+              "The borrow rate for this market when the market has optimal utilization",
+              "precision: SPOT_RATE_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_borrow_rate",
+            "docs": [
+              "The borrow rate for this market when the market has 1000 utilization",
+              "precision: SPOT_RATE_PRECISION"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "decimals",
+            "docs": [
+              "The market's token mint's decimals. To from decimals to a precision, 10^decimals"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "market_index",
+            "type": "u16"
+          },
+          {
+            "name": "orders_enabled",
+            "docs": [
+              "Whether or not spot trading is enabled"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "oracle_source",
+            "type": {
+              "defined": {
+                "name": "OracleSource"
+              }
+            }
+          },
+          {
+            "name": "status",
+            "type": {
+              "defined": {
+                "name": "MarketStatus"
+              }
+            }
+          },
+          {
+            "name": "asset_tier",
+            "docs": [
+              "The asset tier affects how a deposit can be used as collateral and the priority for a borrow being liquidated"
+            ],
+            "type": {
+              "defined": {
+                "name": "AssetTier"
+              }
+            }
+          },
+          {
+            "name": "paused_operations",
+            "type": "u8"
+          },
+          {
+            "name": "if_paused_operations",
+            "type": "u8"
+          },
+          {
+            "name": "fee_adjustment",
+            "type": "i16"
+          },
+          {
+            "name": "max_token_borrows_fraction",
+            "docs": [
+              "What fraction of max_token_deposits",
+              "disabled when 0, 1 => 1/10000 => .01% of max_token_deposits",
+              "precision: X/10000"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "flash_loan_amount",
+            "docs": [
+              "For swaps, the amount of token loaned out in the begin_swap ix",
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "flash_loan_initial_token_amount",
+            "docs": [
+              "For swaps, the amount in the users token account in the begin_swap ix",
+              "Used to calculate how much of the token left the system in end_swap ix",
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_swap_fee",
+            "docs": [
+              "The total fees received from swaps",
+              "precision: token mint precision"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "scale_initial_asset_weight_start",
+            "docs": [
+              "When to begin scaling down the initial asset weight",
+              "disabled when 0",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "min_borrow_rate",
+            "docs": [
+              "The min borrow rate for this market when the market regardless of utilization",
+              "1 => 1/200 => .5%",
+              "precision: X/200"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fuel_boost_deposits",
+            "docs": [
+              "fuel multiplier for spot deposits",
+              "precision: 10"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fuel_boost_borrows",
+            "docs": [
+              "fuel multiplier for spot borrows",
+              "precision: 10"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fuel_boost_taker",
+            "docs": [
+              "fuel multiplier for spot taker",
+              "precision: 10"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fuel_boost_maker",
+            "docs": [
+              "fuel multiplier for spot maker",
+              "precision: 10"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fuel_boost_insurance",
+            "docs": [
+              "fuel multiplier for spot insurance stake",
+              "precision: 10"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "token_program_flag",
+            "type": "u8"
+          },
+          {
+            "name": "pool_id",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                40
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "State",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "whitelist_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "discount_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "signer",
+            "type": "pubkey"
+          },
+          {
+            "name": "srm_vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "perp_fee_structure",
+            "type": {
+              "defined": {
+                "name": "FeeStructure"
+              }
+            }
+          },
+          {
+            "name": "spot_fee_structure",
+            "type": {
+              "defined": {
+                "name": "FeeStructure"
+              }
+            }
+          },
+          {
+            "name": "oracle_guard_rails",
+            "type": {
+              "defined": {
+                "name": "OracleGuardRails"
+              }
+            }
+          },
+          {
+            "name": "number_of_authorities",
+            "type": "u64"
+          },
+          {
+            "name": "number_of_sub_accounts",
+            "type": "u64"
+          },
+          {
+            "name": "lp_cooldown_time",
+            "type": "u64"
+          },
+          {
+            "name": "liquidation_margin_buffer_ratio",
+            "type": "u32"
+          },
+          {
+            "name": "settlement_duration",
+            "type": "u16"
+          },
+          {
+            "name": "number_of_markets",
+            "type": "u16"
+          },
+          {
+            "name": "number_of_spot_markets",
+            "type": "u16"
+          },
+          {
+            "name": "signer_nonce",
+            "type": "u8"
+          },
+          {
+            "name": "min_perp_auction_duration",
+            "type": "u8"
+          },
+          {
+            "name": "default_market_order_time_in_force",
+            "type": "u8"
+          },
+          {
+            "name": "default_spot_auction_duration",
+            "type": "u8"
+          },
+          {
+            "name": "exchange_status",
+            "type": "u8"
+          },
+          {
+            "name": "liquidation_duration",
+            "type": "u8"
+          },
+          {
+            "name": "initial_pct_to_liquidate",
+            "type": "u16"
+          },
+          {
+            "name": "max_number_of_sub_accounts",
+            "type": "u16"
+          },
+          {
+            "name": "max_initialize_user_fee",
+            "type": "u16"
+          },
+          {
+            "name": "feature_bit_flags",
+            "type": "u8"
+          },
+          {
+            "name": "lp_pool_feature_bit_flags",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "User",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "docs": [
+              "The owner/authority of the account"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "delegate",
+            "docs": [
+              "An addresses that can control the account on the authority's behalf. Has limited power, cant withdraw"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "name",
+            "docs": [
+              "Encoded display name e.g. \"toly\""
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "spot_positions",
+            "docs": [
+              "The user's spot positions"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "SpotPosition"
+                  }
+                },
+                8
+              ]
+            }
+          },
+          {
+            "name": "perp_positions",
+            "docs": [
+              "The user's perp positions"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "PerpPosition"
+                  }
+                },
+                8
+              ]
+            }
+          },
+          {
+            "name": "orders",
+            "docs": [
+              "The user's orders"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "Order"
+                  }
+                },
+                32
+              ]
+            }
+          },
+          {
+            "name": "last_add_perp_lp_shares_ts",
+            "docs": [
+              "The last time the user added perp lp positions"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "total_deposits",
+            "docs": [
+              "The total values of deposits the user has made",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_withdraws",
+            "docs": [
+              "The total values of withdrawals the user has made",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_social_loss",
+            "docs": [
+              "The total socialized loss the users has incurred upon the protocol",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "settled_perp_pnl",
+            "docs": [
+              "Fees (taker fees, maker rebate, referrer reward, filler reward) and pnl for perps",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "cumulative_spot_fees",
+            "docs": [
+              "Fees (taker fees, maker rebate, filler reward) for spot",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "cumulative_perp_funding",
+            "docs": [
+              "Cumulative funding paid/received for perps",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "liquidation_margin_freed",
+            "docs": [
+              "The amount of margin freed during liquidation. Used to force the liquidation to occur over a period of time",
+              "Defaults to zero when not being liquidated",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_active_slot",
+            "docs": [
+              "The last slot a user was active. Used to determine if a user is idle"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "next_order_id",
+            "docs": [
+              "Every user order has an order id. This is the next order id to be used"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_margin_ratio",
+            "docs": [
+              "Custom max initial margin ratio for the user"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "next_liquidation_id",
+            "docs": [
+              "The next liquidation id to be used for user"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "sub_account_id",
+            "docs": [
+              "The sub account id for this user"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "status",
+            "docs": [
+              "Whether the user is active, being liquidated or bankrupt"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "is_margin_trading_enabled",
+            "docs": [
+              "Whether the user has enabled margin trading"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "idle",
+            "docs": [
+              "User is idle if they haven't interacted with the protocol in 1 week and they have no orders, perp positions or borrows",
+              "Off-chain keeper bots can ignore users that are idle"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "open_orders",
+            "docs": [
+              "number of open orders"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "has_open_order",
+            "docs": [
+              "Whether or not user has open order"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "open_auctions",
+            "docs": [
+              "number of open orders with auction"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "has_open_auction",
+            "docs": [
+              "Whether or not user has open order with auction"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "margin_mode",
+            "type": {
+              "defined": {
+                "name": "MarginMode"
+              }
+            }
+          },
+          {
+            "name": "pool_id",
+            "type": "u8"
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "last_fuel_bonus_update_ts",
+            "type": "u32"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                12
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "UserStats",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "docs": [
+              "The authority for all of a users sub accounts"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "referrer",
+            "docs": [
+              "The address that referred this user"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "fees",
+            "docs": [
+              "Stats on the fees paid by the user"
+            ],
+            "type": {
+              "defined": {
+                "name": "UserFees"
+              }
+            }
+          },
+          {
+            "name": "next_epoch_ts",
+            "docs": [
+              "The timestamp of the next epoch",
+              "Epoch is used to limit referrer rewards earned in single epoch"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "maker_volume30d",
+            "docs": [
+              "Rolling 30day maker volume for user",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "taker_volume30d",
+            "docs": [
+              "Rolling 30day taker volume for user",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "filler_volume30d",
+            "docs": [
+              "Rolling 30day filler volume for user",
+              "precision: QUOTE_PRECISION"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_maker_volume30d_ts",
+            "docs": [
+              "last time the maker volume was updated"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "last_taker_volume30d_ts",
+            "docs": [
+              "last time the taker volume was updated"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "last_filler_volume30d_ts",
+            "docs": [
+              "last time the filler volume was updated"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "if_staked_quote_asset_amount",
+            "docs": [
+              "The amount of tokens staked in the quote spot markets if"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "number_of_sub_accounts",
+            "docs": [
+              "The current number of sub accounts"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "number_of_sub_accounts_created",
+            "docs": [
+              "The number of sub accounts created. Can be greater than the number of sub accounts if user",
+              "has deleted sub accounts"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "referrer_status",
+            "docs": [
+              "Flags for referrer status:",
+              "First bit (LSB): 1 if user is a referrer, 0 otherwise",
+              "Second bit: 1 if user was referred, 0 otherwise"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "disable_update_perp_bid_ask_twap",
+            "type": "bool"
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u8",
+                1
+              ]
+            }
+          },
+          {
+            "name": "fuel_overflow_status",
+            "docs": [
+              "whether the user has a FuelOverflow account"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fuel_insurance",
+            "docs": [
+              "accumulated fuel for token amounts of insurance"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "fuel_deposits",
+            "docs": [
+              "accumulated fuel for notional of deposits"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "fuel_borrows",
+            "docs": [
+              "accumulate fuel bonus for notional of borrows"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "fuel_positions",
+            "docs": [
+              "accumulated fuel for perp open interest"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "fuel_taker",
+            "docs": [
+              "accumulate fuel bonus for taker volume"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "fuel_maker",
+            "docs": [
+              "accumulate fuel bonus for maker volume"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "if_staked_gov_token_amount",
+            "docs": [
+              "The amount of tokens staked in the governance spot markets if"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_fuel_if_bonus_update_ts",
+            "docs": [
+              "last unix ts user stats data was used to update if fuel (u32 to save space)"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                12
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReferrerName",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "user",
+            "type": "pubkey"
+          },
+          {
+            "name": "user_stats",
+            "type": "pubkey"
+          },
+          {
+            "name": "name",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "FuelOverflow",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "docs": [
+              "The authority of this overflow account"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "fuel_insurance",
+            "type": "u128"
+          },
+          {
+            "name": "fuel_deposits",
+            "type": "u128"
+          },
+          {
+            "name": "fuel_borrows",
+            "type": "u128"
+          },
+          {
+            "name": "fuel_positions",
+            "type": "u128"
+          },
+          {
+            "name": "fuel_taker",
+            "type": "u128"
+          },
+          {
+            "name": "fuel_maker",
+            "type": "u128"
+          },
+          {
+            "name": "last_fuel_sweep_ts",
+            "type": "u32"
+          },
+          {
+            "name": "last_reset_ts",
+            "type": "u32"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u128",
+                6
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/crates/core/src/scenarios/protocols/drift/v2/overrides.yaml
+++ b/crates/core/src/scenarios/protocols/drift/v2/overrides.yaml
@@ -1,0 +1,74 @@
+protocol: Drift
+version: v2
+account_type: Multiple
+idl_file_path: idl.json
+
+tags:
+  - perpetuals
+  - spot-trading
+  - amm
+  - liquidation
+  - defi
+
+templates:
+  - id: drift-perp-market
+    name: Override Perp Market State
+    description: Override core AMM and oracle parameters of a perpetual market
+    idl_account_name: PerpMarket
+    properties:
+      [
+        "amm.base_asset_reserve",
+        "amm.quote_asset_reserve",
+        "amm.peg_multiplier",
+        "amm.last_funding_rate",
+        "amm.base_spread",
+        "amm.historical_oracle_data.last_oracle_price",
+      ]
+    address:
+      type: pubkey
+
+  - id: drift-spot-market
+    name: Override Spot Market State
+    description: Override balances and interest parameters for spot market simulation
+    idl_account_name: SpotMarket
+    properties:
+      [
+        "deposit_balance",
+        "borrow_balance",
+        "cumulative_deposit_interest",
+        "cumulative_borrow_interest",
+        "optimal_utilization",
+        "max_borrow_rate",
+      ]
+    address:
+      type: pubkey
+
+  - id: drift-user-state
+    name: Override User State
+    description: Override user's perp & spot positions and margin parameters
+    idl_account_name: User
+    properties:
+      [
+        "perp_positions",
+        "spot_positions",
+        "settled_perp_pnl",
+        "total_deposits",
+        "max_margin_ratio",
+      ]
+    address:
+      type: pubkey
+
+  - id: drift-global-state
+    name: Override Global State
+    description: Override global parameters controlling pricing, fees, and safety checks
+    idl_account_name: State
+    properties:
+      [
+        "perp_fee_structure",
+        "spot_fee_structure",
+        "oracle_guard_rails",
+        "liquidation_margin_buffer_ratio",
+        "exchange_status",
+      ]
+    address:
+      type: pubkey

--- a/crates/core/src/scenarios/registry.rs
+++ b/crates/core/src/scenarios/registry.rs
@@ -13,6 +13,9 @@ pub const RAYDIUM_CLMM_IDL_CONTENT: &str = include_str!("./protocols/raydium/v3/
 pub const RAYDIUM_CLMM_OVERRIDES_CONTENT: &str =
     include_str!("./protocols/raydium/v3/overrides.yaml");
 
+pub const DRIFT_V2_IDL_CONTENT: &str = include_str!("./protocols/drift/v2/idl.json");
+pub const DRIFT_V2_OVERRIDES_CONTENT: &str = include_str!("./protocols/drift/v2/overrides.yaml");
+
 /// Registry for managing override templates loaded from YAML files
 #[derive(Clone, Debug, Default)]
 pub struct TemplateRegistry {
@@ -27,6 +30,7 @@ impl TemplateRegistry {
         default.load_pyth_overrides();
         default.load_jupiter_overrides();
         default.load_raydium_overrides();
+        default.load_drift_overrides();
         default
     }
 
@@ -40,6 +44,10 @@ impl TemplateRegistry {
             JUPITER_V6_OVERRIDES_CONTENT,
             "jupiter",
         );
+    }
+
+    pub fn load_drift_overrides(&mut self) {
+        self.load_protocol_overrides(DRIFT_V2_IDL_CONTENT, DRIFT_V2_OVERRIDES_CONTENT, "drift");
     }
 
     fn load_protocol_overrides(
@@ -141,10 +149,10 @@ mod tests {
     fn test_registry_loads_both_protocols() {
         let registry = TemplateRegistry::new();
 
-        // Should have Pyth (4 templates) + Jupiter (1 template) + Raydium(3 templates) = 5 total
+        // Should have Pyth (4 templates) + Jupiter (1 template) + Raydium(3 templates) + Drift(4 templates) = 12 total
         assert_eq!(
             registry.count(),
-            8,
+            12,
             "Registry should load 5 templates total"
         );
 
@@ -158,6 +166,11 @@ mod tests {
         assert!(registry.contains("raydium-clmm-sol-usdc"));
         assert!(registry.contains("raydium-clmm-btc-usdc"));
         assert!(registry.contains("raydium-clmm-eth-usdc"));
+
+        assert!(registry.contains("drift-perp-market"));
+        assert!(registry.contains("drift-spot-market"));
+        assert!(registry.contains("drift-user-state"));
+        assert!(registry.contains("drift-global-state"))
     }
 
     #[test]
@@ -240,9 +253,10 @@ mod tests {
         let registry = TemplateRegistry::new();
         let ids = registry.list_ids();
 
-        assert_eq!(ids.len(), 8);
+        assert_eq!(ids.len(), 12);
         assert!(ids.contains(&"raydium-clmm-sol-usdc".to_string()));
         assert!(ids.contains(&"jupiter-token-ledger-override".to_string()));
         assert!(ids.contains(&"pyth-sol-usd-v2".to_string()));
+        assert!(ids.contains(&"drift-perp-market".to_string()));
     }
 }


### PR DESCRIPTION
- Added Drift v2 protocol
- Added cleaned + converted idl.json for Drift v2
- Added `overrides.yaml` with 4 override templates (PerpMarket, SpotMarket, User, Margin/Liquidation)
- Registered Drift protocol and templates in the scenario registry

This enables creating Drift perp, spot, and user-state scenarios directly in Surfpools.