### PR TITLE
fix: add backward compatibility for older anchor versions in subgraph generation

### DIFF
--- a/crates/cli/src/cli/simnet/mod.rs
+++ b/crates/cli/src/cli/simnet/mod.rs
@@ -452,7 +452,7 @@ async fn write_and_execute_iac(
         accounts,
         accounts_dir,
         clones,
-        anchor_version,
+        generate_subgraphs,
     }) = deployment
     {
         if let Some(clones) = clones.as_ref() {
@@ -484,7 +484,7 @@ async fn write_and_execute_iac(
                 &programs,
                 &base_location,
                 cmd.skip_runbook_generation_prompts,
-                anchor_version.as_deref(),
+                generate_subgraphs,
             )?;
         }
 
@@ -502,7 +502,7 @@ async fn write_and_execute_iac(
                 &genesis_accounts,
                 &accounts,
                 &accounts_dir,
-                anchor_version.as_deref(),
+                generate_subgraphs,
             )?);
         } else {
             let runbooks_ids_to_execute = cmd.runbooks.clone();

--- a/crates/cli/src/scaffold/mod.rs
+++ b/crates/cli/src/scaffold/mod.rs
@@ -35,7 +35,7 @@ pub struct ProgramFrameworkData {
     pub accounts: Option<Vec<AccountEntry>>,
     pub accounts_dir: Option<Vec<AccountDirEntry>>,
     pub clones: Option<Vec<String>>,
-    pub anchor_version: Option<String>,
+    pub generate_subgraphs: bool,
 }
 
 impl ProgramFrameworkData {
@@ -46,7 +46,7 @@ impl ProgramFrameworkData {
         accounts: Option<Vec<AccountEntry>>,
         accounts_dir: Option<Vec<AccountDirEntry>>,
         clones: Option<Vec<String>>,
-        anchor_version: Option<String>,
+        generate_subgraphs: bool,
     ) -> Self {
         Self {
             framework,
@@ -55,7 +55,7 @@ impl ProgramFrameworkData {
             accounts,
             accounts_dir,
             clones,
-            anchor_version,
+            generate_subgraphs,
         }
     }
 
@@ -67,7 +67,7 @@ impl ProgramFrameworkData {
             accounts: None,
             accounts_dir: None,
             clones: None,
-            anchor_version: None,
+            generate_subgraphs: true,
         }
     }
 }
@@ -138,7 +138,7 @@ pub fn scaffold_in_memory_iac(
     genesis_accounts: &Option<Vec<GenesisEntry>>,
     accounts: &Option<Vec<AccountEntry>>,
     accounts_dir: &Option<Vec<AccountDirEntry>>,
-    anchor_version: Option<&str>,
+    generate_subgraphs: bool,
 ) -> Result<(String, RunbookSources, WorkspaceManifest), String> {
     let mut deployment_runbook_src: String = String::new();
 
@@ -156,16 +156,17 @@ pub fn scaffold_in_memory_iac(
                 .get_in_memory_interpolated_program_deployment_template(&program_metadata.name),
         );
 
-        if let Some(subgraph_iac) = &framework
-            .get_interpolated_subgraph_template(
-                &program_metadata.name,
-                program_metadata.idl.as_ref(),
-                anchor_version,
-            )
-            .ok()
-            .flatten()
-        {
-            deployment_runbook_src.push_str(subgraph_iac);
+        if generate_subgraphs {
+            if let Some(subgraph_iac) = &framework
+                .get_interpolated_subgraph_template(
+                    &program_metadata.name,
+                    program_metadata.idl.as_ref(),
+                )
+                .ok()
+                .flatten()
+            {
+                deployment_runbook_src.push_str(subgraph_iac);
+            }
         }
     }
 
@@ -205,7 +206,7 @@ pub fn scaffold_iac_layout(
     programs: &[ProgramMetadata],
     base_location: &FileLocation,
     auto_generate_runbooks: bool,
-    anchor_version: Option<&str>,
+    generate_subgraphs: bool,
 ) -> Result<(), String> {
     let mut target_location = base_location.clone();
     target_location.append_path("target")?;
@@ -303,11 +304,12 @@ pub fn scaffold_iac_layout(
             &framework.get_interpolated_program_deployment_template(&program_metadata.name),
         );
 
-        subgraph_runbook_src = framework.get_interpolated_subgraph_template(
-            &program_metadata.name,
-            program_metadata.idl.as_ref(),
-            anchor_version,
-        )?;
+        if generate_subgraphs {
+            subgraph_runbook_src = framework.get_interpolated_subgraph_template(
+                &program_metadata.name,
+                program_metadata.idl.as_ref(),
+            )?;
+        }
 
         // Configure initialize instruction
         // let args = vec![

--- a/crates/cli/src/types/mod.rs
+++ b/crates/cli/src/types/mod.rs
@@ -43,25 +43,10 @@ impl Framework {
         &self,
         program_name: &str,
         idl: Option<&String>,
-        anchor_version: Option<&str>,
     ) -> Result<Option<String>, String> {
         let Some(idl) = idl else {
             return Ok(None);
         };
-
-        if let Some(version) = anchor_version {
-            let version_parts: Vec<&str> = version.split('.').collect();
-            if version_parts.len() >= 2
-                && let (Ok(major), Ok(minor)) = (
-                    version_parts[0].parse::<u32>(),
-                    version_parts[1].parse::<u32>(),
-                )
-                && major == 0
-                && minor < 26
-            {
-                return Ok(None);
-            }
-        }
 
         match self {
             Framework::Anchor | Framework::Native | Framework::Pinocchio => {


### PR DESCRIPTION
   Resolves issue #294 by gracefully handling IDL format incompatibilities with older Anchor versions (< 0.26.0). 
   Instead of blocking deployment when subgraph IaC generation fails, the system now:

   - Detects the Anchor version from Anchor.toml
   - Skips subgraph infrastructure-as-code generation for incompatible versions
   - Allows program deployment to proceed without subgraph generation
   - Maintains normal subgraph generation for newer versions (>= 0.26.0)

   Changes:
   - Add anchor_version field to ProgramFrameworkData struct
   - Pass Anchor version through the entire scaffold pipeline
   - Implement version checking before subgraph template generation
   - Skip subgraph generation for versions < 0.26.0