### PR TITLE
Fix: Fetch StakeHistory sysvar and Stake program from mainnet

### DIFF
--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -236,18 +236,59 @@ impl SurfnetSvmLocker {
         };
         epoch_info.transaction_count = None;
 
-        // Fetch StakeHistory sysvar from remote if available. Native programs access
-        // this via get_sysvar syscall, not as a transaction account, so Surfpool must
-        // proactively populate it.
-        let stake_history_account = if let Some(remote_client) = remote_ctx {
-            remote_client
-                .get_raw_account(&solana_sdk_ids::sysvar::stake_history::id())
-                .await
-                .ok()
-                .flatten()
-        } else {
-            None
-        };
+        // Fetch stake-related accounts from remote if available.
+        // - StakeHistory: accessed via get_sysvar syscall, not as a transaction account
+        // - StakeConfig: LiteSVM creates a minimal default that the Stake program can't
+        //   deserialize, so we overwrite it with the real mainnet data
+        // - Stake program + programdata: LiteSVM bundles an outdated stake ELF that
+        //   can't deserialize V4 vote accounts used on mainnet
+        #[allow(deprecated)]
+        let (stake_history_account, stake_config_account, stake_program_accounts) =
+            if let Some(remote_client) = remote_ctx {
+                let history = remote_client
+                    .get_raw_account(&solana_sdk_ids::sysvar::stake_history::id())
+                    .await
+                    .ok()
+                    .flatten();
+                let config = remote_client
+                    .get_raw_account(&solana_sdk_ids::stake::config::id())
+                    .await
+                    .ok()
+                    .flatten();
+                let stake_program = remote_client
+                    .get_raw_account(&solana_sdk_ids::stake::id())
+                    .await
+                    .ok()
+                    .flatten();
+                let stake_programdata = remote_client
+                    .get_raw_account(
+                        &solana_loader_v3_interface::get_program_data_address(
+                            &solana_sdk_ids::stake::id(),
+                        ),
+                    )
+                    .await
+                    .ok()
+                    .flatten();
+                let stake_prog = match (stake_program, stake_programdata) {
+                    (Some(prog), Some(data)) => {
+                        info!(
+                            "Fetched Stake program from remote: program={}, programdata={}",
+                            prog.data.len(),
+                            data.data.len(),
+                        );
+                        Some((prog, data))
+                    }
+                    _ => None,
+                };
+                info!(
+                    "Fetched stake accounts from remote: StakeHistory={}, StakeConfig={}",
+                    history.as_ref().map_or(0, |a| a.data.len()),
+                    config.as_ref().map_or(0, |a| a.data.len()),
+                );
+                (history, config, stake_prog)
+            } else {
+                (None, None, None)
+            };
 
         self.with_svm_writer(|svm_writer| {
             svm_writer.initialize(
@@ -258,6 +299,8 @@ impl SurfnetSvmLocker {
                 do_profile_instructions,
                 log_bytes_limit,
                 stake_history_account,
+                stake_config_account,
+                stake_program_accounts,
             );
         });
         Ok(epoch_info)
@@ -2024,28 +2067,73 @@ impl SurfnetSvmLocker {
         };
         epoch_info.transaction_count = None;
 
-        // Re-fetch StakeHistory from remote after reset (same as initialize)
-        let stake_history_account = if let Some(remote_client) = remote_ctx {
-            remote_client
-                .get_raw_account(&solana_sdk_ids::sysvar::stake_history::id())
-                .await
-                .ok()
-                .flatten()
-        } else {
-            None
-        };
+        // Re-fetch stake-related accounts from remote after reset (same as initialize)
+        #[allow(deprecated)]
+        let (stake_history_account, stake_config_account, stake_program_accounts) =
+            if let Some(remote_client) = remote_ctx {
+                let history = remote_client
+                    .get_raw_account(&solana_sdk_ids::sysvar::stake_history::id())
+                    .await
+                    .ok()
+                    .flatten();
+                let config = remote_client
+                    .get_raw_account(&solana_sdk_ids::stake::config::id())
+                    .await
+                    .ok()
+                    .flatten();
+                let stake_program = remote_client
+                    .get_raw_account(&solana_sdk_ids::stake::id())
+                    .await
+                    .ok()
+                    .flatten();
+                let stake_programdata = remote_client
+                    .get_raw_account(
+                        &solana_loader_v3_interface::get_program_data_address(
+                            &solana_sdk_ids::stake::id(),
+                        ),
+                    )
+                    .await
+                    .ok()
+                    .flatten();
+                let stake_prog = match (stake_program, stake_programdata) {
+                    (Some(prog), Some(data)) => Some((prog, data)),
+                    _ => None,
+                };
+                (history, config, stake_prog)
+            } else {
+                (None, None, None)
+            };
 
         self.with_svm_writer(move |svm_writer| {
             let _ = svm_writer.reset_network(epoch_info);
             let _ = svm_writer.offline_accounts.clear();
-            // Restore StakeHistory after reset — it's accessed via syscall by the Stake
-            // program and is lost during reset_network since reconstruct_sysvars doesn't
-            // rebuild it.
+            // Restore StakeHistory, StakeConfig, and Stake program after reset.
             if let Some(account) = stake_history_account {
                 let _ = svm_writer.inner.svm.set_account(
                     solana_sdk_ids::sysvar::stake_history::id(),
                     account,
                 );
+            }
+            #[allow(deprecated)]
+            if let Some(account) = stake_config_account {
+                let _ = svm_writer.inner.svm.set_account(
+                    solana_sdk_ids::stake::config::id(),
+                    account,
+                );
+            }
+            if let Some((program_account, programdata_account)) = stake_program_accounts {
+                let programdata_address =
+                    solana_loader_v3_interface::get_program_data_address(
+                        &solana_sdk_ids::stake::id(),
+                    );
+                let _ = svm_writer
+                    .inner
+                    .svm
+                    .set_account(programdata_address, programdata_account);
+                let _ = svm_writer
+                    .inner
+                    .svm
+                    .set_account(solana_sdk_ids::stake::id(), program_account);
             }
         });
         Ok(())

--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -236,6 +236,19 @@ impl SurfnetSvmLocker {
         };
         epoch_info.transaction_count = None;
 
+        // Fetch StakeHistory sysvar from remote if available. Native programs access
+        // this via get_sysvar syscall, not as a transaction account, so Surfpool must
+        // proactively populate it.
+        let stake_history_account = if let Some(remote_client) = remote_ctx {
+            remote_client
+                .get_raw_account(&solana_sdk_ids::sysvar::stake_history::id())
+                .await
+                .ok()
+                .flatten()
+        } else {
+            None
+        };
+
         self.with_svm_writer(|svm_writer| {
             svm_writer.initialize(
                 epoch_info.clone(),
@@ -244,6 +257,7 @@ impl SurfnetSvmLocker {
                 remote_ctx,
                 do_profile_instructions,
                 log_bytes_limit,
+                stake_history_account,
             );
         });
         Ok(epoch_info)
@@ -2010,9 +2024,29 @@ impl SurfnetSvmLocker {
         };
         epoch_info.transaction_count = None;
 
+        // Re-fetch StakeHistory from remote after reset (same as initialize)
+        let stake_history_account = if let Some(remote_client) = remote_ctx {
+            remote_client
+                .get_raw_account(&solana_sdk_ids::sysvar::stake_history::id())
+                .await
+                .ok()
+                .flatten()
+        } else {
+            None
+        };
+
         self.with_svm_writer(move |svm_writer| {
             let _ = svm_writer.reset_network(epoch_info);
             let _ = svm_writer.offline_accounts.clear();
+            // Restore StakeHistory after reset — it's accessed via syscall by the Stake
+            // program and is lost during reset_network since reconstruct_sysvars doesn't
+            // rebuild it.
+            if let Some(account) = stake_history_account {
+                let _ = svm_writer.inner.svm.set_account(
+                    solana_sdk_ids::sysvar::stake_history::id(),
+                    account,
+                );
+            }
         });
         Ok(())
     }

--- a/crates/core/src/surfnet/remote.rs
+++ b/crates/core/src/surfnet/remote.rs
@@ -96,6 +96,21 @@ impl SurfnetRemoteClient {
         self.client.get_epoch_schedule().await.map_err(Into::into)
     }
 
+    /// Fetches a raw account by pubkey without any classification logic (token, program, etc.).
+    /// Useful for fetching sysvar accounts that are accessed via syscalls rather than as
+    /// transaction accounts.
+    pub async fn get_raw_account(
+        &self,
+        pubkey: &Pubkey,
+    ) -> SurfpoolResult<Option<Account>> {
+        let res = self
+            .client
+            .get_account_with_commitment(pubkey, CommitmentConfig::finalized())
+            .await
+            .map_err(|e| SurfpoolError::get_account(*pubkey, e))?;
+        Ok(res.value)
+    }
+
     pub async fn get_account(
         &self,
         pubkey: &Pubkey,

--- a/crates/core/src/surfnet/surfnet_lite_svm.rs
+++ b/crates/core/src/surfnet/surfnet_lite_svm.rs
@@ -122,23 +122,32 @@ impl SurfnetLiteSvm {
             return;
         }
 
-        // Preserve all critical sysvars across garbage collection
+        // Preserve all critical sysvars/config accounts across garbage collection
         // - RecentBlockhashes: for blockhash validation
         // - SlotHashes: for ALT resolution
         // - Clock: for time-dependent programs
         // - StakeHistory: for Stake program Split/Deactivate instructions (accessed via syscall)
+        // - StakeConfig: LiteSVM default is too small for the Stake program to deserialize
+        // - Stake program + programdata: mainnet version replaces outdated bundled ELF
         let recent_blockhashes = self.svm.get_sysvar::<RecentBlockhashes>();
         let slot_hashes = self.svm.get_sysvar::<SlotHashes>();
         let clock = self.svm.get_sysvar::<Clock>();
         let stake_history_account =
             self.svm.get_account(&solana_sdk_ids::sysvar::stake_history::id());
+        let stake_config_account =
+            self.svm.get_account(&solana_sdk_ids::stake::config::id());
+        let stake_program_account =
+            self.svm.get_account(&solana_sdk_ids::stake::id());
+        let stake_programdata_account = self.svm.get_account(
+            &solana_loader_v3_interface::get_program_data_address(&solana_sdk_ids::stake::id()),
+        );
 
         // todo: this is also resetting the log bytes limit and airdrop keypair, would be nice to avoid
         self.svm = Self::full_litesvm_settings(feature_set);
 
         create_native_mint(self);
 
-        // Restore all preserved sysvars
+        // Restore all preserved sysvars/config accounts
         self.svm.set_sysvar(&recent_blockhashes);
         self.svm.set_sysvar(&slot_hashes);
         self.svm.set_sysvar(&clock);
@@ -146,6 +155,24 @@ impl SurfnetLiteSvm {
             let _ = self
                 .svm
                 .set_account(solana_sdk_ids::sysvar::stake_history::id(), account);
+        }
+        if let Some(account) = stake_config_account {
+            let _ = self
+                .svm
+                .set_account(solana_sdk_ids::stake::config::id(), account);
+        }
+        // Restore the mainnet Stake program (programdata first, then program account
+        // to trigger program cache recompilation)
+        if let (Some(programdata), Some(program)) =
+            (stake_programdata_account, stake_program_account)
+        {
+            let programdata_address = solana_loader_v3_interface::get_program_data_address(
+                &solana_sdk_ids::stake::id(),
+            );
+            let _ = self.svm.set_account(programdata_address, programdata);
+            let _ = self
+                .svm
+                .set_account(solana_sdk_ids::stake::id(), program);
         }
     }
 

--- a/crates/core/src/surfnet/surfnet_lite_svm.rs
+++ b/crates/core/src/surfnet/surfnet_lite_svm.rs
@@ -126,9 +126,12 @@ impl SurfnetLiteSvm {
         // - RecentBlockhashes: for blockhash validation
         // - SlotHashes: for ALT resolution
         // - Clock: for time-dependent programs
+        // - StakeHistory: for Stake program Split/Deactivate instructions (accessed via syscall)
         let recent_blockhashes = self.svm.get_sysvar::<RecentBlockhashes>();
         let slot_hashes = self.svm.get_sysvar::<SlotHashes>();
         let clock = self.svm.get_sysvar::<Clock>();
+        let stake_history_account =
+            self.svm.get_account(&solana_sdk_ids::sysvar::stake_history::id());
 
         // todo: this is also resetting the log bytes limit and airdrop keypair, would be nice to avoid
         self.svm = Self::full_litesvm_settings(feature_set);
@@ -139,6 +142,11 @@ impl SurfnetLiteSvm {
         self.svm.set_sysvar(&recent_blockhashes);
         self.svm.set_sysvar(&slot_hashes);
         self.svm.set_sysvar(&clock);
+        if let Some(account) = stake_history_account {
+            let _ = self
+                .svm
+                .set_account(solana_sdk_ids::sysvar::stake_history::id(), account);
+        }
     }
 
     pub fn apply_feature_config(&mut self, feature_set: FeatureSet) -> &mut Self {

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -654,6 +654,8 @@ impl SurfnetSvm {
         do_profile_instructions: bool,
         log_bytes_limit: Option<usize>,
         stake_history_account: Option<Account>,
+        stake_config_account: Option<Account>,
+        stake_program_accounts: Option<(Account, Account)>,
     ) {
         self.chain_tip = self.new_blockhash();
         self.latest_epoch_info = epoch_info.clone();
@@ -683,6 +685,35 @@ impl SurfnetSvm {
                 solana_sdk_ids::sysvar::stake_history::id(),
                 account,
             );
+        }
+
+        // Overwrite the default StakeConfig with real mainnet data. LiteSVM creates a
+        // minimal default (10 bytes) that the Stake program cannot deserialize, causing
+        // DelegateStake to fail with InvalidAccountData.
+        #[allow(deprecated)]
+        if let Some(account) = stake_config_account {
+            let _ = self.inner.svm.set_account(
+                solana_sdk_ids::stake::config::id(),
+                account,
+            );
+        }
+
+        // Replace the bundled Stake program with the live mainnet version.
+        // LiteSVM ships core_bpf_stake-1.0.1.so which was compiled against an older
+        // VoteStateVersions enum that doesn't include V4. Mainnet vote accounts now
+        // use V4, so DelegateStake fails with InvalidAccountData when it tries to
+        // deserialize them. Loading the current mainnet Stake program resolves this.
+        if let Some((program_account, programdata_account)) = stake_program_accounts {
+            let programdata_address =
+                solana_loader_v3_interface::get_program_data_address(&solana_sdk_ids::stake::id());
+            let _ = self
+                .inner
+                .svm
+                .set_account(programdata_address, programdata_account);
+            let _ = self
+                .inner
+                .svm
+                .set_account(solana_sdk_ids::stake::id(), program_account);
         }
 
         if let Some(remote_client) = remote_ctx {

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -653,6 +653,7 @@ impl SurfnetSvm {
         remote_ctx: &Option<SurfnetRemoteClient>,
         do_profile_instructions: bool,
         log_bytes_limit: Option<usize>,
+        stake_history_account: Option<Account>,
     ) {
         self.chain_tip = self.new_blockhash();
         self.latest_epoch_info = epoch_info.clone();
@@ -673,6 +674,16 @@ impl SurfnetSvm {
         }
 
         self.inner.set_sysvar(&epoch_schedule);
+
+        // Set StakeHistory from remote if available. The Stake program accesses this
+        // sysvar via the get_sysvar syscall (not as a transaction account), so it must
+        // be proactively populated.
+        if let Some(account) = stake_history_account {
+            let _ = self.inner.svm.set_account(
+                solana_sdk_ids::sysvar::stake_history::id(),
+                account,
+            );
+        }
 
         if let Some(remote_client) = remote_ctx {
             let _ = self


### PR DESCRIPTION
### Description

- Fetch `StakeHistory` sysvar from remote RPC during init/reset — the Stake program accesses it via `get_sysvar` syscall (not as a transaction account), so lazy fetching never picks it up. Without this, `Split` panics with `SBF program Panicked in src/sysvar/stake_history.rs`
- Replace LiteSVM's bundled Stake program (`core_bpf_stake-1.0.1.so`) with the live mainnet version — the bundled ELF was compiled against `solana-vote-interface` v2.x which only knows `VoteStateVersions` variants 0-2, but mainnet vote accounts now use V4 (discriminant 3), causing `DelegateStake` to fail with `InvalidAccountData`
- Preserve all fetched accounts (StakeHistory, StakeConfig, Stake program + programdata) across garbage collection and network resets
- Add `get_raw_account` method to `SurfnetRemoteClient` for fetching accounts without token/program classification