### PR TITLE
fix(core): handle divide by zero in time travel calculations

### DIFF
--- a/crates/core/src/helpers/time_travel.rs
+++ b/crates/core/src/helpers/time_travel.rs
@@ -38,10 +38,15 @@ pub fn calculate_absolute_timestamp_clock(
     if slot_time == 0 {
         return Err(TimeTravelError::ZeroSlotTime);
     }
+    if epoch_info.slots_in_epoch == 0 {
+        return Err(TimeTravelError::ZeroSlotsInEpoch);
+    }
 
     let time_jump_in_ms = timestamp_target - current_updated_at;
     let time_jump_in_absolute_slots = time_jump_in_ms / slot_time;
-    let remaining_slots_for_current_epoch = epoch_info.slots_in_epoch - epoch_info.slot_index;
+    let remaining_slots_for_current_epoch = epoch_info
+        .slots_in_epoch
+        .saturating_sub(epoch_info.slot_index);
 
     let time_jump_in_epochs = if time_jump_in_absolute_slots >= remaining_slots_for_current_epoch {
         (time_jump_in_absolute_slots - remaining_slots_for_current_epoch)

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -1227,6 +1227,7 @@ pub enum TimeTravelError {
     PastSlot { target: u64, current: u64 },
     PastEpoch { target: u64, current: u64 },
     ZeroSlotTime,
+    ZeroSlotsInEpoch,
 }
 
 impl std::fmt::Display for TimeTravelError {
@@ -1255,6 +1256,9 @@ impl std::fmt::Display for TimeTravelError {
             }
             TimeTravelError::ZeroSlotTime => {
                 write!(f, "Cannot calculate time travel with zero slot time")
+            }
+            TimeTravelError::ZeroSlotsInEpoch => {
+                write!(f, "Cannot calculate time travel with zero slots in epoch")
             }
         }
     }


### PR DESCRIPTION
#613 should already be fixed because `slots_in_epoch` should never be zero, but remove the divide by 0 risk anyways