### PR TITLE
chore: bump litesvm to v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4779,13 +4779,10 @@ dependencies = [
  "agave-syscalls",
  "ansi_term",
  "bincode",
- "hex",
  "indexmap 2.13.0",
  "itertools 0.14.0",
  "log 0.4.29",
- "qualifier_attr",
  "serde",
- "sha2 0.10.9",
  "solana-account 3.3.0",
  "solana-address 2.0.0",
  "solana-address-lookup-table-interface 3.0.1",
@@ -4835,12 +4832,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "litesvm"
+version = "0.10.0"
+source = "git+https://github.com/LiteSVM/litesvm#881db7bc88a2ff6b8d679dc493dcf3238d5727ac"
+dependencies = [
+ "agave-feature-set",
+ "agave-reserved-account-keys",
+ "agave-syscalls",
+ "ansi_term",
+ "bincode",
+ "hex",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "log 0.4.29",
+ "qualifier_attr",
+ "serde",
+ "sha2 0.10.9",
+ "solana-account 3.3.0",
+ "solana-address 2.0.0",
+ "solana-address-lookup-table-interface 3.0.1",
+ "solana-bpf-loader-program",
+ "solana-builtins",
+ "solana-clock 3.0.0",
+ "solana-compute-budget",
+ "solana-compute-budget-instruction",
+ "solana-epoch-rewards 3.0.0",
+ "solana-epoch-schedule 3.0.0",
+ "solana-feature-gate-interface 3.1.0",
+ "solana-fee",
+ "solana-fee-structure",
+ "solana-hash 3.1.0",
+ "solana-instruction 3.1.0",
+ "solana-instructions-sysvar 3.0.0",
+ "solana-keypair",
+ "solana-last-restart-slot 3.0.0",
+ "solana-loader-v3-interface 6.1.0",
+ "solana-loader-v4-interface 3.1.0",
+ "solana-message 3.0.1",
+ "solana-native-token 3.0.0",
+ "solana-nonce 3.0.0",
+ "solana-nonce-account",
+ "solana-precompile-error",
+ "solana-program-error 3.0.0",
+ "solana-program-runtime",
+ "solana-rent 3.1.0",
+ "solana-sdk-ids 3.1.0",
+ "solana-sha256-hasher 3.1.0",
+ "solana-signature",
+ "solana-signer",
+ "solana-slot-hashes 3.0.0",
+ "solana-slot-history 3.0.0",
+ "solana-stake-interface 2.0.2",
+ "solana-svm-callback",
+ "solana-svm-log-collector",
+ "solana-svm-timings",
+ "solana-svm-transaction",
+ "solana-system-interface 2.0.0",
+ "solana-system-program",
+ "solana-sysvar 3.1.1",
+ "solana-sysvar-id 3.1.0",
+ "solana-transaction",
+ "solana-transaction-context",
+ "solana-transaction-error 3.0.0",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "litesvm-token"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f319bae54889c96cef85253ea2374310998294d1dbd1d40c3b9e117a273d3c1"
 dependencies = [
- "litesvm",
+ "litesvm 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec",
  "solana-account 3.3.0",
  "solana-address 2.0.0",
@@ -8239,9 +8302,9 @@ dependencies = [
 
 [[package]]
 name = "solana-feature-gate-interface"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7347ab62e6d47a82e340c865133795b394feea7c2b2771d293f57691c6544c3f"
+checksum = "75ca9b5cbb6f500f7fd73db5bd95640f71a83f04d6121a0e59a43b202dca2731"
 dependencies = [
  "bincode",
  "serde",
@@ -8250,10 +8313,10 @@ dependencies = [
  "solana-account-info 3.1.0",
  "solana-instruction 3.1.0",
  "solana-program-error 3.0.0",
- "solana-pubkey 3.0.0",
- "solana-rent 3.1.0",
+ "solana-pubkey 4.0.0",
+ "solana-rent 4.0.0",
  "solana-sdk-ids 3.1.0",
- "solana-system-interface 2.0.0",
+ "solana-system-interface 3.0.0",
 ]
 
 [[package]]
@@ -9318,6 +9381,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-rent"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763fe5c88a76ce18235db595b21d38b7aebf6db56b324cdf9fc96059f4410823"
+dependencies = [
+ "solana-sdk-macro 3.0.0",
+]
+
+[[package]]
 name = "solana-reward-info"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9352,7 +9424,7 @@ dependencies = [
  "solana-commitment-config",
  "solana-epoch-info",
  "solana-epoch-schedule 3.0.0",
- "solana-feature-gate-interface 3.0.0",
+ "solana-feature-gate-interface 3.1.0",
  "solana-hash 3.1.0",
  "solana-instruction 3.1.0",
  "solana-message 3.0.1",
@@ -9502,7 +9574,7 @@ dependencies = [
  "solana-epoch-info",
  "solana-epoch-rewards-hasher",
  "solana-epoch-schedule 3.0.0",
- "solana-feature-gate-interface 3.0.0",
+ "solana-feature-gate-interface 3.1.0",
  "solana-fee",
  "solana-fee-calculator 3.0.0",
  "solana-fee-structure",
@@ -10155,6 +10227,21 @@ dependencies = [
  "solana-msg 3.0.0",
  "solana-program-error 3.0.0",
  "solana-pubkey 3.0.0",
+]
+
+[[package]]
+name = "solana-system-interface"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14591d6508042ebefb110305d3ba761615927146a26917ade45dc332d8e1ecde"
+dependencies = [
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-address 2.0.0",
+ "solana-instruction 3.1.0",
+ "solana-msg 3.0.0",
+ "solana-program-error 3.0.0",
 ]
 
 [[package]]
@@ -11199,7 +11286,7 @@ dependencies = [
  "jsonrpc-ws-server",
  "lazy_static",
  "libloading",
- "litesvm",
+ "litesvm 0.10.0 (git+https://github.com/LiteSVM/litesvm)",
  "litesvm-token",
  "log 0.4.29",
  "reqwest 0.12.28",
@@ -11217,7 +11304,7 @@ dependencies = [
  "solana-compute-budget-interface",
  "solana-epoch-info",
  "solana-epoch-schedule 3.0.0",
- "solana-feature-gate-interface 3.0.0",
+ "solana-feature-gate-interface 3.1.0",
  "solana-genesis-config",
  "solana-hash 3.1.0",
  "solana-inflation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4770,71 +4770,9 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "litesvm"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6d4edace08253a908d301768f291a7115e8e19e13473dd6e1ace78d6366433"
-dependencies = [
- "agave-feature-set",
- "agave-reserved-account-keys",
- "agave-syscalls",
- "ansi_term",
- "bincode",
- "indexmap 2.13.0",
- "itertools 0.14.0",
- "log 0.4.29",
- "serde",
- "solana-account 3.3.0",
- "solana-address 2.0.0",
- "solana-address-lookup-table-interface 3.0.1",
- "solana-bpf-loader-program",
- "solana-builtins",
- "solana-clock 3.0.0",
- "solana-compute-budget",
- "solana-compute-budget-instruction",
- "solana-epoch-rewards 3.0.0",
- "solana-epoch-schedule 3.0.0",
- "solana-fee",
- "solana-fee-structure",
- "solana-hash 3.1.0",
- "solana-instruction 3.1.0",
- "solana-instructions-sysvar 3.0.0",
- "solana-keypair",
- "solana-last-restart-slot 3.0.0",
- "solana-loader-v3-interface 6.1.0",
- "solana-loader-v4-interface 3.1.0",
- "solana-message 3.0.1",
- "solana-native-token 3.0.0",
- "solana-nonce 3.0.0",
- "solana-nonce-account",
- "solana-precompile-error",
- "solana-program-error 3.0.0",
- "solana-program-runtime",
- "solana-rent 3.1.0",
- "solana-sdk-ids 3.1.0",
- "solana-sha256-hasher 3.1.0",
- "solana-signature",
- "solana-signer",
- "solana-slot-hashes 3.0.0",
- "solana-slot-history 3.0.0",
- "solana-stake-interface 2.0.2",
- "solana-svm-callback",
- "solana-svm-log-collector",
- "solana-svm-timings",
- "solana-svm-transaction",
- "solana-system-interface 2.0.0",
- "solana-system-program",
- "solana-sysvar 3.1.1",
- "solana-sysvar-id 3.1.0",
- "solana-transaction",
- "solana-transaction-context",
- "solana-transaction-error 3.0.0",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "litesvm"
-version = "0.10.0"
-source = "git+https://github.com/LiteSVM/litesvm#881db7bc88a2ff6b8d679dc493dcf3238d5727ac"
+checksum = "347d8c652d592c618ac996f2ab21f8c0b0f2da3fbbca227a6887ee61bb75f2de"
 dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
@@ -4899,11 +4837,11 @@ dependencies = [
 
 [[package]]
 name = "litesvm-token"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f319bae54889c96cef85253ea2374310998294d1dbd1d40c3b9e117a273d3c1"
+checksum = "d6cdb7d678bfa9279f8cb29079c976a4d930c7b30070a9687f4d6d64b528e748"
 dependencies = [
- "litesvm 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "litesvm",
  "smallvec",
  "solana-account 3.3.0",
  "solana-address 2.0.0",
@@ -11286,7 +11224,7 @@ dependencies = [
  "jsonrpc-ws-server",
  "lazy_static",
  "libloading",
- "litesvm 0.10.0 (git+https://github.com/LiteSVM/litesvm)",
+ "litesvm",
  "litesvm-token",
  "log 0.4.29",
  "reqwest 0.12.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,9 @@ juniper_codegen = { version = "0.16.0", default-features = false }
 juniper_graphql_ws = { version = "0.4.0", default-features = false }
 lazy_static = "1.5.0"
 libloading = "0.7.4"
-litesvm = { version = "0.10.0", features = ["nodejs-internal"] }
+# litesvm = { version = "0.10.0", features = ["nodejs-internal"] }
+litesvm = { git = "https://github.com/LiteSVM/litesvm", package = "litesvm", features = ["nodejs-internal"]}
+# litesvm = { path = "../litesvm/crates/litesvm", features = ["nodejs-internal"] }
 litesvm-token = "0.10.0"
 log = "0.4.27"
 mime_guess = { version = "2.0.4", default-features = false }
@@ -112,7 +114,7 @@ solana-commitment-config = { version = "3.1", default-features = false }
 solana-compute-budget-interface = { version = "3.0", default-features = false }
 solana-epoch-info = { version = "3.1", default-features = false }
 solana-epoch-schedule = { version = "3.0", default-features = false }
-solana-feature-gate-interface = { version = "3.0", default-features = false }
+solana-feature-gate-interface = { version = "3.1", default-features = false }
 solana-genesis-config = { version = "3.0", default-features = false }
 # solana-geyser-plugin-manager = { version = "=3.1.6", default-features = false }  # Disabled: version conflicts with litesvm 0.9.1 (requires solana-instruction =3.0.0 vs ~3.1)
 solana-hash = { version = "3.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,10 +81,8 @@ juniper_codegen = { version = "0.16.0", default-features = false }
 juniper_graphql_ws = { version = "0.4.0", default-features = false }
 lazy_static = "1.5.0"
 libloading = "0.7.4"
-# litesvm = { version = "0.10.0", features = ["nodejs-internal"] }
-litesvm = { git = "https://github.com/LiteSVM/litesvm", package = "litesvm", features = ["nodejs-internal"]}
-# litesvm = { path = "../litesvm/crates/litesvm", features = ["nodejs-internal"] }
-litesvm-token = "0.10.0"
+litesvm = { version = "0.11.0", features = ["nodejs-internal"] }
+litesvm-token = "0.11.0"
 log = "0.4.27"
 mime_guess = { version = "2.0.4", default-features = false }
 mustache = "0.9.0"

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -409,7 +409,6 @@ impl StartSimnet {
             } else {
                 Some(self.log_bytes_limit)
             },
-            feature_config: self.feature_config(),
             skip_signature_verification: self.skip_signature_verification,
             surfnet_id: self.surfnet_id.clone(),
             snapshot,

--- a/crates/core/src/rpc/full.rs
+++ b/crates/core/src/rpc/full.rs
@@ -2913,7 +2913,7 @@ mod tests {
     #[test]
     fn test_request_airdrop() {
         let pk = Pubkey::new_unique();
-        let lamports = 1000;
+        let lamports = 1_000_000;
         let setup = TestSetup::new(SurfpoolFullRpc);
         let res = setup
             .rpc

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -273,24 +273,7 @@ impl SurfnetSvmLocker {
     /// Retrieves a local account from the SVM cache, returning a contextualized result.
     pub fn get_account_local(&self, pubkey: &Pubkey) -> SvmAccessContext<GetAccountResult> {
         self.with_contextualized_svm_reader(|svm_reader| {
-            let result = svm_reader.inner.get_account_result(pubkey).unwrap();
-
-            if result.is_none() {
-                return match svm_reader.get_account_from_feature_set(pubkey) {
-                    Some(account) => {
-                        GetAccountResult::FoundAccount(
-                            *pubkey, account,
-                            // mark this as an account to insert into the SVM, since the feature is activated and LiteSVM doesn't
-                            // automatically insert activated feature accounts
-                            // TODO: mark as false once https://github.com/LiteSVM/litesvm/pull/308 is released
-                            true,
-                        )
-                    }
-                    None => GetAccountResult::None(*pubkey),
-                };
-            } else {
-                return result;
-            }
+            return svm_reader.inner.get_account_result(pubkey).unwrap();
         })
     }
 
@@ -357,19 +340,8 @@ impl SurfnetSvmLocker {
             let mut accounts = vec![];
 
             for pubkey in pubkeys {
-                let mut result = svm_reader.inner.get_account_result(pubkey).unwrap();
-                if result.is_none() {
-                    result = match svm_reader.get_account_from_feature_set(pubkey) {
-                        Some(account) => GetAccountResult::FoundAccount(
-                            *pubkey, account,
-                            // mark this as an account to insert into the SVM, since the feature is activated and LiteSVM doesn't
-                            // automatically insert activated feature accounts
-                            // TODO: mark as false once https://github.com/LiteSVM/litesvm/pull/308 is released
-                            true,
-                        ),
-                        None => GetAccountResult::None(*pubkey),
-                    }
-                };
+                let result = svm_reader.inner.get_account_result(pubkey).unwrap();
+                if result.is_none() {};
                 accounts.push(result);
             }
             accounts

--- a/crates/core/src/surfnet/surfnet_lite_svm.rs
+++ b/crates/core/src/surfnet/surfnet_lite_svm.rs
@@ -22,6 +22,8 @@ use crate::{
     surfnet::{GetAccountResult, locker::is_supported_token_program},
 };
 
+pub const LAMPORTS_PER_SOL: u64 = 1_000_000_000;
+
 #[derive(Clone)]
 pub struct SurfnetLiteSvm {
     pub svm: LiteSVM,
@@ -31,7 +33,7 @@ pub struct SurfnetLiteSvm {
 impl SurfnetLiteSvm {
     pub fn new() -> Self {
         Self {
-            svm: LiteSVM::new(),
+            svm: LiteSVM::default(),
             db: None,
         }
     }
@@ -49,16 +51,37 @@ impl SurfnetLiteSvm {
         }
     }
 
+    /// Initializes LiteSVM with as few settings as possible; for initial startup of VM
+    /// that will be overriden later when more context is available.
+    fn base_litesvm_settings() -> LiteSVM {
+        LiteSVM::default()
+            .with_feature_set(FeatureSet::default()) // start with all features enabled, but don't load feature accounts
+            .with_builtins()
+            .with_lamports(1_000_000u64.wrapping_mul(LAMPORTS_PER_SOL))
+            .with_sysvars()
+            .with_default_programs()
+            .with_blockhash_check(false)
+            .with_sigverify(false)
+    }
+
+    /// Initializes LiteSVM with full settings; starts with base settings, then adds in
+    /// features and other setup that depends on the feature set.
+    fn full_litesvm_settings(feature_set: FeatureSet) -> LiteSVM {
+        Self::base_litesvm_settings()
+            .with_feature_set(feature_set)
+            .with_feature_accounts()
+            .with_builtins()
+            .with_sysvars()
+            .with_default_programs()
+    }
+
     pub fn initialize(
         mut self,
-        feature_set: FeatureSet,
+        // feature_set: FeatureSet,
         database_url: Option<&str>,
         surfnet_id: &str,
     ) -> SurfpoolResult<Self> {
-        self.svm = LiteSVM::new()
-            .with_blockhash_check(false)
-            .with_sigverify(false)
-            .with_feature_set(feature_set);
+        self.svm = Self::base_litesvm_settings();
 
         create_native_mint(&mut self);
 
@@ -79,10 +102,7 @@ impl SurfnetLiteSvm {
     }
 
     pub fn reset(&mut self, feature_set: FeatureSet) -> SurfpoolResult<()> {
-        self.svm = LiteSVM::new()
-            .with_blockhash_check(false)
-            .with_sigverify(false)
-            .with_feature_set(feature_set);
+        self.svm = Self::full_litesvm_settings(feature_set);
 
         create_native_mint(self);
 
@@ -111,10 +131,7 @@ impl SurfnetLiteSvm {
         let clock = self.svm.get_sysvar::<Clock>();
 
         // todo: this is also resetting the log bytes limit and airdrop keypair, would be nice to avoid
-        self.svm = LiteSVM::new()
-            .with_blockhash_check(false)
-            .with_sigverify(false)
-            .with_feature_set(feature_set);
+        self.svm = Self::full_litesvm_settings(feature_set);
 
         create_native_mint(self);
 
@@ -125,13 +142,7 @@ impl SurfnetLiteSvm {
     }
 
     pub fn apply_feature_config(&mut self, feature_set: FeatureSet) -> &mut Self {
-        self.svm = LiteSVM::new()
-            .with_blockhash_check(false)
-            .with_sigverify(false)
-            .with_feature_set(feature_set)
-            .with_builtins()
-            .with_sysvars()
-            .with_default_programs();
+        self.svm = Self::full_litesvm_settings(feature_set);
 
         create_native_mint(self);
         self

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -28,7 +28,6 @@ use solana_clock::{Clock, Slot};
 use solana_commitment_config::{CommitmentConfig, CommitmentLevel};
 use solana_epoch_info::EpochInfo;
 use solana_epoch_schedule::EpochSchedule;
-use solana_feature_gate_interface::Feature;
 use solana_genesis_config::GenesisConfig;
 use solana_hash::Hash;
 use solana_inflation::Inflation;
@@ -295,10 +294,6 @@ pub struct SurfnetSvm {
     /// Tracks the slot at which we last persisted the checkpoint.
     pub last_checkpoint_slot: u64,
 }
-
-pub const FEATURE: Feature = Feature {
-    activated_at: Some(0),
-};
 
 impl SurfnetSvm {
     pub fn default() -> (Self, Receiver<SimnetEvent>, Receiver<GeyserEvent>) {
@@ -906,25 +901,6 @@ impl SurfnetSvm {
             block_height,
             signatures: vec![],
         }
-    }
-
-    pub fn get_account_from_feature_set(&self, pubkey: &Pubkey) -> Option<Account> {
-        // Currently, liteSVM doesn't create feature gate accounts and store them in the vm,
-        // so when a user is fetching one, we make one on the fly.
-        // TODO: remove once https://github.com/LiteSVM/litesvm/pull/308 is released
-        self.feature_set.active().get(pubkey).map(|_| {
-            let feature_bytes = bincode::serialize(&FEATURE).unwrap();
-            let lamports = self
-                .inner
-                .minimum_balance_for_rent_exemption(feature_bytes.len());
-            Account {
-                lamports,
-                data: feature_bytes,
-                owner: solana_sdk_ids::feature::id(),
-                executable: false,
-                rent_epoch: 0,
-            }
-        })
     }
 
     /// Reconstructs RecentBlockhashes, SlotHashes, and Clock sysvars deterministically

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -5,7 +5,7 @@ use std::{
     time::SystemTime,
 };
 
-use agave_feature_set::{FeatureSet, enable_extend_program_checked};
+use agave_feature_set::FeatureSet;
 use base64::{Engine, prelude::BASE64_STANDARD};
 use chrono::Utc;
 use convert_case::Casing;
@@ -421,12 +421,6 @@ impl SurfnetSvm {
     ) -> SurfpoolResult<(Self, Receiver<SimnetEvent>, Receiver<GeyserEvent>)> {
         let (simnet_events_tx, simnet_events_rx) = crossbeam_channel::bounded(1024);
         let (geyser_events_tx, geyser_events_rx) = crossbeam_channel::bounded(1024);
-
-        // let mut feature_set = FeatureSet::default();
-
-        // todo: remove once txtx deployments upgrade solana dependencies.
-        // todo: consider making this configurable via config
-        // feature_set.deactivate(&enable_extend_program_checked::id());
 
         let inner = SurfnetLiteSvm::new().initialize(database_url, surfnet_id)?;
 

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -422,14 +422,13 @@ impl SurfnetSvm {
         let (simnet_events_tx, simnet_events_rx) = crossbeam_channel::bounded(1024);
         let (geyser_events_tx, geyser_events_rx) = crossbeam_channel::bounded(1024);
 
-        let mut feature_set = FeatureSet::all_enabled();
+        // let mut feature_set = FeatureSet::default();
 
         // todo: remove once txtx deployments upgrade solana dependencies.
         // todo: consider making this configurable via config
-        feature_set.deactivate(&enable_extend_program_checked::id());
+        // feature_set.deactivate(&enable_extend_program_checked::id());
 
-        let inner =
-            SurfnetLiteSvm::new().initialize(feature_set.clone(), database_url, surfnet_id)?;
+        let inner = SurfnetLiteSvm::new().initialize(database_url, surfnet_id)?;
 
         let native_mint_account = inner
             .get_account(&spl_token_interface::native_mint::ID)?
@@ -598,7 +597,7 @@ impl SurfnetSvm {
             inflation: Inflation::default(),
             write_version: 0,
             registered_idls: registered_idls_db,
-            feature_set,
+            feature_set: FeatureSet::default(),
             instruction_profiling_enabled: true,
             max_profiles: DEFAULT_PROFILING_MAP_CAPACITY,
             runbook_executions: Vec::new(),
@@ -627,16 +626,19 @@ impl SurfnetSvm {
     /// # Arguments
     /// * `config` - The feature configuration specifying which features to enable/disable.
     pub fn apply_feature_config(&mut self, config: &SvmFeatureConfig) {
+        let mut starting_set = FeatureSet::all_enabled();
         // Apply explicit enables
         for pubkey in &config.enable {
-            self.feature_set.activate(pubkey, 0);
+            debug!("Activating feature {}", pubkey);
+            starting_set.activate(pubkey, 0);
         }
 
         // Apply explicit disables
         for pubkey in &config.disable {
-            self.feature_set.deactivate(pubkey);
+            debug!("Deactivating feature {}", pubkey);
+            starting_set.deactivate(pubkey);
         }
-
+        self.feature_set = starting_set;
         // Rebuild inner VM with updated feature set
         self.inner.apply_feature_config(self.feature_set.clone());
     }
@@ -722,6 +724,7 @@ impl SurfnetSvm {
     pub fn airdrop(&mut self, pubkey: &Pubkey, lamports: u64) -> SurfpoolResult<TransactionResult> {
         // Capture pre-airdrop balances for the airdrop account, recipient, and system program.
         let airdrop_pubkey = self.inner.airdrop_pubkey();
+        println!("Airdrop pubkey: {}", airdrop_pubkey);
 
         let airdrop_account_before = self
             .get_account(&airdrop_pubkey)?
@@ -4248,14 +4251,17 @@ mod tests {
     fn test_apply_feature_config_disable_feature(test_type: TestType) {
         let (mut svm, _events_rx, _geyser_rx) = test_type.initialize_svm();
 
-        // Feature should be active by default (all_enabled)
+        // Feature should be inactive by default (all_disabled)
         let feature_id = disable_fees_sysvar::id();
+        assert!(!svm.feature_set.is_active(&feature_id));
+
+        // Now applying feature config defaults to all enabled
+        svm.apply_feature_config(&SvmFeatureConfig::new());
         assert!(svm.feature_set.is_active(&feature_id));
 
-        // Now disable it via config
+        // But we can explicitly disable via config
         let config = SvmFeatureConfig::new().disable(disable_fees_sysvar::id());
         svm.apply_feature_config(&config);
-
         assert!(!svm.feature_set.is_active(&feature_id));
     }
 

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -2932,7 +2932,7 @@ async fn test_profile_transaction_insufficient_funds(test_type: TestType) {
     // Set up test accounts with insufficient funds
     let payer = Keypair::new();
     let recipient = Pubkey::new_unique();
-    let insufficient_funds = 10000;
+    let insufficient_funds = LAMPORTS_PER_SOL;
     let large_transfer = LAMPORTS_PER_SOL * 10;
 
     svm_locker
@@ -3506,7 +3506,7 @@ async fn test_get_local_signatures_with_limit(test_type: TestType) {
 
     let payer = Keypair::new();
     let _recipient = Keypair::new();
-    let lamports_to_send = 1_000_000;
+    let lamports_to_send = 10_000_000;
 
     svm_locker_for_context
         .airdrop(&payer.pubkey(), lamports_to_send * 10)
@@ -5556,7 +5556,7 @@ async fn test_ws_signature_subscribe(subscription_type: SignatureSubscriptionTyp
     // create a test transaction
     let payer = Keypair::new();
     let recipient = Pubkey::new_unique();
-    let lamports_to_send = 100_000;
+    let lamports_to_send = 1_000_000;
     svm_locker
         .airdrop(&payer.pubkey(), LAMPORTS_PER_SOL)
         .unwrap()
@@ -5631,12 +5631,13 @@ async fn test_ws_signature_subscribe_failed_transaction(test_type: TestType) {
     let payer = Keypair::new();
     let recipient = Pubkey::new_unique();
     svm_locker
-        .airdrop(&payer.pubkey(), 10_000)
+        .airdrop(&payer.pubkey(), LAMPORTS_PER_SOL)
         .unwrap()
-        .unwrap(); // airdrop a very small amount.unwrap()
+        .unwrap();
 
     let recent_blockhash = svm_locker.with_svm_reader(|svm| svm.latest_blockhash());
-    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, LAMPORTS_PER_SOL); // Try to send more than we have
+    let transfer_ix =
+        system_instruction::transfer(&payer.pubkey(), &recipient, LAMPORTS_PER_SOL * 2); // Try to send more than we have
     let tx = Transaction::new_signed_with_payer(
         &[transfer_ix],
         Some(&payer.pubkey()),
@@ -5699,7 +5700,7 @@ async fn test_ws_signature_subscribe_multiple_subscribers(test_type: TestType) {
         .unwrap();
 
     let recent_blockhash = svm_locker.with_svm_reader(|svm| svm.latest_blockhash());
-    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, 100_000);
+    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, 1_000_000);
     let tx = Transaction::new_signed_with_payer(
         &[transfer_ix],
         Some(&payer.pubkey()),
@@ -5777,7 +5778,7 @@ async fn test_ws_signature_subscribe_before_transaction_exists(test_type: TestTy
         .unwrap();
 
     let recent_blockhash = svm_locker.with_svm_reader(|svm| svm.latest_blockhash());
-    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, 100_000);
+    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, 1_000_000);
     let tx = Transaction::new_signed_with_payer(
         &[transfer_ix],
         Some(&payer.pubkey()),
@@ -5847,7 +5848,7 @@ async fn test_ws_account_subscribe_balance_change(test_type: TestType) {
 
     // make a transaction to change the account balance
     let recent_blockhash = svm_locker.with_svm_reader(|svm| svm.latest_blockhash());
-    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, 100_000);
+    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, 1_000_000);
     let tx = Transaction::new_signed_with_payer(
         &[transfer_ix],
         Some(&payer.pubkey()),
@@ -5873,7 +5874,7 @@ async fn test_ws_account_subscribe_balance_change(test_type: TestType) {
     let updated_account = account_update.unwrap();
     assert_eq!(
         updated_account.lamports,
-        LAMPORTS_PER_SOL - 100_000 - 5000, // original - transfer amount - fees
+        LAMPORTS_PER_SOL - 1_000_000 - 5000, // original - transfer amount - fees
         "Account balance should be updated"
     );
     println!(
@@ -5911,7 +5912,7 @@ async fn test_ws_account_subscribe_multiple_changes(test_type: TestType) {
     for i in 0..3 {
         let recent_blockhash = svm_locker.with_svm_reader(|svm| svm.latest_blockhash());
 
-        let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, 100_000);
+        let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, 1_000_000);
         let tx = Transaction::new_signed_with_payer(
             &[transfer_ix],
             Some(&payer.pubkey()),
@@ -5982,7 +5983,7 @@ async fn test_ws_account_subscribe_multiple_subscribers(test_type: TestType) {
 
     // trigger a change with a transfer (not airdrop)
     let recent_blockhash = svm_locker.with_svm_reader(|svm| svm.latest_blockhash());
-    let transfer_ix = system_instruction::transfer(&sender.pubkey(), &payer.pubkey(), 100_000);
+    let transfer_ix = system_instruction::transfer(&sender.pubkey(), &payer.pubkey(), 1_000_000);
     let tx = Transaction::new_signed_with_payer(
         &[transfer_ix],
         Some(&sender.pubkey()),
@@ -6045,7 +6046,7 @@ async fn test_ws_account_subscribe_new_account_creation(test_type: TestType) {
 
     // create the account with a transfer
     let recent_blockhash = svm_locker.with_svm_reader(|svm| svm.latest_blockhash());
-    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &new_account, 100_000);
+    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &new_account, 1_000_000);
     let tx = Transaction::new_signed_with_payer(
         &[transfer_ix],
         Some(&payer.pubkey()),
@@ -6074,7 +6075,7 @@ async fn test_ws_account_subscribe_new_account_creation(test_type: TestType) {
 
     let created_account = account_update.unwrap();
     assert_eq!(
-        created_account.lamports, 100_000,
+        created_account.lamports, 1_000_000,
         "New account should have correct balance"
     );
     println!(
@@ -6101,7 +6102,7 @@ async fn test_ws_account_subscribe_account_closure(test_type: TestType) {
 
     // give the account some funds
     svm_locker
-        .airdrop(&account_to_close.pubkey(), 10_000)
+        .airdrop(&account_to_close.pubkey(), LAMPORTS_PER_SOL)
         .unwrap()
         .unwrap();
 
@@ -6111,7 +6112,11 @@ async fn test_ws_account_subscribe_account_closure(test_type: TestType) {
 
     // close the account by sending all funds minus fee
     let recent_blockhash = svm_locker.with_svm_reader(|svm| svm.latest_blockhash());
-    let close_ix = system_instruction::transfer(&account_to_close.pubkey(), &recipient, 5_000);
+    let close_ix = system_instruction::transfer(
+        &account_to_close.pubkey(),
+        &recipient,
+        LAMPORTS_PER_SOL - 5_000,
+    );
     let tx = Transaction::new_signed_with_payer(
         &[close_ix],
         Some(&account_to_close.pubkey()),
@@ -6302,7 +6307,7 @@ async fn test_ws_logs_subscribe_all_transactions(test_type: TestType) {
 
     // create and process a test transaction
     let recent_blockhash = svm_locker.with_svm_reader(|svm| svm.latest_blockhash());
-    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, 100_000);
+    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, 1_000_000);
     let tx = Transaction::new_signed_with_payer(
         &[transfer_ix],
         Some(&payer.pubkey()),
@@ -6335,7 +6340,8 @@ async fn test_ws_logs_subscribe_all_transactions(test_type: TestType) {
     );
     assert!(
         logs_response.err.is_none(),
-        "Transaction should succeed without error"
+        "Transaction should succeed without error, got error: {}",
+        logs_response.err.unwrap()
     );
     assert!(
         !logs_response.logs.is_empty(),
@@ -6380,7 +6386,7 @@ async fn test_ws_logs_subscribe_mentions_account(test_type: TestType) {
 
     // create transaction that uses system program
     let recent_blockhash = svm_locker.with_svm_reader(|svm| svm.latest_blockhash());
-    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, 100_000);
+    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, 1_000_000);
     let tx = Transaction::new_signed_with_payer(
         &[transfer_ix],
         Some(&payer.pubkey()),
@@ -6450,7 +6456,7 @@ async fn test_ws_logs_subscribe_confirmed_commitment(test_type: TestType) {
         .unwrap();
 
     let recent_blockhash = svm_locker.with_svm_reader(|svm| svm.latest_blockhash());
-    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, 100_000);
+    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, 1_000_000);
     let tx = Transaction::new_signed_with_payer(
         &[transfer_ix],
         Some(&payer.pubkey()),
@@ -6517,7 +6523,7 @@ async fn test_ws_logs_subscribe_finalized_commitment(test_type: TestType) {
         .unwrap();
 
     let recent_blockhash = svm_locker.with_svm_reader(|svm| svm.latest_blockhash());
-    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, 100_000);
+    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, 1_000_000);
     let tx = Transaction::new_signed_with_payer(
         &[transfer_ix],
         Some(&payer.pubkey()),
@@ -6577,7 +6583,10 @@ async fn test_ws_logs_subscribe_failed_transaction(test_type: TestType) {
     // create test accounts
     let payer = Keypair::new();
     let recipient = Pubkey::new_unique();
-    svm_locker.airdrop(&payer.pubkey(), 5_000).unwrap().unwrap();
+    svm_locker
+        .airdrop(&payer.pubkey(), LAMPORTS_PER_SOL)
+        .unwrap()
+        .unwrap();
 
     // subscribe to all logs
     let logs_rx = svm_locker
@@ -6585,7 +6594,8 @@ async fn test_ws_logs_subscribe_failed_transaction(test_type: TestType) {
 
     // create and process a transaction that will fail (insufficient funds)
     let recent_blockhash = svm_locker.with_svm_reader(|svm| svm.latest_blockhash());
-    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, LAMPORTS_PER_SOL);
+    let transfer_ix =
+        system_instruction::transfer(&payer.pubkey(), &recipient, LAMPORTS_PER_SOL * 2);
     let tx = Transaction::new_signed_with_payer(
         &[transfer_ix],
         Some(&payer.pubkey()),
@@ -6657,7 +6667,7 @@ async fn test_ws_logs_subscribe_multiple_subscribers(test_type: TestType) {
         .unwrap();
 
     let recent_blockhash = svm_locker.with_svm_reader(|svm| svm.latest_blockhash());
-    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, 100_000);
+    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, 1_000_000);
     let tx = Transaction::new_signed_with_payer(
         &[transfer_ix],
         Some(&payer.pubkey()),
@@ -6725,7 +6735,7 @@ async fn test_ws_logs_subscribe_logs_content(test_type: TestType) {
 
     // create and process a transaction
     let recent_blockhash = svm_locker.with_svm_reader(|svm| svm.latest_blockhash());
-    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, 100_000);
+    let transfer_ix = system_instruction::transfer(&payer.pubkey(), &recipient, 1_000_000);
     let tx = Transaction::new_signed_with_payer(
         &[transfer_ix],
         Some(&payer.pubkey()),

--- a/crates/types/src/types.rs
+++ b/crates/types/src/types.rs
@@ -606,7 +606,6 @@ pub struct SimnetConfig {
     pub instruction_profiling_enabled: bool,
     pub max_profiles: usize,
     pub log_bytes_limit: Option<usize>,
-    pub feature_config: SvmFeatureConfig,
     pub skip_signature_verification: bool,
     /// Unique identifier for this surfnet instance. Used to isolate database storage
     /// when multiple surfnets share the same database. Defaults to "default".
@@ -629,7 +628,6 @@ impl Default for SimnetConfig {
             instruction_profiling_enabled: true,
             max_profiles: DEFAULT_PROFILING_MAP_CAPACITY,
             log_bytes_limit: Some(10_000),
-            feature_config: SvmFeatureConfig::default(),
             skip_signature_verification: false,
             surfnet_id: "default".to_string(),
             snapshot: BTreeMap::new(),


### PR DESCRIPTION
Fixes #578 
 
The new LiteSVM release adds a fix to automatically create feature accounts for activated features. This allows us to remove some hacky code paths where we were previously inserting these accounts manually.

This LiteSVM change also had some downstream changes - the `with_feature_set` initializer combined with the `with_feature_accounts` initializer makes the features active and creates the accounts. Then, later if we were to deactivate a feature, the feature account would still exist and appear active in some cases. This is normal behavior for the VM, but we were instantiating things in a weird order - first with all features, then stripping it down to mainnet features. This was causing some issues. So I've refactored how we initialize the VM - not setting feature accounts until we've got the actual list of feature sets ready.

Finally, the LiteSVM release had some fixes around rent handling, specifically requiring the accurate minimum rent. This broke a bunch of our tests that were not leaving accounts with minimum rent. Those tests are fixed.