### PR TITLE
fix: solana program close (stop or stuck surfpool)

### DIFF
--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -1024,9 +1024,8 @@ impl SurfnetSvmLocker {
                 // the RPC handler from hanging on recv() when errors occur during
                 // account fetching, ALT resolution, or other pre-processing steps.
                 // This is critical for issue #454 where program close stops block production.
-                let _ = status_tx.try_send(TransactionStatusEvent::VerificationFailure(
-                    e.to_string(),
-                ));
+                let _ =
+                    status_tx.try_send(TransactionStatusEvent::VerificationFailure(e.to_string()));
                 return Err(e);
             }
         };


### PR DESCRIPTION
#Fixes 454 : where solana program close causes Surfpool to stop producing blocks with error -32002: receiving on an empty and disconnected channel.

When process_transaction() returned an error during preprocessing (account fetching, ALT resolution, etc.), the status_tx channel was dropped without sending any response. This caused the RPC handler's recv() to return RecvError, stopping block production.

before : 
<img width="1797" height="1052" alt="Screenshot 2025-12-30 at 4 43 52 AM 2" src="https://github.com/user-attachments/assets/ce106734-fab7-4484-ac9f-ce7083aafea4" />

Modified process_transaction() in locker.rs to always send a VerificationFailure event through the status channel before returning errors

after : 
<img width="1799" height="1040" alt="Screenshot 2026-01-01 at 4 32 27 AM 2" src="https://github.com/user-attachments/assets/05f19323-4bf6-4a0a-a070-1450b53f112e" />



