### PR TITLE
feat: adds a new  subcommand to compare snapshot files with mainnet RPC

### DIFF
--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -23,7 +23,10 @@ use txtx_cloud::LoginCommand;
 use txtx_core::manifest::WorkspaceManifest;
 use txtx_gql::kit::{helpers::fs::FileLocation, types::frontend::LogLevel};
 
-use crate::{cli::simnet::handle_state_diff_command, cloud::CloudStartCommand, runbook::handle_execute_runbook_command};
+use crate::{
+    cli::simnet::handle_state_diff_command, cloud::CloudStartCommand,
+    runbook::handle_execute_runbook_command,
+};
 
 mod simnet;
 
@@ -146,14 +149,17 @@ enum StateAction {
 struct DiffArgs {
     // Snapshot to compare with mainnet accounts
     #[clap(value_name = "SNAPSHOT_FILE")]
-    snapshot : String,
+    snapshot: String,
     // Optional : Custom mainnet RPC url
-    #[clap(value_name = "MAINNET_URL", default_value = "https://api.mainnet-beta.solana.com")]
-    mainnet_url : String,
+    #[clap(
+        value_name = "MAINNET_URL",
+        default_value = "https://api.mainnet-beta.solana.com"
+    )]
+    mainnet_url: String,
     /// only show difference
-    #[clap(short , long)]
-    brief : bool
- }
+    #[clap(short, long)]
+    brief: bool,
+}
 
 #[derive(Parser, PartialEq, Clone, Debug)]
 pub struct StartSimnet {

--- a/crates/cli/src/macros.rs
+++ b/crates/cli/src/macros.rs
@@ -182,8 +182,10 @@ macro_rules! format_note {
 macro_rules! compare_field {
     ($field_name:expr, $snapshot_val:expr, $mainnet_val:expr) => {
         if $snapshot_val != $mainnet_val {
-            println!("  {} differs: Snapshot={}, Mainnet={}", 
-                     $field_name, $snapshot_val, $mainnet_val);
+            println!(
+                "  {} differs: Snapshot={}, Mainnet={}",
+                $field_name, $snapshot_val, $mainnet_val
+            );
             false
         } else {
             true


### PR DESCRIPTION
Purpose: This feature enables developers to compare a local snapshot of Solana account states

Command Path: Added surfpool state diff <SNAPSHOT_FILE> [MAINNET_URL]

This new command allows developers to compare a local Solana account snapshot file against the live mainnet. It loads a JSON snapshot, fetches the latest state for each account from mainnet RPC, and performs a detailed comparison of lamports, owner, executable status, rent epoch, and data length. The tool provides clear, formatted output highlighting differences and a summary count, essential for debugging state drift and validating local test scenarios against the real network