### PR TITLE
fix(geyser): align commitment slots and remove duplicate account re-emits

### DIFF
--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -4443,13 +4443,14 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_v0_transaction_without_alt_emits_geyser_account_updates() {
+        use std::time::Duration;
+
         use crossbeam_channel::{RecvTimeoutError, unbounded};
         use solana_keypair::Keypair;
         use solana_message::{VersionedMessage, v0};
         use solana_signer::Signer;
         use solana_system_interface::instruction as system_instruction;
         use solana_transaction::versioned::VersionedTransaction;
-        use std::time::Duration;
 
         let (svm, _events_rx, geyser_rx) = SurfnetSvm::default();
         let locker = SurfnetSvmLocker::new(svm);
@@ -4475,11 +4476,9 @@ mod tests {
         )
         .expect("v0 message should compile");
 
-        let tx = VersionedTransaction::try_new(
-            VersionedMessage::V0(message),
-            &[payer.insecure_clone()],
-        )
-        .expect("v0 transaction should sign");
+        let tx =
+            VersionedTransaction::try_new(VersionedMessage::V0(message), &[payer.insecure_clone()])
+                .expect("v0 transaction should sign");
 
         let tx_signature = tx.signatures[0];
         let (status_tx, _status_rx) = unbounded();

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -1664,18 +1664,32 @@ impl SurfnetSvmLocker {
                 .map(|p| svm_writer.inner.get_account_no_db(p))
                 .collect::<Vec<Option<Account>>>();
             let (sanitized_transaction, versioned_transaction) = if do_propagate {
+                let address_loader = match (&transaction.message, &loaded_addresses) {
+                    (VersionedMessage::V0(_), Some(loaded_addresses)) => {
+                        SimpleAddressLoader::Enabled(loaded_addresses.clone())
+                    }
+                    // V0 messages without address table lookups still require an enabled loader.
+                    (VersionedMessage::V0(_), None) => {
+                        SimpleAddressLoader::Enabled(LoadedAddresses::default())
+                    }
+                    (VersionedMessage::Legacy(_), _) => SimpleAddressLoader::Disabled,
+                };
+
                 (
                     SanitizedTransaction::try_create(
                         transaction.clone(),
                         transaction.message.hash(),
                         Some(false),
-                        if let Some(loaded_addresses) = &loaded_addresses {
-                            SimpleAddressLoader::Enabled(loaded_addresses.clone())
-                        } else {
-                            SimpleAddressLoader::Disabled
-                        },
+                        address_loader,
                         &HashSet::new(), // todo: provide reserved account keys
                     )
+                    .map_err(|error| {
+                        debug!(
+                            "Failed to sanitize transaction {} for Geyser account updates: {:?}",
+                            signature, error
+                        );
+                        error
+                    })
                     .ok(),
                     Some(transaction.clone()),
                 )
@@ -4425,6 +4439,98 @@ mod tests {
             &serde_json::json!(999),
         );
         assert!(result.is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_v0_transaction_without_alt_emits_geyser_account_updates() {
+        use crossbeam_channel::{RecvTimeoutError, unbounded};
+        use solana_keypair::Keypair;
+        use solana_message::{VersionedMessage, v0};
+        use solana_signer::Signer;
+        use solana_system_interface::instruction as system_instruction;
+        use solana_transaction::versioned::VersionedTransaction;
+        use std::time::Duration;
+
+        let (svm, _events_rx, geyser_rx) = SurfnetSvm::default();
+        let locker = SurfnetSvmLocker::new(svm);
+
+        let payer = Keypair::new();
+        let payer_pubkey = payer.pubkey();
+        let recipient = Pubkey::new_unique();
+
+        let _ = locker
+            .airdrop(&payer_pubkey, 1_000_000_000)
+            .expect("airdrop should succeed");
+
+        let recent_blockhash = locker.latest_absolute_blockhash();
+        let message = v0::Message::try_compile(
+            &payer_pubkey,
+            &[system_instruction::transfer(
+                &payer_pubkey,
+                &recipient,
+                1_000_000,
+            )],
+            &[],
+            recent_blockhash,
+        )
+        .expect("v0 message should compile");
+
+        let tx = VersionedTransaction::try_new(
+            VersionedMessage::V0(message),
+            &[payer.insecure_clone()],
+        )
+        .expect("v0 transaction should sign");
+
+        let tx_signature = tx.signatures[0];
+        let (status_tx, _status_rx) = unbounded();
+        locker
+            .process_transaction(&None, tx, status_tx, true, true)
+            .await
+            .expect("transaction processing should succeed");
+
+        let mut account_updates = vec![];
+        let mut got_transaction_notify = false;
+
+        for _ in 0..32 {
+            match geyser_rx.recv_timeout(Duration::from_millis(50)) {
+                Ok(crate::surfnet::GeyserEvent::UpdateAccount(update)) => {
+                    account_updates.push(update);
+                }
+                Ok(crate::surfnet::GeyserEvent::NotifyTransaction(_, _)) => {
+                    got_transaction_notify = true;
+                }
+                Ok(_) => {}
+                Err(RecvTimeoutError::Timeout) | Err(RecvTimeoutError::Disconnected) => break,
+            }
+        }
+
+        assert!(
+            got_transaction_notify,
+            "Expected NotifyTransaction geyser event"
+        );
+        assert!(
+            !account_updates.is_empty(),
+            "Expected account update geyser events for v0 transaction without ALTs"
+        );
+        assert!(
+            account_updates.iter().any(|u| u.pubkey == payer_pubkey),
+            "Expected payer account update"
+        );
+        assert!(
+            account_updates.iter().any(|u| u.pubkey == recipient),
+            "Expected recipient account update"
+        );
+
+        for update in account_updates {
+            let sanitized_transaction = update
+                .sanitized_transaction
+                .expect("Expected sanitized transaction on account update");
+            assert_eq!(
+                *sanitized_transaction.signature(),
+                tx_signature,
+                "Account update should carry transaction signature"
+            );
+        }
     }
 
     // Snapshot loading tests

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -1692,12 +1692,10 @@ impl SurfnetSvm {
     ///
     /// # Returns
     /// `Ok(Vec<Signature>)` with confirmed signatures, or `Err(SurfpoolError)` on error.
-    fn confirm_transactions(&mut self) -> Result<(Vec<Signature>, HashSet<Pubkey>), SurfpoolError> {
+    fn confirm_transactions(&mut self) -> Result<Vec<Signature>, SurfpoolError> {
         let mut confirmed_transactions = vec![];
         let slot = self.latest_epoch_info.slot_index;
         let current_slot = self.latest_epoch_info.absolute_slot;
-
-        let mut all_mutated_account_keys = HashSet::new();
 
         while let Some((tx, status_tx, error)) =
             self.transactions_queued_for_confirmation.pop_front()
@@ -1727,7 +1725,6 @@ impl SurfnetSvm {
                 continue;
             };
             let (tx_with_status_meta, mutated_account_keys) = tx_data.as_ref();
-            all_mutated_account_keys.extend(mutated_account_keys);
 
             for pubkey in mutated_account_keys {
                 self.account_update_slots.insert(*pubkey, current_slot);
@@ -1746,7 +1743,7 @@ impl SurfnetSvm {
             confirmed_transactions.push(signature);
         }
 
-        Ok((confirmed_transactions, all_mutated_account_keys))
+        Ok(confirmed_transactions)
     }
 
     /// Finalizes transactions queued for finalization, sending finalized events as needed.
@@ -1933,20 +1930,7 @@ impl SurfnetSvm {
         }
         self.chain_tip = self.new_blockhash();
         // Confirm processed transactions
-        let (confirmed_signatures, all_mutated_account_keys) = self.confirm_transactions()?;
-        let write_version = self.increment_write_version();
-
-        // Notify Geyser plugin of account updates
-        for pubkey in all_mutated_account_keys {
-            let Some(account) = self.inner.get_account(&pubkey)? else {
-                continue;
-            };
-            self.geyser_events_tx
-                .send(GeyserEvent::UpdateAccount(
-                    GeyserAccountUpdate::block_update(pubkey, account, slot, write_version),
-                ))
-                .ok();
-        }
+        let confirmed_signatures = self.confirm_transactions()?;
 
         let num_transactions = confirmed_signatures.len() as u64;
         self.updated_at += self.slot_time;
@@ -2001,20 +1985,22 @@ impl SurfnetSvm {
         let root = new_slot.saturating_sub(FINALIZATION_SLOT_THRESHOLD);
         self.notify_slot_subscribers(new_slot, parent_slot, root);
 
-        // Notify geyser plugins of slot status (Confirmed)
+        let geyser_parent_slot = slot.saturating_sub(1);
+
+        // Emit confirmation for the same slot used by processed account/transaction updates.
         self.geyser_events_tx
             .send(GeyserEvent::UpdateSlotStatus {
-                slot: new_slot,
-                parent: Some(parent_slot),
+                slot,
+                parent: slot.checked_sub(1),
                 status: GeyserSlotStatus::Confirmed,
             })
             .ok();
 
         // Notify geyser plugins of block metadata
         let block_metadata = GeyserBlockMetadata {
-            slot: new_slot,
+            slot,
             blockhash: self.chain_tip.hash.clone(),
-            parent_slot,
+            parent_slot: geyser_parent_slot,
             parent_blockhash: previous_chain_tip.hash.clone(),
             block_time: Some(self.updated_at as i64 / 1_000),
             block_height: Some(self.chain_tip.index),
@@ -2030,7 +2016,7 @@ impl SurfnetSvm {
             .map(|h| h.to_bytes().to_vec())
             .unwrap_or_else(|_| vec![0u8; 32]);
         let entry_info = GeyserEntryInfo {
-            slot: new_slot,
+            slot,
             index: 0, // Single entry per block
             num_hashes: 1,
             hash: entry_hash,


### PR DESCRIPTION
Hi, submitting a minor fix for geyser. I know that currently the `geyser_plugin` is disabled due to conflict with litesvm, so it's a little hard to test this PR, locally i've resolved the dependancy issues by cloning/updating the deps version, so it's ok for this PR to sit for a while until something proper is done for geyser support in main

**Summary of the changes:**
- Removes duplicate account re-emits during confirmation for `processed` commitment
- Keeps account mutation tracking (account_update_slots) without sending extra synthetic account updates
- Aligns geyser commitment progression to the same slot used by processed tx/account updates:
        * UpdateSlotStatus::Confirmed now emits with slot (not slot + 1)
        * NotifyBlockMetadata now emits with slot and parent derived from that same slot
        * NotifyEntry now emits with slot.
         * AccountUpdates always have proper `txn_signature` set, currently it's NOT set for "confirmed" commitment


**Why:**
The previous flow produced duplicate account updates and inconsistent slot mapping across processed/confirmed paths, which made commitment behavior confusing in gRPC consumers.

**Impact:**
Account streams no longer get duplicate processed-like updates from confirmation re-emits.
Commitment promotion (processed -> confirmed -> finalized) is now based on a consistent slot identity.