### PR TITLE
fix(core): surfnet encode_ui_account to handle ReadableAccount inputs and enable agave unstable api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ solana-program-pack = { version = "3.0", default-features = false }
 solana-pubkey = { version = "3.0", default-features = false }
 solana-rpc-client = { version = "3.1", default-features = false }
 solana-rpc-client-api = { version = "3.1", default-features = false }
-solana-runtime = { version = "3.1", default-features = false }
+solana-runtime = { version = "3.1", default-features = false, features = ["agave-unstable-api"] }
 solana-sdk-ids = { version = "3.1", default-features = false }
 solana-signature = { version = "3.1", default-features = false, features = [
     "rand",

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -2911,9 +2911,6 @@ impl SurfnetSvmLocker {
             inner: local_accounts,
         } = self.get_program_accounts_local(program_id, account_config.clone(), filters.clone())?;
 
-        let encoding = account_config.encoding.unwrap_or(UiAccountEncoding::Base64);
-        let data_slice = account_config.data_slice;
-
         let remote_accounts_result = client
             .get_program_accounts(program_id, account_config, filters)
             .await?;
@@ -2925,10 +2922,10 @@ impl SurfnetSvmLocker {
         });
 
         let mut combined_accounts = remote_accounts
-            .iter()
+            .into_iter()
             .map(|(pubkey, account)| RpcKeyedAccount {
                 pubkey: pubkey.to_string(),
-                account: self.encode_ui_account(pubkey, account, encoding, None, data_slice),
+                account,
             })
             .collect::<Vec<RpcKeyedAccount>>();
 

--- a/crates/core/src/surfnet/remote.rs
+++ b/crates/core/src/surfnet/remote.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use serde_json::json;
-use solana_account::Account;
+use solana_account_decoder::UiAccount;
 use solana_client::{
     nonblocking::rpc_client::RpcClient,
     rpc_client::{GetConfirmedSignaturesForAddress2Config, RpcClientConfig},
@@ -297,10 +297,10 @@ impl SurfnetRemoteClient {
         program_id: &Pubkey,
         account_config: RpcAccountInfoConfig,
         filters: Option<Vec<RpcFilterType>>,
-    ) -> SurfpoolResult<RemoteRpcResult<Vec<(Pubkey, Account)>>> {
+    ) -> SurfpoolResult<RemoteRpcResult<Vec<(Pubkey, UiAccount)>>> {
         handle_remote_rpc(|| async {
             self.client
-                .get_program_accounts_with_config(
+                .get_program_ui_accounts_with_config(
                     program_id,
                     RpcProgramAccountsConfig {
                         filters,

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -3128,12 +3128,13 @@ impl SurfnetSvm {
         data_slice_config: Option<UiDataSliceConfig>,
     ) -> UiAccount {
         let owner_program_id = account.owner();
+        let data = account.data();
 
-        let filter_slot = self.latest_epoch_info.absolute_slot; // todo: consider if we should pass in a slot
         if encoding == UiAccountEncoding::JsonParsed {
             if let Ok(Some(registered_idls)) =
                 self.registered_idls.get(&owner_program_id.to_string())
             {
+                let filter_slot = self.latest_epoch_info.absolute_slot;
                 // IDLs are stored sorted by slot descending (most recent first)
                 let ordered_available_idls = registered_idls
                     .iter()
@@ -3146,12 +3147,12 @@ impl SurfnetSvm {
                         }
                     })
                     .collect::<Vec<_>>();
+
                 // if we have none in this loop, it means the only IDLs registered for this pubkey are for a
                 // future slot, for some reason. if we have some, we'll try each one in this loop, starting
                 // with the most recent one, to see if the account data can be parsed to the IDL type
                 for idl in &ordered_available_idls {
                     // If we have a valid IDL, use it to parse the account data
-                    let data = account.data();
                     let discriminator = &data[..8];
                     if let Some(matching_account) = idl
                         .accounts
@@ -3192,10 +3193,10 @@ impl SurfnetSvm {
                                             .to_json(Some(&get_txtx_value_json_converters())),
                                         space: data.len() as u64,
                                     }),
-                                    owner: account.owner().to_string(),
+                                    owner: owner_program_id.to_string(),
                                     executable: account.executable(),
                                     rent_epoch: account.rent_epoch(),
-                                    space: Some(account.data().len() as u64),
+                                    space: Some(data.len() as u64),
                                 };
                             }
                         }


### PR DESCRIPTION
* fix: surfnet encode_ui_account to handle ReadableAccount inputs and IDL parsing safely and enable agave unstable api feature to solana runtime

* chore: optimization on get_program_accounts_local_then_remote

* fmt

* undo unecessary changes

---------