### PR TITLE
fix(core): keep resetNetwork blockhash state consistent

### DIFF
--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -1520,6 +1520,14 @@ impl SurfnetSvm {
         self.latest_epoch_info = epoch_info.clone();
         // Set genesis_slot to the current slot when resetting (similar to initialize)
         self.genesis_slot = epoch_info.absolute_slot;
+        let chain_tip_hash = SyntheticBlockhash::new(epoch_info.block_height).to_string();
+        self.chain_tip = BlockIdentifier::new(epoch_info.block_height, chain_tip_hash.as_str());
+        // Rebuild sysvars so getLatestBlockhash / sendTransaction stay aligned after reset.
+        self.reconstruct_sysvars();
+        // Reset checkpoint state to avoid recovering stale chain tips after a reset.
+        self.slot_checkpoint.clear()?;
+        self.last_checkpoint_slot = self.genesis_slot;
+        self.recent_blockhashes.clear();
 
         Ok(())
     }


### PR DESCRIPTION
Another small PR (i swear i'm not AI, just really love the tool and use it a lot for backtests and found some bugs due to this) 😀

Realign chain_tip on reset_network, reconstruct blockhash-related sysvars, and clear
checkpoint/recent-blockhash caches so getLatestBlockhash never returns a stale hash.

<details>
  <summary>Repro script that would fail on current master, but work after the fix (spoiler)</summary>
Some
  
```bash
#!/usr/bin/env bash
set -euo pipefail

RPC_URL="${1:-http://127.0.0.1:8899}"
ITERATIONS="${2:-3}"

if ! command -v curl >/dev/null 2>&1; then
  echo "error: curl is required" >&2
  exit 1
fi
if ! command -v jq >/dev/null 2>&1; then
  echo "error: jq is required" >&2
  exit 1
fi

rpc() {
  local payload="$1"
  curl -sS "$RPC_URL" -H 'Content-Type: application/json' -d "$payload"
}

echo "RPC endpoint: $RPC_URL"
echo "Running $ITERATIONS reset/check iterations"

for i in $(seq 1 "$ITERATIONS"); do
  # Reproduces the path used by SurfnetApi.reset_network()
  rpc '{"jsonrpc":"2.0","id":1,"method":"surfnet_resetNetwork","params":[]}' >/dev/null

  latest_resp=$(rpc '{"jsonrpc":"2.0","id":2,"method":"getLatestBlockhash","params":[{"commitment":"processed"}]}')
  blockhash=$(echo "$latest_resp" | jq -r '.result.value.blockhash')
  slot=$(echo "$latest_resp" | jq -r '.result.context.slot')

  valid_resp=$(rpc "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"isBlockhashValid\",\"params\":[\"$blockhash\",{\"commitment\":\"processed\"}]}")
  valid=$(echo "$valid_resp" | jq -r '.result.value')

  echo "iter=$i slot=$slot blockhash=$blockhash isBlockhashValid=$valid"

  if [[ "$valid" != "true" ]]; then
    echo ""
    echo "BUG REPRODUCED: getLatestBlockhash returned a hash that is not valid immediately after surfnet_resetNetwork." >&2
    exit 2
  fi
done

echo "No bug detected in this run."
  ```
  
</details>

