### PR TITLE
fix: increase max_request_body_size to 15 MiB

### DIFF
--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -1070,6 +1070,7 @@ async fn start_http_rpc_server_runloop(
             let server = match ServerBuilder::new(io)
                 .cors(DomainsValidation::Disabled)
                 .threads(6)
+                .max_request_body_size(15 * 1024 * 1024)
                 .start_http(&server_bind)
             {
                 Ok(server) => server,


### PR DESCRIPTION
Solana accounts can be up to 10 MB. With base64/hex encoding overhead, the JSON-RPC payload for a max-size account reaches ~13.5 MB, exceeding the default 5 MiB limit and causing HTTP 413 during surfnet_setAccount runbook execution. 15 MiB accommodates the largest possible account with headroom.