### PR TITLE
fix: increase max_request_body_size to 15 MiB

### DIFF
--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -1070,6 +1070,7 @@ async fn start_http_rpc_server_runloop(
             let server = match ServerBuilder::new(io)
                 .cors(DomainsValidation::Disabled)
                 .threads(6)
+                .max_request_body_size(15 * 1024 * 1024)
                 .start_http(&server_bind)
             {
                 Ok(server) => server,


### PR DESCRIPTION
## Summary

- Increases `jsonrpc_http_server` `max_request_body_size` from the default 5 MiB to 15 MiB

## Problem

Solana accounts can be up to 10 MB. When the txtx runbook engine executes `set_account` directives via `surfnet_setAccount` JSON-RPC calls (self-loopback to the HTTP server), large accounts — such as circuit buffer accounts — get hex/base64-encoded in the JSON-RPC envelope, reaching ~13.5 MB. This exceeds the default 5 MiB limit, causing HTTP 413 responses.

## Fix

One-line change: `.max_request_body_size(15 * 1024 * 1024)` on the `ServerBuilder`. 15 MiB accommodates the largest possible Solana account with encoding overhead and headroom.