### PR TITLE
fix(jito_rpc): makes jito bundle atomic

### DIFF
--- a/crates/core/src/rpc/jito.rs
+++ b/crates/core/src/rpc/jito.rs
@@ -3,10 +3,7 @@ use std::str::FromStr;
 use jsonrpc_core::{Error, Result};
 use jsonrpc_derive::rpc;
 use sha2::{Digest, Sha256};
-use solana_client::{
-    rpc_config::{RpcSendTransactionConfig, RpcSimulateTransactionConfig},
-    rpc_custom_error::RpcCustomError,
-};
+use solana_client::{rpc_config::RpcSendTransactionConfig, rpc_custom_error::RpcCustomError};
 use solana_signature::Signature;
 
 use super::{
@@ -101,13 +98,7 @@ impl Jito for SurfpoolJitoRpc {
         // pre-flight simulate each transaction and bail out early if any of them fails.
         for (idx, txn) in transactions.iter().enumerate() {
             let simulate_result = match hiro_system_kit::nestable_block_on(
-                full_rpc.simulate_transaction(
-                    meta.clone(),
-                    txn.clone(),
-                    Some(RpcSimulateTransactionConfig {
-                        ..Default::default()
-                    }),
-                ),
+                full_rpc.simulate_transaction(meta.clone(), txn.clone(), None),
             ) {
                 Ok(res) => res,
                 Err(e) => {

--- a/crates/core/src/rpc/jito.rs
+++ b/crates/core/src/rpc/jito.rs
@@ -1,15 +1,17 @@
-use std::str::FromStr;
-
 use jsonrpc_core::{Error, Result};
 use jsonrpc_derive::rpc;
 use sha2::{Digest, Sha256};
 use solana_client::{rpc_config::RpcSendTransactionConfig, rpc_custom_error::RpcCustomError};
 use solana_signature::Signature;
+use solana_transaction::versioned::VersionedTransaction;
+use solana_transaction_status::UiTransactionEncoding;
 
 use super::{
     RunloopContext,
     full::{Full, SurfpoolFullRpc, SurfpoolRpcSendTransactionConfig},
+    utils::decode_and_deserialize,
 };
+use crate::surfnet::locker::SurfnetSvmLocker;
 
 /// Maximum number of transactions allowed in a single bundle, matching Jito's limit.
 const MAX_BUNDLE_SIZE: usize = 5;
@@ -83,45 +85,100 @@ impl Jito for SurfpoolJitoRpc {
             )));
         }
 
-        let Some(_ctx) = &meta else {
+        let Some(ctx) = &meta else {
             return Err(RpcCustomError::NodeUnhealthy {
                 num_slots_behind: None,
             }
             .into());
         };
 
-        let full_rpc = SurfpoolFullRpc;
-        let mut bundle_signatures = Vec::new();
         let base_config = config.unwrap_or_default();
 
-        // Jito's block engine doesn't roll back on failure (bundles are non-atomic), so we
-        // pre-flight simulate each transaction and bail out early if any of them fails.
-        for (idx, txn) in transactions.iter().enumerate() {
-            let simulate_result = match hiro_system_kit::nestable_block_on(
-                full_rpc.simulate_transaction(meta.clone(), txn.clone(), None),
-            ) {
-                Ok(res) => res,
-                Err(e) => {
-                    return Err(Error {
-                        code: e.code,
-                        message: format!(
-                            "Jito bundle couldn't be sent as it's not atomic: simulation RPC failed for transaction {}: {}",
-                            idx + 1,
-                            e.message
-                        ),
-                        data: e.data,
-                    });
-                }
-            };
+        // Decode all bundle transactions up front so we can run them against a disposable clone.
+        let tx_encoding = base_config
+            .encoding
+            .unwrap_or(UiTransactionEncoding::Base58);
+        let binary_encoding = tx_encoding.into_binary_encoding().ok_or_else(|| {
+            Error::invalid_params(format!(
+                "unsupported encoding: {tx_encoding}. Supported encodings: base58, base64"
+            ))
+        })?;
 
-            if simulate_result.value.err.is_some() {
+        // execute the whole bundle on a disposable sandbox VM
+        // by cloning the svm state into a temporary svm_state
+        let sandbox_svm = ctx
+            .svm_locker
+            .with_svm_reader(|svm_reader| svm_reader.clone_for_profiling());
+        let sandbox_svm_locker = SurfnetSvmLocker::new(sandbox_svm);
+
+        // For now, keep bundle execution local-only; remote ctx / commitment plumbs can be added later.
+        let remote_ctx = &None;
+        let skip_preflight = true;
+        let sigverify = true;
+
+        let mut bundle_signatures: Vec<Signature> = Vec::with_capacity(transactions.len());
+        for (idx, tx_data) in transactions.iter().enumerate() {
+            let (_, tx) =
+                decode_and_deserialize::<VersionedTransaction>(tx_data.clone(), binary_encoding)
+                    .map_err(|e| {
+                        let err_message = e.message;
+                        let code = e.code;
+                        let data = e.data;
+                        Error {
+                            code,
+                            message: format!(
+                                "Failed to decode bundle transaction {}: {}",
+                                idx + 1,
+                                err_message
+                            ),
+                            data,
+                        }
+                    })?;
+
+            let (status_tx, status_rx) = crossbeam_channel::bounded(transactions.len());
+            let process_res =
+                hiro_system_kit::nestable_block_on(sandbox_svm_locker.process_transaction(
+                    remote_ctx,
+                    tx.clone(),
+                    status_tx,
+                    skip_preflight,
+                    sigverify,
+                ));
+
+            let signature = tx.signatures[0];
+            bundle_signatures.push(signature);
+
+            if let Err(e) = process_res {
                 return Err(Error::invalid_params(format!(
-                    "Jito bundle couldn't be sent as it's not atomic: simulation failed for transaction {}",
+                    "Jito bundle couldn't be sent as it's not atomic {}: {e}",
                     idx + 1
                 )));
             }
+
+            // `process_transaction` can return `Ok(())` even when the tx failed, because the
+            // failure is communicated through the status channel. Treat any non-success status
+            // as a bundle failure.
+            match status_rx.recv_timeout(std::time::Duration::from_secs(2)) {
+                Ok(surfpool_types::TransactionStatusEvent::Success(_)) => {}
+                Ok(other) => {
+                    return Err(Error::invalid_params(format!(
+                        "Jito bundle couldn't be sent as it's not atomic: simulation failed for transaction {}: {:?}",
+                        idx + 1,
+                        other
+                    )));
+                }
+                Err(e) => {
+                    return Err(Error::invalid_params(format!(
+                        "Jito bundle couldn't be sent as it's not atomic: simulation RPC failed for transaction {}: {e}",
+                        idx + 1
+                    )));
+                }
+            }
         }
 
+        // TODO: I think it'd be best if we were to copy the changed accounts states and directly change
+        // the original svm state? It's a bit complecated, but will avoid having to send the transactions twice
+        let full_rpc = SurfpoolFullRpc;
         for (idx, tx_data) in transactions.iter().enumerate() {
             let bundle_config = Some(SurfpoolRpcSendTransactionConfig {
                 base: RpcSendTransactionConfig {
@@ -130,23 +187,13 @@ impl Jito for SurfpoolJitoRpc {
                 },
                 skip_sig_verify: None,
             });
-            // Delegate to Full RPC's sendTransaction method
-            match full_rpc.send_transaction(meta.clone(), tx_data.clone(), bundle_config) {
-                Ok(signature_str) => {
-                    // Parse the signature to collect for bundle ID calculation
-                    let signature = Signature::from_str(&signature_str).map_err(|e| {
-                        Error::invalid_params(format!("Failed to parse signature: {e}"))
-                    })?;
-                    bundle_signatures.push(signature);
-                }
-                Err(e) => {
-                    // Add bundle transaction index to error message
-                    return Err(Error {
-                        code: e.code,
-                        message: format!("Bundle transaction {} failed: {}", idx, e.message),
-                        data: e.data,
-                    });
-                }
+            if let Err(e) = full_rpc.send_transaction(meta.clone(), tx_data.clone(), bundle_config)
+            {
+                return Err(Error {
+                    code: e.code,
+                    message: format!("Bundle transaction {} failed: {}", idx, e.message),
+                    data: e.data,
+                });
             }
         }
 
@@ -166,6 +213,14 @@ impl Jito for SurfpoolJitoRpc {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        },
+        time::Duration,
+    };
+
     use sha2::{Digest, Sha256};
     use solana_keypair::Keypair;
     use solana_message::{VersionedMessage, v0::Message as V0Message};
@@ -443,6 +498,144 @@ mod tests {
         assert_eq!(
             bundle_id, expected_bundle_id,
             "Bundle ID should match SHA-256 of comma-separated signatures"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_send_bundle_dependent_transaction_failure_aborts_entire_bundle() {
+        let payer = Keypair::new();
+        let recipient = Keypair::new();
+
+        // Use mempool-backed setup so we can assert that a sandbox failure does NOT enqueue any
+        // ProcessTransaction commands (phase 2 commit currently still uses sendTransaction).
+        let (mempool_tx, mempool_rx) = crossbeam_channel::unbounded();
+        let setup = TestSetup::new_with_mempool(SurfpoolJitoRpc, mempool_tx);
+
+        // Drain any ProcessTransaction commands so `sendTransaction` cannot block this test even
+        // if Phase 2 is accidentally reached. We track whether anything was sent.
+        let observed_process_tx = Arc::new(AtomicUsize::new(0));
+        let stop_drain = Arc::new(AtomicBool::new(false));
+        let observed_process_tx_clone = observed_process_tx.clone();
+        let stop_drain_clone = stop_drain.clone();
+        let svm_locker_clone = setup.context.svm_locker.clone();
+        let drain_handle = hiro_system_kit::thread_named("mempool_drain_dependent_bundle")
+            .spawn(move || {
+                while !stop_drain_clone.load(Ordering::SeqCst) {
+                    let Ok(cmd) = mempool_rx.recv_timeout(Duration::from_millis(200)) else {
+                        continue;
+                    };
+                    match cmd {
+                        SimnetCommand::ProcessTransaction(_, tx, status_tx, _, _) => {
+                            observed_process_tx_clone.fetch_add(1, Ordering::SeqCst);
+
+                            // Minimal bookkeeping (mirrors other bundle tests) + unblock the RPC.
+                            let sig = tx.signatures[0];
+                            let mut writer = svm_locker_clone.0.blocking_write();
+                            let slot = writer.get_latest_absolute_slot();
+                            writer.transactions_queued_for_confirmation.push_back((
+                                tx.clone(),
+                                status_tx.clone(),
+                                None,
+                            ));
+                            let tx_with_status_meta = TransactionWithStatusMeta {
+                                slot,
+                                transaction: tx,
+                                ..Default::default()
+                            };
+                            let mutated_accounts = std::collections::HashSet::new();
+                            let _ = writer.transactions.store(
+                                sig.to_string(),
+                                SurfnetTransactionStatus::processed(
+                                    tx_with_status_meta,
+                                    mutated_accounts,
+                                ),
+                            );
+
+                            let _ = status_tx.send(TransactionStatusEvent::Success(
+                                TransactionConfirmationStatus::Confirmed,
+                            ));
+                        }
+                        SimnetCommand::AirdropProcessed => continue,
+                        _ => continue,
+                    }
+                }
+            })
+            .unwrap();
+
+        let recent_blockhash = setup
+            .context
+            .svm_locker
+            .with_svm_reader(|svm_reader| svm_reader.latest_blockhash());
+
+        // Airdrop to payer so tx1 can fund the recipient.
+        let _ = setup
+            .context
+            .svm_locker
+            .0
+            .write()
+            .await
+            .airdrop(&payer.pubkey(), 5 * LAMPORTS_PER_SOL);
+
+        // tx1: payer -> recipient (funds recipient so it can pay fees for tx2)
+        let tx1 = build_v0_transaction(
+            &payer.pubkey(),
+            &[&payer],
+            &[system_instruction::transfer(
+                &payer.pubkey(),
+                &recipient.pubkey(),
+                LAMPORTS_PER_SOL,
+            )],
+            &recent_blockhash,
+        );
+
+        // tx2 depends on tx1 having executed (recipient needs funds), but must still fail.
+        let tx2 = build_v0_transaction(
+            &recipient.pubkey(),
+            &[&recipient],
+            &[system_instruction::transfer(
+                &recipient.pubkey(),
+                &payer.pubkey(),
+                2 * LAMPORTS_PER_SOL,
+            )],
+            &recent_blockhash,
+        );
+
+        let tx1_encoded = bs58::encode(bincode::serialize(&tx1).unwrap()).into_string();
+        let tx2_encoded = bs58::encode(bincode::serialize(&tx2).unwrap()).into_string();
+
+        let setup_clone = setup.clone();
+        let handle =
+            hiro_system_kit::thread_named("send_bundle_dependent_failure").spawn(move || {
+                setup_clone.rpc.send_bundle(
+                    Some(setup_clone.context),
+                    vec![tx1_encoded, tx2_encoded],
+                    None,
+                )
+            });
+        let handle = handle.unwrap();
+
+        let result = handle.join().unwrap();
+
+        assert!(
+            result.is_err(),
+            "Bundle should fail if any sandbox transaction fails"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.message
+                .contains("Jito bundle couldn't be sent as it's not atomic"),
+            "Expected sandbox failure for tx2, got: {}",
+            err.message
+        );
+
+        stop_drain.store(true, Ordering::SeqCst);
+        let _ = drain_handle.join();
+
+        // If sandbox failure happens as expected, Phase 2 should never run.
+        assert_eq!(
+            observed_process_tx.load(Ordering::SeqCst),
+            0,
+            "Expected zero mempool ProcessTransaction commands; sandbox failure should prevent Phase 2"
         );
     }
 

--- a/crates/core/src/rpc/jito.rs
+++ b/crates/core/src/rpc/jito.rs
@@ -5,6 +5,7 @@ use solana_client::{rpc_config::RpcSendTransactionConfig, rpc_custom_error::RpcC
 use solana_signature::Signature;
 use solana_transaction::versioned::VersionedTransaction;
 use solana_transaction_status::UiTransactionEncoding;
+use surfpool_types::TransactionStatusEvent;
 
 use super::{
     RunloopContext,
@@ -150,7 +151,7 @@ impl Jito for SurfpoolJitoRpc {
 
             if let Err(e) = process_res {
                 return Err(Error::invalid_params(format!(
-                    "Jito bundle couldn't be sent as it's not atomic {}: {e}",
+                    "Jito bundle couldn't be executed, failed to process transaction {}: {e}",
                     idx + 1
                 )));
             }
@@ -159,19 +160,33 @@ impl Jito for SurfpoolJitoRpc {
             // failure is communicated through the status channel. Treat any non-success status
             // as a bundle failure.
             match status_rx.recv_timeout(std::time::Duration::from_secs(2)) {
-                Ok(surfpool_types::TransactionStatusEvent::Success(_)) => {}
-                Ok(other) => {
+                Ok(TransactionStatusEvent::Success(_)) => {}
+                Ok(TransactionStatusEvent::SimulationFailure(other)) => {
                     return Err(Error::invalid_params(format!(
-                        "Jito bundle couldn't be sent as it's not atomic: simulation failed for transaction {}: {:?}",
+                        "Jito bundle couldn't be executed: simulation failed for transaction {}: {:?}",
                         idx + 1,
                         other
                     )));
                 }
-                Err(e) => {
+                Ok(TransactionStatusEvent::ExecutionFailure(other)) => {
                     return Err(Error::invalid_params(format!(
-                        "Jito bundle couldn't be sent as it's not atomic: simulation RPC failed for transaction {}: {e}",
-                        idx + 1
+                        "Jito bundle couldn't be executed: Execution failed for transaction {}: {:?}",
+                        idx + 1,
+                        other
                     )));
+                }
+                Ok(TransactionStatusEvent::VerificationFailure(ver_fail_err)) => {
+                    return Err(Error::invalid_params(format!(
+                        "Jito bundle couldn't be executed: Verification failed for transaction {}: {:?}",
+                        idx + 1,
+                        ver_fail_err
+                    )));
+                }
+                Err(_) => {
+                    return Err(RpcCustomError::NodeUnhealthy {
+                        num_slots_behind: None,
+                    }
+                    .into());
                 }
             }
         }
@@ -232,6 +247,7 @@ mod tests {
 
     use super::*;
     use crate::{
+        surfnet::GetAccountResult,
         tests::helpers::TestSetup,
         types::{SurfnetTransactionStatus, TransactionWithStatusMeta},
     };
@@ -507,7 +523,7 @@ mod tests {
         let recipient = Keypair::new();
 
         // Use mempool-backed setup so we can assert that a sandbox failure does NOT enqueue any
-        // ProcessTransaction commands (phase 2 commit currently still uses sendTransaction).
+        // ProcessTransaction commands
         let (mempool_tx, mempool_rx) = crossbeam_channel::unbounded();
         let setup = TestSetup::new_with_mempool(SurfpoolJitoRpc, mempool_tx);
 
@@ -555,7 +571,6 @@ mod tests {
                                 TransactionConfirmationStatus::Confirmed,
                             ));
                         }
-                        SimnetCommand::AirdropProcessed => continue,
                         _ => continue,
                     }
                 }
@@ -622,14 +637,28 @@ mod tests {
         );
         let err = result.unwrap_err();
         assert!(
-            err.message
-                .contains("Jito bundle couldn't be sent as it's not atomic"),
+            err.message.contains("Jito bundle couldn't be executed"),
             "Expected sandbox failure for tx2, got: {}",
             err.message
         );
 
         stop_drain.store(true, Ordering::SeqCst);
         let _ = drain_handle.join();
+
+        let recp_pubkey = recipient.pubkey();
+        let recp_bal = setup
+            .context
+            .svm_locker
+            .with_svm_reader(|svm| svm.get_account(&recp_pubkey))
+            .ok()
+            .flatten()
+            .map(|a| a.lamports)
+            .unwrap_or(0); // this should be fine, since the recp. kp was new, it's not in the svm state
+
+        assert_eq!(
+            recp_bal, 0,
+            "expected jito bundle to not take effect after bundle failure"
+        );
 
         // If sandbox failure happens as expected, Phase 2 should never run.
         assert_eq!(
@@ -672,13 +701,12 @@ mod tests {
         let err = result.unwrap_err();
 
         assert!(
-            err.message
-                .contains("Jito bundle couldn't be sent as it's not atomic"),
+            err.message.contains("Jito bundle couldn't be executed"),
             "Expected not-atomic error, got: {}",
             err.message
         );
         assert!(
-            err.message.contains("simulation failed for transaction 1"),
+            err.message.contains("Jito bundle couldn't be executed:"),
             "Expected simulation-failure error for transaction 1, got: {}",
             err.message
         );

--- a/crates/core/src/rpc/jito.rs
+++ b/crates/core/src/rpc/jito.rs
@@ -3,7 +3,10 @@ use std::str::FromStr;
 use jsonrpc_core::{Error, Result};
 use jsonrpc_derive::rpc;
 use sha2::{Digest, Sha256};
-use solana_client::{rpc_config::RpcSendTransactionConfig, rpc_custom_error::RpcCustomError};
+use solana_client::{
+    rpc_config::{RpcSendTransactionConfig, RpcSimulateTransactionConfig},
+    rpc_custom_error::RpcCustomError,
+};
 use solana_signature::Signature;
 
 use super::{
@@ -94,10 +97,40 @@ impl Jito for SurfpoolJitoRpc {
         let mut bundle_signatures = Vec::new();
         let base_config = config.unwrap_or_default();
 
-        // Process each transaction in the bundle sequentially using Full RPC
-        // Force skip_preflight to match Jito Block Engine behavior (no simulation on sendBundle)
-        // NOTE: this is not atomic — earlier transactions are NOT rolled back if a later one fails.
-        // TODO(#594): implement atomic all-or-nothing bundle execution
+        // Jito's block engine doesn't roll back on failure (bundles are non-atomic), so we
+        // pre-flight simulate each transaction and bail out early if any of them fails.
+        for (idx, txn) in transactions.iter().enumerate() {
+            let simulate_result = match hiro_system_kit::nestable_block_on(
+                full_rpc.simulate_transaction(
+                    meta.clone(),
+                    txn.clone(),
+                    Some(RpcSimulateTransactionConfig {
+                        ..Default::default()
+                    }),
+                ),
+            ) {
+                Ok(res) => res,
+                Err(e) => {
+                    return Err(Error {
+                        code: e.code,
+                        message: format!(
+                            "Jito bundle couldn't be sent as it's not atomic: simulation RPC failed for transaction {}: {}",
+                            idx + 1,
+                            e.message
+                        ),
+                        data: e.data,
+                    });
+                }
+            };
+
+            if simulate_result.value.err.is_some() {
+                return Err(Error::invalid_params(format!(
+                    "Jito bundle couldn't be sent as it's not atomic: simulation failed for transaction {}",
+                    idx + 1
+                )));
+            }
+        }
+
         for (idx, tx_data) in transactions.iter().enumerate() {
             let bundle_config = Some(SurfpoolRpcSendTransactionConfig {
                 base: RpcSendTransactionConfig {
@@ -419,6 +452,51 @@ mod tests {
         assert_eq!(
             bundle_id, expected_bundle_id,
             "Bundle ID should match SHA-256 of comma-separated signatures"
+        );
+    }
+
+    #[test]
+    fn test_send_bundle_simulation_failure_returns_not_atomic_error() {
+        let setup = TestSetup::new(SurfpoolJitoRpc);
+
+        // Build a tx that should fail during `simulateTransaction` because the payer
+        // has no lamports (no explicit airdrop in this test).
+        let payer = Keypair::new();
+        let recipient = Pubkey::new_unique();
+        let recent_blockhash = setup
+            .context
+            .svm_locker
+            .with_svm_reader(|svm_reader| svm_reader.latest_blockhash());
+
+        let tx = build_v0_transaction(
+            &payer.pubkey(),
+            &[&payer],
+            &[system_instruction::transfer(
+                &payer.pubkey(),
+                &recipient,
+                LAMPORTS_PER_SOL,
+            )],
+            &recent_blockhash,
+        );
+        let tx_encoded = bs58::encode(bincode::serialize(&tx).unwrap()).into_string();
+
+        let result = setup
+            .rpc
+            .send_bundle(Some(setup.context), vec![tx_encoded], None);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+
+        assert!(
+            err.message
+                .contains("Jito bundle couldn't be sent as it's not atomic"),
+            "Expected not-atomic error, got: {}",
+            err.message
+        );
+        assert!(
+            err.message.contains("simulation failed for transaction 1"),
+            "Expected simulation-failure error for transaction 1, got: {}",
+            err.message
         );
     }
 }

--- a/crates/core/src/rpc/jito.rs
+++ b/crates/core/src/rpc/jito.rs
@@ -1,4 +1,6 @@
-use jsonrpc_core::{Error, Result};
+use std::sync::Arc;
+
+use jsonrpc_core::{BoxFuture, Error, Result};
 use jsonrpc_derive::rpc;
 use sha2::{Digest, Sha256};
 use solana_client::{rpc_config::RpcSendTransactionConfig, rpc_custom_error::RpcCustomError};
@@ -7,12 +9,8 @@ use solana_transaction::versioned::VersionedTransaction;
 use solana_transaction_status::UiTransactionEncoding;
 use surfpool_types::TransactionStatusEvent;
 
-use super::{
-    RunloopContext,
-    full::{Full, SurfpoolFullRpc, SurfpoolRpcSendTransactionConfig},
-    utils::decode_and_deserialize,
-};
-use crate::surfnet::locker::SurfnetSvmLocker;
+use super::{RunloopContext, utils::decode_and_deserialize};
+use crate::surfnet::{locker::SurfnetSvmLocker, svm::BundleSandbox};
 
 /// Maximum number of transactions allowed in a single bundle, matching Jito's limit.
 const MAX_BUNDLE_SIZE: usize = 5;
@@ -22,17 +20,31 @@ const MAX_BUNDLE_SIZE: usize = 5;
 pub trait Jito {
     type Metadata;
 
-    /// Sends a bundle of transactions to be processed sequentially.
+    /// Sends a bundle of transactions to be processed atomically.
     ///
     /// This RPC method accepts a bundle of transactions (Jito-compatible format) and processes them
-    /// one by one in order. All transactions in the bundle must succeed for the bundle to be accepted.
+    /// one by one in order against an isolated sandbox VM. **The bundle is all-or-nothing**: if any
+    /// transaction in the bundle fails (simulation error, execution error, or verification error),
+    /// every other transaction's effects are discarded and the underlying VM is left byte-identical
+    /// to its pre-bundle state. No Geyser event, no Simnet event, and no WebSocket subscriber
+    /// notification is dispatched for a bundle that fails.
+    ///
+    /// On full success, the sandbox's state changes — account mutations, transaction storage
+    /// writes, token-account index updates, write-version increments, etc. — are atomically
+    /// committed onto the original VM under an exclusive writer guard, and Geyser/Simnet events
+    /// plus WebSocket subscriber notifications (account, program, signature, logs) are fired
+    /// onto the live event channels exactly as if each transaction had been submitted through
+    /// the regular `sendTransaction` RPC.
     ///
     /// ## Parameters
     /// - `transactions`: An array of serialized transaction data (base64 or base58 encoded).
     /// - `config`: Optional configuration for encoding format.
     ///
     /// ## Returns
-    /// - `Result<String>`: A bundle ID (SHA-256 hash of comma-separated signatures).
+    /// - `BoxFuture<Result<String>>`: A future resolving to the bundle ID (SHA-256 hash of
+    ///   comma-separated signatures), or an error if any transaction in the bundle fails.
+    ///   Returning a future (rather than blocking) lets the JSON-RPC runtime drive the async
+    ///   sandbox execution without spawning a nested tokio runtime on an HTTP worker thread.
     ///
     /// ## Example Request (JSON-RPC)
     /// ```json
@@ -48,20 +60,17 @@ pub trait Jito {
     /// ```
     ///
     /// ## Notes
-    /// - Bundles are limited to a maximum of 5 transactions, matching Jito's limit
-    /// - Transactions are processed sequentially in the order provided
-    /// - Each transaction must complete successfully before the next one starts
-    /// - If any transaction fails, an error is returned — however, earlier transactions in the
-    ///   bundle that already succeeded are NOT rolled back (not atomic)
-    /// - TODO(#594): implement atomic all-or-nothing bundle execution
-    /// - The bundle ID is calculated as SHA-256 hash of comma-separated transaction signatures
+    /// - Bundles are limited to a maximum of 5 transactions, matching Jito's limit.
+    /// - Transactions are processed sequentially in the order provided against a single sandbox.
+    /// - Atomicity is guaranteed: on any failure the original VM is unaffected.
+    /// - The bundle ID is calculated as SHA-256 hash of comma-separated transaction signatures.
     #[rpc(meta, name = "sendBundle")]
     fn send_bundle(
         &self,
         meta: Self::Metadata,
         transactions: Vec<String>,
         config: Option<RpcSendTransactionConfig>,
-    ) -> Result<String>;
+    ) -> BoxFuture<Result<String>>;
 }
 
 #[derive(Clone)]
@@ -75,154 +84,187 @@ impl Jito for SurfpoolJitoRpc {
         meta: Self::Metadata,
         transactions: Vec<String>,
         config: Option<RpcSendTransactionConfig>,
-    ) -> Result<String> {
-        if transactions.is_empty() {
-            return Err(Error::invalid_params("Bundle cannot be empty"));
-        }
-
-        if transactions.len() > MAX_BUNDLE_SIZE {
-            return Err(Error::invalid_params(format!(
-                "Bundle exceeds maximum size of {MAX_BUNDLE_SIZE} transactions"
-            )));
-        }
-
-        let Some(ctx) = &meta else {
-            return Err(RpcCustomError::NodeUnhealthy {
-                num_slots_behind: None,
+    ) -> BoxFuture<Result<String>> {
+        Box::pin(async move {
+            if transactions.is_empty() {
+                return Err(Error::invalid_params("Bundle cannot be empty"));
             }
-            .into());
-        };
 
-        let base_config = config.unwrap_or_default();
-
-        // Decode all bundle transactions up front so we can run them against a disposable clone.
-        let tx_encoding = base_config
-            .encoding
-            .unwrap_or(UiTransactionEncoding::Base58);
-        let binary_encoding = tx_encoding.into_binary_encoding().ok_or_else(|| {
-            Error::invalid_params(format!(
-                "unsupported encoding: {tx_encoding}. Supported encodings: base58, base64"
-            ))
-        })?;
-
-        // execute the whole bundle on a disposable sandbox VM
-        // by cloning the svm state into a temporary svm_state
-        let sandbox_svm = ctx
-            .svm_locker
-            .with_svm_reader(|svm_reader| svm_reader.clone_for_profiling());
-        let sandbox_svm_locker = SurfnetSvmLocker::new(sandbox_svm);
-
-        // For now, keep bundle execution local-only; remote ctx / commitment plumbs can be added later.
-        let remote_ctx = &None;
-        let skip_preflight = true;
-        let sigverify = true;
-
-        let mut bundle_signatures: Vec<Signature> = Vec::with_capacity(transactions.len());
-        for (idx, tx_data) in transactions.iter().enumerate() {
-            let (_, tx) =
-                decode_and_deserialize::<VersionedTransaction>(tx_data.clone(), binary_encoding)
-                    .map_err(|e| {
-                        let err_message = e.message;
-                        let code = e.code;
-                        let data = e.data;
-                        Error {
-                            code,
-                            message: format!(
-                                "Failed to decode bundle transaction {}: {}",
-                                idx + 1,
-                                err_message
-                            ),
-                            data,
-                        }
-                    })?;
-
-            let (status_tx, status_rx) = crossbeam_channel::bounded(transactions.len());
-            let process_res =
-                hiro_system_kit::nestable_block_on(sandbox_svm_locker.process_transaction(
-                    remote_ctx,
-                    tx.clone(),
-                    status_tx,
-                    skip_preflight,
-                    sigverify,
-                ));
-
-            let signature = tx.signatures[0];
-            bundle_signatures.push(signature);
-
-            if let Err(e) = process_res {
+            if transactions.len() > MAX_BUNDLE_SIZE {
                 return Err(Error::invalid_params(format!(
-                    "Jito bundle couldn't be executed, failed to process transaction {}: {e}",
-                    idx + 1
+                    "Bundle exceeds maximum size of {MAX_BUNDLE_SIZE} transactions"
                 )));
             }
 
-            // `process_transaction` can return `Ok(())` even when the tx failed, because the
-            // failure is communicated through the status channel. Treat any non-success status
-            // as a bundle failure.
-            match status_rx.recv_timeout(std::time::Duration::from_secs(2)) {
-                Ok(TransactionStatusEvent::Success(_)) => {}
-                Ok(TransactionStatusEvent::SimulationFailure(other)) => {
-                    return Err(Error::invalid_params(format!(
-                        "Jito bundle couldn't be executed: simulation failed for transaction {}: {:?}",
-                        idx + 1,
-                        other
-                    )));
+            let Some(ctx) = meta else {
+                return Err(RpcCustomError::NodeUnhealthy {
+                    num_slots_behind: None,
                 }
-                Ok(TransactionStatusEvent::ExecutionFailure(other)) => {
-                    return Err(Error::invalid_params(format!(
-                        "Jito bundle couldn't be executed: Execution failed for transaction {}: {:?}",
-                        idx + 1,
-                        other
-                    )));
-                }
-                Ok(TransactionStatusEvent::VerificationFailure(ver_fail_err)) => {
-                    return Err(Error::invalid_params(format!(
-                        "Jito bundle couldn't be executed: Verification failed for transaction {}: {:?}",
-                        idx + 1,
-                        ver_fail_err
-                    )));
-                }
-                Err(_) => {
-                    return Err(RpcCustomError::NodeUnhealthy {
-                        num_slots_behind: None,
-                    }
-                    .into());
-                }
-            }
-        }
+                .into());
+            };
 
-        // TODO: I think it'd be best if we were to copy the changed accounts states and directly change
-        // the original svm state? It's a bit complecated, but will avoid having to send the transactions twice
-        let full_rpc = SurfpoolFullRpc;
-        for (idx, tx_data) in transactions.iter().enumerate() {
-            let bundle_config = Some(SurfpoolRpcSendTransactionConfig {
-                base: RpcSendTransactionConfig {
-                    skip_preflight: true,
-                    ..base_config.clone()
-                },
-                skip_sig_verify: None,
-            });
-            if let Err(e) = full_rpc.send_transaction(meta.clone(), tx_data.clone(), bundle_config)
-            {
-                return Err(Error {
+            let base_config = config.unwrap_or_default();
+
+            // Decode all bundle transactions up front so we can run them against an isolated
+            // sandbox.
+            let tx_encoding = base_config
+                .encoding
+                .unwrap_or(UiTransactionEncoding::Base58);
+            let binary_encoding = tx_encoding.into_binary_encoding().ok_or_else(|| {
+                Error::invalid_params(format!(
+                    "unsupported encoding: {tx_encoding}. Supported encodings: base58, base64"
+                ))
+            })?;
+
+            let mut decoded_txs: Vec<VersionedTransaction> =
+                Vec::with_capacity(transactions.len());
+            for (idx, tx_data) in transactions.iter().enumerate() {
+                let (_, tx) = decode_and_deserialize::<VersionedTransaction>(
+                    tx_data.clone(),
+                    binary_encoding,
+                )
+                .map_err(|e| Error {
                     code: e.code,
-                    message: format!("Bundle transaction {} failed: {}", idx, e.message),
+                    message: format!(
+                        "Failed to decode bundle transaction {}: {}",
+                        idx + 1,
+                        e.message
+                    ),
                     data: e.data,
-                });
+                })?;
+                decoded_txs.push(tx);
             }
-        }
 
-        // Calculate bundle ID by hashing comma-separated signatures (Jito-compatible)
-        // https://github.com/jito-foundation/jito-solana/blob/master/sdk/src/bundle/mod.rs#L21
-        let concatenated_signatures = bundle_signatures
-            .iter()
-            .map(|sig| sig.to_string())
-            .collect::<Vec<_>>()
-            .join(",");
-        let mut hasher = Sha256::new();
-        hasher.update(concatenated_signatures.as_bytes());
-        let bundle_id = hasher.finalize();
-        Ok(hex::encode(bundle_id))
+            // -- Phase A: Sandbox execution -------------------------------------------------
+            // Take a brief read lock on the original VM to construct a sandbox whose storages
+            // are overlay-wrapped, whose subscription registries are empty (no live WS leak),
+            // and whose event channels buffer into receivers we hold here.
+            let bundle_sandbox = ctx
+                .svm_locker
+                .with_svm_reader(|svm_reader| svm_reader.clone_for_bundle_sandbox());
+
+            let BundleSandbox {
+                svm: sandbox_svm,
+                geyser_rx,
+                simnet_rx,
+            } = bundle_sandbox;
+
+            let sandbox_locker = SurfnetSvmLocker::new(sandbox_svm);
+
+            let remote_ctx = &None;
+            let skip_preflight = true;
+            let sigverify = true;
+
+            let mut bundle_signatures: Vec<Signature> = Vec::with_capacity(decoded_txs.len());
+            for (idx, tx) in decoded_txs.iter().enumerate() {
+                let (status_tx, status_rx) = crossbeam_channel::bounded(1);
+
+                // Awaiting directly here lets the surrounding JSON-RPC runtime drive the
+                // future. We must NOT use `hiro_system_kit::nestable_block_on` because the
+                // HTTP worker thread is already inside a tokio runtime and `block_on` on the
+                // current handle panics with "Cannot start a runtime from within a runtime".
+                let process_res = sandbox_locker
+                    .process_transaction(
+                        remote_ctx,
+                        tx.clone(),
+                        status_tx,
+                        skip_preflight,
+                        sigverify,
+                    )
+                    .await;
+
+                bundle_signatures.push(tx.signatures[0]);
+
+                if let Err(e) = process_res {
+                    // Dropping `sandbox_locker` discards all overlay state and the cloned
+                    // LiteSVM, so the original VM is byte-identical to its pre-bundle state.
+                    return Err(Error::invalid_params(format!(
+                        "Jito bundle couldn't be executed, failed to process transaction {}: {e}",
+                        idx + 1
+                    )));
+                }
+
+                // `process_transaction` only returns after the sandbox has run the tx and
+                // dispatched a status event, so `try_recv`/`recv_timeout` will not actually
+                // park the worker for any meaningful time; the 2s timeout is a hard ceiling
+                // for an unexpectedly missed status.
+                match status_rx.recv_timeout(std::time::Duration::from_secs(2)) {
+                    Ok(TransactionStatusEvent::Success(_)) => {}
+                    Ok(TransactionStatusEvent::SimulationFailure(other)) => {
+                        return Err(Error::invalid_params(format!(
+                            "Jito bundle couldn't be executed: simulation failed for transaction {}: {:?}",
+                            idx + 1,
+                            other
+                        )));
+                    }
+                    Ok(TransactionStatusEvent::ExecutionFailure(other)) => {
+                        return Err(Error::invalid_params(format!(
+                            "Jito bundle couldn't be executed: Execution failed for transaction {}: {:?}",
+                            idx + 1,
+                            other
+                        )));
+                    }
+                    Ok(TransactionStatusEvent::VerificationFailure(ver_fail_err)) => {
+                        return Err(Error::invalid_params(format!(
+                            "Jito bundle couldn't be executed: Verification failed for transaction {}: {:?}",
+                            idx + 1,
+                            ver_fail_err
+                        )));
+                    }
+                    Err(_) => {
+                        return Err(RpcCustomError::NodeUnhealthy {
+                            num_slots_behind: None,
+                        }
+                        .into());
+                    }
+                }
+            }
+
+            // -- Phase B: Atomic commit -----------------------------------------------------
+            // All bundle transactions succeeded on the sandbox. Extract the sandbox SVM (the
+            // only remaining Arc reference is the local `sandbox_locker`), reassemble the
+            // BundleSandbox and call commit_sandbox under the original VM's writer lock.
+            let sandbox_svm = match Arc::try_unwrap(sandbox_locker.0) {
+                Ok(rwlock) => rwlock.into_inner(),
+                Err(_) => {
+                    // Should never happen: sandbox_locker was constructed locally and never
+                    // shared.
+                    return Err(Error::internal_error());
+                }
+            };
+            let reassembled = BundleSandbox {
+                svm: sandbox_svm,
+                geyser_rx,
+                simnet_rx,
+            };
+
+            // Use a discardable status channel for the bundle. The runloop will use it to
+            // attempt sending Confirmed/Finalized updates; nobody reads it so try_send fails
+            // silently.
+            let (bundle_status_tx, _bundle_status_rx) = crossbeam_channel::unbounded();
+
+            ctx.svm_locker
+                .with_svm_writer(move |original| {
+                    original.commit_sandbox(reassembled, bundle_status_tx)
+                })
+                .map_err(|e| {
+                    Error::invalid_params(format!(
+                        "Jito bundle commit failed after successful sandbox execution: {e}"
+                    ))
+                })?;
+
+            // Calculate bundle ID by hashing comma-separated signatures (Jito-compatible)
+            // https://github.com/jito-foundation/jito-solana/blob/master/sdk/src/bundle/mod.rs#L21
+            let concatenated_signatures = bundle_signatures
+                .iter()
+                .map(|sig| sig.to_string())
+                .collect::<Vec<_>>()
+                .join(",");
+            let mut hasher = Sha256::new();
+            hasher.update(concatenated_signatures.as_bytes());
+            let bundle_id = hasher.finalize();
+            Ok(hex::encode(bundle_id))
+        })
     }
 }
 
@@ -247,7 +289,6 @@ mod tests {
 
     use super::*;
     use crate::{
-        surfnet::GetAccountResult,
         tests::helpers::TestSetup,
         types::{SurfnetTransactionStatus, TransactionWithStatusMeta},
     };
@@ -266,10 +307,13 @@ mod tests {
         VersionedTransaction::try_new(msg, signers).unwrap()
     }
 
-    #[test]
-    fn test_send_bundle_empty_bundle_rejected() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_send_bundle_empty_bundle_rejected() {
         let setup = TestSetup::new(SurfpoolJitoRpc);
-        let result = setup.rpc.send_bundle(Some(setup.context), vec![], None);
+        let result = setup
+            .rpc
+            .send_bundle(Some(setup.context.clone()), vec![], None)
+            .await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -280,13 +324,14 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_send_bundle_exceeds_max_size_rejected() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_send_bundle_exceeds_max_size_rejected() {
         let setup = TestSetup::new(SurfpoolJitoRpc);
         let transactions = vec!["tx".to_string(); MAX_BUNDLE_SIZE + 1];
         let result = setup
             .rpc
-            .send_bundle(Some(setup.context), transactions, None);
+            .send_bundle(Some(setup.context.clone()), transactions, None)
+            .await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -297,12 +342,13 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_send_bundle_no_context_returns_unhealthy() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_send_bundle_no_context_returns_unhealthy() {
         let setup = TestSetup::new(SurfpoolJitoRpc);
         let result = setup
             .rpc
-            .send_bundle(None, vec!["some_tx".to_string()], None);
+            .send_bundle(None, vec!["some_tx".to_string()], None)
+            .await;
 
         assert!(result.is_err());
     }
@@ -311,8 +357,7 @@ mod tests {
     async fn test_send_bundle_single_transaction() {
         let payer = Keypair::new();
         let recipient = Pubkey::new_unique();
-        let (mempool_tx, mempool_rx) = crossbeam_channel::unbounded();
-        let setup = TestSetup::new_with_mempool(SurfpoolJitoRpc, mempool_tx);
+        let setup = TestSetup::new(SurfpoolJitoRpc);
         let recent_blockhash = setup
             .context
             .svm_locker
@@ -340,56 +385,11 @@ mod tests {
         let tx_encoded = bs58::encode(bincode::serialize(&tx).unwrap()).into_string();
         let expected_sig = tx.signatures[0];
 
-        let setup_clone = setup.clone();
-        let handle = hiro_system_kit::thread_named("send_bundle")
-            .spawn(move || {
-                setup_clone
-                    .rpc
-                    .send_bundle(Some(setup_clone.context), vec![tx_encoded], None)
-            })
-            .unwrap();
+        let result = setup
+            .rpc
+            .send_bundle(Some(setup.context.clone()), vec![tx_encoded], None)
+            .await;
 
-        // Process the transaction from mempool
-        loop {
-            match mempool_rx.recv() {
-                Ok(SimnetCommand::ProcessTransaction(_, tx, status_tx, _, _)) => {
-                    let mut writer = setup.context.svm_locker.0.write().await;
-                    let slot = writer.get_latest_absolute_slot();
-                    writer.transactions_queued_for_confirmation.push_back((
-                        tx.clone(),
-                        status_tx.clone(),
-                        None,
-                    ));
-                    let sig = tx.signatures[0];
-                    let tx_with_status_meta = TransactionWithStatusMeta {
-                        slot,
-                        transaction: tx,
-                        ..Default::default()
-                    };
-                    let mutated_accounts = std::collections::HashSet::new();
-                    writer
-                        .transactions
-                        .store(
-                            sig.to_string(),
-                            SurfnetTransactionStatus::processed(
-                                tx_with_status_meta,
-                                mutated_accounts,
-                            ),
-                        )
-                        .unwrap();
-                    status_tx
-                        .send(TransactionStatusEvent::Success(
-                            TransactionConfirmationStatus::Confirmed,
-                        ))
-                        .unwrap();
-                    break;
-                }
-                Ok(SimnetCommand::AirdropProcessed) => continue,
-                _ => panic!("failed to receive transaction from mempool"),
-            }
-        }
-
-        let result = handle.join().unwrap();
         assert!(result.is_ok(), "Bundle should succeed: {:?}", result);
 
         // Verify bundle ID is SHA-256 of the signature
@@ -401,6 +401,20 @@ mod tests {
             bundle_id, expected_bundle_id,
             "Bundle ID should match SHA-256 of signature"
         );
+
+        // Verify recipient balance reflects the committed bundle
+        let recipient_lamports = setup
+            .context
+            .svm_locker
+            .with_svm_reader(|svm| svm.get_account(&recipient))
+            .ok()
+            .flatten()
+            .map(|a| a.lamports)
+            .unwrap_or(0);
+        assert_eq!(
+            recipient_lamports, LAMPORTS_PER_SOL,
+            "Bundle commit should have applied lamport transfer to recipient"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -408,8 +422,7 @@ mod tests {
         let payer = Keypair::new();
         let recipient1 = Pubkey::new_unique();
         let recipient2 = Pubkey::new_unique();
-        let (mempool_tx, mempool_rx) = crossbeam_channel::unbounded();
-        let setup = TestSetup::new_with_mempool(SurfpoolJitoRpc, mempool_tx);
+        let setup = TestSetup::new(SurfpoolJitoRpc);
         let recent_blockhash = setup
             .context
             .svm_locker
@@ -450,60 +463,36 @@ mod tests {
         let expected_sig1 = tx1.signatures[0];
         let expected_sig2 = tx2.signatures[0];
 
-        let setup_clone = setup.clone();
-        let handle = hiro_system_kit::thread_named("send_bundle")
-            .spawn(move || {
-                setup_clone.rpc.send_bundle(
-                    Some(setup_clone.context),
-                    vec![tx1_encoded, tx2_encoded],
-                    None,
-                )
-            })
-            .unwrap();
+        let result = setup
+            .rpc
+            .send_bundle(
+                Some(setup.context.clone()),
+                vec![tx1_encoded, tx2_encoded],
+                None,
+            )
+            .await;
 
-        // Process both transactions from mempool
-        let mut processed_count = 0;
-        while processed_count < 2 {
-            match mempool_rx.recv() {
-                Ok(SimnetCommand::ProcessTransaction(_, tx, status_tx, _, _)) => {
-                    let mut writer = setup.context.svm_locker.0.write().await;
-                    let slot = writer.get_latest_absolute_slot();
-                    writer.transactions_queued_for_confirmation.push_back((
-                        tx.clone(),
-                        status_tx.clone(),
-                        None,
-                    ));
-                    let sig = tx.signatures[0];
-                    let tx_with_status_meta = TransactionWithStatusMeta {
-                        slot,
-                        transaction: tx,
-                        ..Default::default()
-                    };
-                    let mutated_accounts = std::collections::HashSet::new();
-                    writer
-                        .transactions
-                        .store(
-                            sig.to_string(),
-                            SurfnetTransactionStatus::processed(
-                                tx_with_status_meta,
-                                mutated_accounts,
-                            ),
-                        )
-                        .unwrap();
-                    status_tx
-                        .send(TransactionStatusEvent::Success(
-                            TransactionConfirmationStatus::Confirmed,
-                        ))
-                        .unwrap();
-                    processed_count += 1;
-                }
-                Ok(SimnetCommand::AirdropProcessed) => continue,
-                _ => panic!("failed to receive transaction from mempool"),
-            }
-        }
-
-        let result = handle.join().unwrap();
         assert!(result.is_ok(), "Bundle should succeed: {:?}", result);
+
+        // Both recipient balances should reflect committed bundle
+        let recipient1_lamports = setup
+            .context
+            .svm_locker
+            .with_svm_reader(|svm| svm.get_account(&recipient1))
+            .ok()
+            .flatten()
+            .map(|a| a.lamports)
+            .unwrap_or(0);
+        let recipient2_lamports = setup
+            .context
+            .svm_locker
+            .with_svm_reader(|svm| svm.get_account(&recipient2))
+            .ok()
+            .flatten()
+            .map(|a| a.lamports)
+            .unwrap_or(0);
+        assert_eq!(recipient1_lamports, LAMPORTS_PER_SOL);
+        assert_eq!(recipient2_lamports, LAMPORTS_PER_SOL);
 
         // Verify bundle ID is SHA-256 of comma-separated signatures
         let bundle_id = result.unwrap();
@@ -618,18 +607,14 @@ mod tests {
         let tx1_encoded = bs58::encode(bincode::serialize(&tx1).unwrap()).into_string();
         let tx2_encoded = bs58::encode(bincode::serialize(&tx2).unwrap()).into_string();
 
-        let setup_clone = setup.clone();
-        let handle =
-            hiro_system_kit::thread_named("send_bundle_dependent_failure").spawn(move || {
-                setup_clone.rpc.send_bundle(
-                    Some(setup_clone.context),
-                    vec![tx1_encoded, tx2_encoded],
-                    None,
-                )
-            });
-        let handle = handle.unwrap();
-
-        let result = handle.join().unwrap();
+        let result = setup
+            .rpc
+            .send_bundle(
+                Some(setup.context.clone()),
+                vec![tx1_encoded, tx2_encoded],
+                None,
+            )
+            .await;
 
         assert!(
             result.is_err(),
@@ -668,8 +653,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_send_bundle_simulation_failure_returns_not_atomic_error() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_send_bundle_simulation_failure_returns_not_atomic_error() {
         let setup = TestSetup::new(SurfpoolJitoRpc);
 
         // Build a tx that should fail during `simulateTransaction` because the payer
@@ -695,7 +680,8 @@ mod tests {
 
         let result = setup
             .rpc
-            .send_bundle(Some(setup.context), vec![tx_encoded], None);
+            .send_bundle(Some(setup.context.clone()), vec![tx_encoded], None)
+            .await;
 
         assert!(result.is_err());
         let err = result.unwrap_err();

--- a/crates/core/src/rpc/jito.rs
+++ b/crates/core/src/rpc/jito.rs
@@ -116,8 +116,7 @@ impl Jito for SurfpoolJitoRpc {
                 ))
             })?;
 
-            let mut decoded_txs: Vec<VersionedTransaction> =
-                Vec::with_capacity(transactions.len());
+            let mut decoded_txs: Vec<VersionedTransaction> = Vec::with_capacity(transactions.len());
             for (idx, tx_data) in transactions.iter().enumerate() {
                 let (_, tx) = decode_and_deserialize::<VersionedTransaction>(
                     tx_data.clone(),

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -248,6 +248,29 @@ pub trait Storage<K, V>: Send + Sync {
 
     // Enable cloning of boxed trait objects
     fn clone_box(&self) -> Box<dyn Storage<K, V>>;
+
+    /// Returns `Some` if this storage is an overlay-style wrapper (`OverlayStorage`) whose
+    /// buffered writes/deletes can be drained for atomic commit semantics. Default `None`.
+    /// Used by the atomic Jito bundle commit path to flush a sandbox SVM's overlay storages
+    /// back onto the original VM's underlying storage on bundle success.
+    fn as_overlay(&self) -> Option<&dyn OverlayLike<K, V>> {
+        None
+    }
+}
+
+/// Trait implemented by `OverlayStorage<K, V>` to expose its buffered writes/deletes so that a
+/// caller (e.g. atomic bundle commit) can drain them back onto a target storage.
+pub trait OverlayLike<K, V>: Send + Sync {
+    /// Returns the current in-memory overlay state: pending writes, pending deletes
+    /// (tombstones), and whether the base was logically cleared.
+    fn extract_overlay(&self) -> StorageResult<OverlayDelta<K, V>>;
+}
+
+/// Captured overlay state for atomic replay onto a target storage.
+pub struct OverlayDelta<K, V> {
+    pub writes: Vec<(K, V)>,
+    pub deletes: Vec<K>,
+    pub base_cleared: bool,
 }
 
 // Implement Clone for Box<dyn Storage<K, V>>

--- a/crates/core/src/storage/overlay.rs
+++ b/crates/core/src/storage/overlay.rs
@@ -6,7 +6,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use super::{Storage, StorageError, StorageResult};
+use super::{OverlayDelta, OverlayLike, Storage, StorageError, StorageResult};
 
 /// Represents the state of a key in the overlay
 #[derive(Clone)]
@@ -263,6 +263,39 @@ where
             base: self.base.clone_box(),
             overlay: Arc::new(RwLock::new(overlay.clone())),
             base_cleared: Arc::new(RwLock::new(base_cleared)),
+        })
+    }
+
+    fn as_overlay(&self) -> Option<&dyn OverlayLike<K, V>> {
+        Some(self)
+    }
+}
+
+impl<K, V> OverlayLike<K, V> for OverlayStorage<K, V>
+where
+    K: Serialize + for<'de> Deserialize<'de> + Clone + Eq + Hash + Send + Sync + 'static,
+    V: Serialize + for<'de> Deserialize<'de> + Clone + Send + Sync + 'static,
+{
+    fn extract_overlay(&self) -> StorageResult<OverlayDelta<K, V>> {
+        let overlay = self.overlay.read().map_err(|_| StorageError::LockError)?;
+        let base_cleared = *self
+            .base_cleared
+            .read()
+            .map_err(|_| StorageError::LockError)?;
+
+        let mut writes = Vec::new();
+        let mut deletes = Vec::new();
+        for (k, entry) in overlay.iter() {
+            match entry {
+                OverlayEntry::Written(v) => writes.push((k.clone(), v.clone())),
+                OverlayEntry::Deleted => deletes.push(k.clone()),
+            }
+        }
+
+        Ok(OverlayDelta {
+            writes,
+            deletes,
+            base_cleared,
         })
     }
 }

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -84,7 +84,7 @@ use crate::{
         LogsSubscriptionData, locker::is_supported_token_program, surfnet_lite_svm::SurfnetLiteSvm,
     },
     types::{
-        GeyserAccountUpdate, MintAccount, OfflineAccountConfig, SerializableAccountAdditionalData,
+        MintAccount, OfflineAccountConfig, SerializableAccountAdditionalData,
         SurfnetTransactionStatus, SyntheticBlockhash, TokenAccount, TransactionWithStatusMeta,
     },
 };
@@ -363,6 +363,44 @@ fn remove_pubkey_from_index(
     Ok(())
 }
 
+/// A bundle execution sandbox: an isolated [`SurfnetSvm`] clone whose buffered event channels
+/// can be drained on bundle commit to replay events onto the original VM. Construct via
+/// [`SurfnetSvm::clone_for_bundle_sandbox`] and consume via [`SurfnetSvm::commit_sandbox`] on
+/// success or simply drop on failure to discard all in-progress state.
+pub struct BundleSandbox {
+    pub svm: SurfnetSvm,
+    pub geyser_rx: Receiver<GeyserEvent>,
+    pub simnet_rx: Receiver<SimnetEvent>,
+}
+
+/// Generic helper: drain the overlay state of `sandbox_storage` (which must be an
+/// `OverlayStorage`-wrapped storage as produced by `clone_for_profiling`) and apply each
+/// write/delete to `target_storage`. If the sandbox overlay had been logically cleared
+/// (via `clear()`), the target is cleared first.
+///
+/// If `sandbox_storage` is not overlay-style (i.e. `as_overlay()` returns `None`), this is a
+/// no-op — that should never happen for fields constructed by `clone_for_profiling`, which
+/// always wraps every storage field with `OverlayStorage`.
+fn commit_overlay_storage<K, V>(
+    sandbox_storage: &dyn Storage<K, V>,
+    target_storage: &mut dyn Storage<K, V>,
+) -> SurfpoolResult<()> {
+    let Some(overlay) = sandbox_storage.as_overlay() else {
+        return Ok(());
+    };
+    let delta = overlay.extract_overlay()?;
+    if delta.base_cleared {
+        target_storage.clear()?;
+    }
+    for k in delta.deletes {
+        target_storage.take(&k)?;
+    }
+    for (k, v) in delta.writes {
+        target_storage.store(k, v)?;
+    }
+    Ok(())
+}
+
 impl SurfnetSvm {
     pub fn default() -> (Self, Receiver<SimnetEvent>, Receiver<GeyserEvent>) {
         Self::new(SurfnetSvmConfig::default()).unwrap()
@@ -405,6 +443,20 @@ impl SurfnetSvm {
     /// Creates a clone of the SVM with overlay storage wrappers for all database-backed fields.
     /// This allows profiling transactions without affecting the underlying database.
     /// All storage writes are buffered in memory and discarded when the clone is dropped.
+    ///
+    /// Subscription registries (`signature_subscriptions`, `account_subscriptions`,
+    /// `program_subscriptions`, `slot_subscriptions`, `logs_subscriptions`,
+    /// `snapshot_subscriptions`) are all replaced with empty containers on the sandbox so that
+    /// any notification dispatched during sandbox execution cannot reach live WebSocket clients.
+    /// Although `HashMap::clone()` of the original maps is a deep copy of the container, each
+    /// contained `crossbeam_channel::Sender` is a handle to the same channel held by live
+    /// subscriber receivers — re-firing them from the sandbox would leak notifications even on
+    /// bundle abort. Emptying the containers closes that leak.
+    ///
+    /// Event channels (`simnet_events_tx`, `geyser_events_tx`) are replaced with internal
+    /// buffered channels whose receivers are kept on the sandbox under `sandbox_simnet_events_rx`
+    /// and `sandbox_geyser_events_rx`. Bundle commit code can drain these to replay the events
+    /// on the original VM's channels.
     pub fn clone_for_profiling(&self) -> Self {
         let (dummy_simnet_tx, _) = crossbeam_channel::bounded(1);
         let (dummy_geyser_tx, _) = crossbeam_channel::bounded(1);
@@ -448,10 +500,14 @@ impl SurfnetSvm {
             simnet_events_tx: dummy_simnet_tx,
             geyser_events_tx: dummy_geyser_tx,
 
-            signature_subscriptions: self.signature_subscriptions.clone(),
-            account_subscriptions: self.account_subscriptions.clone(),
-            program_subscriptions: self.program_subscriptions.clone(),
-            // Don't clone subscriptions - profiling clone shouldn't send notifications
+            signature_subscriptions: HashMap::new(),
+            account_subscriptions: HashMap::new(),
+            program_subscriptions: HashMap::new(),
+            // All six subscription containers are emptied on the sandbox so that no notification
+            // dispatched during sandbox execution can reach live WebSocket subscribers. The three
+            // map-based containers above contain `crossbeam_channel::Sender` handles whose
+            // `clone()` produces a producer for the same underlying channel held by the live
+            // subscriber's receiver — emptying the map is what actually prevents the leak.
             slot_subscriptions: Vec::new(),
             logs_subscriptions: Vec::new(),
             snapshot_subscriptions: Vec::new(),
@@ -502,6 +558,205 @@ impl SurfnetSvm {
         for (_, template) in registry.templates.into_iter() {
             let _ = self.register_idl(template.idl, None);
         }
+    }
+
+    /// Creates a sandbox tailored for atomic Jito-style bundle execution. Behavior matches
+    /// [`Self::clone_for_profiling`] (all storage fields are overlay-wrapped; subscription
+    /// containers are emptied so live WS subscribers cannot be notified from the sandbox),
+    /// but the `simnet_events_tx` and `geyser_events_tx` channels are replaced with
+    /// **unbounded buffered** channels whose receivers are returned alongside the sandbox.
+    /// The atomic-commit phase ([`Self::commit_sandbox`]) drains those receivers to replay
+    /// the captured events onto the original VM's real event channels on bundle success.
+    ///
+    /// On bundle failure, simply dropping the returned [`BundleSandbox`] discards every
+    /// buffered event, every overlay write, and the cloned `LiteSVM` state — the original
+    /// VM is left byte-identical to its pre-bundle state.
+    pub fn clone_for_bundle_sandbox(&self) -> BundleSandbox {
+        let mut svm = self.clone_for_profiling();
+        let (geyser_tx, geyser_rx) = crossbeam_channel::unbounded();
+        let (simnet_tx, simnet_rx) = crossbeam_channel::unbounded();
+        svm.geyser_events_tx = geyser_tx;
+        svm.simnet_events_tx = simnet_tx;
+        BundleSandbox {
+            svm,
+            geyser_rx,
+            simnet_rx,
+        }
+    }
+
+    /// Atomically commit the outcome of a fully-successful bundle sandbox onto `self`.
+    ///
+    /// This is the second half of the atomic Jito bundle pipeline. It must be invoked only
+    /// after every transaction in the bundle succeeded inside the sandbox. The caller must
+    /// hold an exclusive writer guard on `self`'s `SurfnetSvmLocker` so that no other RPC
+    /// path can observe a half-committed state.
+    ///
+    /// Order of operations is **state mutations first, side-effects second**:
+    ///   1. Drain every overlay-wrapped storage field from the sandbox onto `self`'s
+    ///      corresponding underlying storage. This is the first moment any SQLite/Postgres
+    ///      handle is touched on behalf of the bundle.
+    ///   2. Move the sandbox's `LiteSVM` (the in-memory accounts DB) onto `self`, replacing
+    ///      `self.inner.svm` with the post-bundle account state.
+    ///   3. Drain the sandbox's account-DB overlay (`inner.db`) onto `self.inner.db` so any
+    ///      SQLite-backed account persistence reflects the bundle's mutations.
+    ///   4. Pull forward counters (`write_version`, `transactions_processed`), per-account
+    ///      update slots, pending confirmation/finalization queues, perf samples, and the
+    ///      recent-blockhash deque from the sandbox.
+    ///   5. Drain the sandbox's buffered geyser events; replay each onto `self.geyser_events_tx`.
+    ///      For each `UpdateAccount` event, also fire `notify_account_subscribers` /
+    ///      `notify_program_subscribers` on `self` (the sandbox's registries were emptied,
+    ///      so those notifications could not have been delivered during sandbox execution).
+    ///   6. Drain the sandbox's buffered simnet events; replay each onto `self.simnet_events_tx`.
+    ///   7. For each transaction committed by the bundle, fire signature and logs subscribers
+    ///      at `Processed` commitment on `self`'s subscription registries, and send a
+    ///      `TransactionStatusEvent::Success(Processed)` on the per-tx status channel that
+    ///      is now part of `self.transactions_queued_for_confirmation` (so the existing
+    ///      confirmation/finalization runloop will promote bundle txs through the commitment
+    ///      ladder identically to txs submitted via `sendTransaction`).
+    ///
+    /// Returns the ordered list of signatures committed by the bundle.
+    pub fn commit_sandbox(
+        &mut self,
+        sandbox: BundleSandbox,
+        bundle_status_tx: Sender<TransactionStatusEvent>,
+    ) -> SurfpoolResult<Vec<Signature>> {
+        let BundleSandbox {
+            mut svm,
+            geyser_rx,
+            simnet_rx,
+        } = sandbox;
+
+        // 1. Drain all overlay storages onto self's real storages.
+        commit_overlay_storage(svm.blocks.as_ref(), self.blocks.as_mut())?;
+        commit_overlay_storage(svm.transactions.as_ref(), self.transactions.as_mut())?;
+        commit_overlay_storage(svm.profile_tag_map.as_ref(), self.profile_tag_map.as_mut())?;
+        commit_overlay_storage(
+            svm.simulated_transaction_profiles.as_ref(),
+            self.simulated_transaction_profiles.as_mut(),
+        )?;
+        commit_overlay_storage(
+            svm.executed_transaction_profiles.as_ref(),
+            self.executed_transaction_profiles.as_mut(),
+        )?;
+        commit_overlay_storage(
+            svm.accounts_by_owner.as_ref(),
+            self.accounts_by_owner.as_mut(),
+        )?;
+        commit_overlay_storage(
+            svm.account_associated_data.as_ref(),
+            self.account_associated_data.as_mut(),
+        )?;
+        commit_overlay_storage(svm.token_accounts.as_ref(), self.token_accounts.as_mut())?;
+        commit_overlay_storage(svm.token_mints.as_ref(), self.token_mints.as_mut())?;
+        commit_overlay_storage(
+            svm.token_accounts_by_owner.as_ref(),
+            self.token_accounts_by_owner.as_mut(),
+        )?;
+        commit_overlay_storage(
+            svm.token_accounts_by_delegate.as_ref(),
+            self.token_accounts_by_delegate.as_mut(),
+        )?;
+        commit_overlay_storage(
+            svm.token_accounts_by_mint.as_ref(),
+            self.token_accounts_by_mint.as_mut(),
+        )?;
+        commit_overlay_storage(svm.registered_idls.as_ref(), self.registered_idls.as_mut())?;
+        commit_overlay_storage(
+            svm.streamed_accounts.as_ref(),
+            self.streamed_accounts.as_mut(),
+        )?;
+        commit_overlay_storage(
+            svm.scheduled_overrides.as_ref(),
+            self.scheduled_overrides.as_mut(),
+        )?;
+        commit_overlay_storage(
+            svm.offline_accounts.as_ref(),
+            self.offline_accounts.as_mut(),
+        )?;
+        commit_overlay_storage(svm.slot_checkpoint.as_ref(), self.slot_checkpoint.as_mut())?;
+
+        // 2. Move the sandbox's executed LiteSVM accounts state onto self.
+        std::mem::swap(&mut self.inner.svm, &mut svm.inner.svm);
+
+        // 3. Drain sandbox's account-DB overlay onto self.inner.db.
+        if let (Some(sandbox_db), Some(target_db)) = (svm.inner.db.as_ref(), self.inner.db.as_mut())
+        {
+            commit_overlay_storage(sandbox_db.as_ref(), target_db.as_mut())?;
+        }
+
+        // 4. Counter/version/queue state.
+        self.transactions_processed = svm.transactions_processed;
+        self.write_version = svm.write_version;
+        for (k, v) in svm.account_update_slots.drain() {
+            self.account_update_slots.insert(k, v);
+        }
+        self.perf_samples = svm.perf_samples.clone();
+        self.recent_blockhashes = svm.recent_blockhashes.clone();
+
+        // Push sandbox's queued txs onto self's queues, rewriting the per-tx status channel
+        // to the bundle's status channel so the runloop's Confirmed/Finalized promotions
+        // flow through a single channel (the caller drops the receiver).
+        let mut signatures = Vec::new();
+        for (tx, _sandbox_status_tx, err) in svm.transactions_queued_for_confirmation.drain(..) {
+            signatures.push(tx.signatures[0]);
+            self.transactions_queued_for_confirmation.push_back((
+                tx,
+                bundle_status_tx.clone(),
+                err,
+            ));
+        }
+        for (slot, tx, _sandbox_status_tx, err) in
+            svm.transactions_queued_for_finalization.drain(..)
+        {
+            self.transactions_queued_for_finalization.push_back((
+                slot,
+                tx,
+                bundle_status_tx.clone(),
+                err,
+            ));
+        }
+
+        // 5. Drain buffered geyser events; replay onto self's real channel; for each
+        //    UpdateAccount, also fire account/program subscribers on self's registries.
+        while let Ok(event) = geyser_rx.try_recv() {
+            if let GeyserEvent::UpdateAccount(update) = &event {
+                self.notify_account_subscribers(&update.pubkey, &update.account);
+                self.notify_program_subscribers(&update.pubkey, &update.account);
+            }
+            let _ = self.geyser_events_tx.send(event);
+        }
+
+        // 6. Drain buffered simnet events; replay onto self's real channel.
+        while let Ok(event) = simnet_rx.try_recv() {
+            let _ = self.simnet_events_tx.try_send(event);
+        }
+
+        // 7. Fire signature/logs subscribers and Success acks for each committed tx.
+        //    Use the now-committed `self.transactions` storage as the source of err/logs.
+        let slot = self.get_latest_absolute_slot();
+        for sig in &signatures {
+            let (err, logs) = match self.transactions.get(&sig.to_string()).ok().flatten() {
+                Some(SurfnetTransactionStatus::Processed(boxed)) => {
+                    let (meta, _mutated) = boxed.as_ref();
+                    let err = meta.meta.status.clone().err();
+                    let logs = meta.meta.log_messages.clone().unwrap_or_default();
+                    (err, logs)
+                }
+                _ => (None, Vec::new()),
+            };
+            self.notify_signature_subscribers(
+                SignatureSubscriptionType::processed(),
+                sig,
+                slot,
+                err.clone(),
+            );
+            self.notify_logs_subscribers(sig, err, logs, CommitmentLevel::Processed);
+            let _ = bundle_status_tx.try_send(TransactionStatusEvent::Success(
+                TransactionConfirmationStatus::Processed,
+            ));
+        }
+
+        Ok(signatures)
     }
 
     /// Creates a new instance of `SurfnetSvm`.


### PR DESCRIPTION
## Summery
Simulates each transaction sent in the `sendBundle` rpc method and early returns if any of them fail.

## Changes
* Adds an iterator inside the `SurfpoolJitoRpc::send_bundle` function before sending transactions
* Adds test to check if it returns the right error message

## Note
This might not entirely replicate jito bundles. But since it's majorly used for testing purposes, it works well to say that the bundle is `atomic`

Closes #594 