### PR TITLE
chore: various cleanups

### DIFF
--- a/crates/cli/src/cli/simnet/mod.rs
+++ b/crates/cli/src/cli/simnet/mod.rs
@@ -522,9 +522,6 @@ enum RunbookExecutionMode {
     /// `bin_path` injection) or `--anchor-compat` without an existing
     /// `txtx.yml`. Requires framework detection.
     InMemory,
-    /// `--anchor-compat` set AND `txtx.yml` exists: the original code fell
-    /// through without setting either data pointer. Preserved as-is.
-    Neither,
 }
 
 impl RunbookExecutionMode {
@@ -533,9 +530,9 @@ impl RunbookExecutionMode {
             // `--artifacts-path` always wins: the custom bin_path has to be
             // injected, which only the in-memory runbook can do.
             (true, _, _) => Self::InMemory,
+            // An on-disk `txtx.yml` is authoritative regardless of `--anchor-compat`.
+            (false, _, true) => Self::ExistingOnDisk,
             (false, true, false) => Self::InMemory,
-            (false, true, true) => Self::Neither,
-            (false, false, true) => Self::ExistingOnDisk,
             (false, false, false) => Self::ScaffoldOnDisk,
         }
     }
@@ -622,7 +619,7 @@ async fn write_and_execute_iac(
                         cmd.artifacts_path.as_deref(),
                     )?);
                 }
-                RunbookExecutionMode::ExistingOnDisk | RunbookExecutionMode::Neither => {}
+                RunbookExecutionMode::ExistingOnDisk => {}
             }
         }
 

--- a/crates/cli/src/cli/simnet/mod.rs
+++ b/crates/cli/src/cli/simnet/mod.rs
@@ -506,15 +506,11 @@ fn log_events(
 
 /// How a simnet session decides to execute its deployment runbooks.
 ///
-/// The previous implementation encoded this as three independent booleans
-/// (`has_custom_artifacts_path`, `cmd.anchor_compat`, `txtx_manifest_exists`)
-/// combined into ad-hoc predicates at the call sites. The truth table below
-/// lifts those predicates into one place so every decision downstream is a
-/// single `match` instead of a compound boolean. Semantics are byte-identical
-/// to the pre-refactor version, including the `Neither` fallthrough that the
-/// original logic produced for the anchor-compat-with-existing-txtx case
-/// (preserved deliberately; whether that case is a bug is a separate
-/// question).
+/// Classifies the three runtime inputs that steer execution
+/// (`cmd.artifacts_path.is_some()`, `cmd.anchor_compat`, whether a `txtx.yml`
+/// exists at the simnet's base location) into a single variant. Downstream
+/// callers `match` on the variant instead of recomputing compound boolean
+/// predicates at each decision site.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum RunbookExecutionMode {
     /// A `txtx.yml` already exists on disk: execute it as-is.

--- a/crates/cli/src/cli/simnet/mod.rs
+++ b/crates/cli/src/cli/simnet/mod.rs
@@ -532,45 +532,6 @@ enum RunbookExecutionMode {
 }
 
 impl RunbookExecutionMode {
-    /// Truth table proving equivalence with the pre-refactor boolean form.
-    ///
-    /// Predicates:
-    /// - `H` = `has_custom_artifacts_path` (i.e. `cmd.artifacts_path.is_some()`)
-    /// - `A` = `anchor_compat`
-    /// - `T` = `txtx_exists`
-    ///
-    /// Pre-refactor action tuple, derived from the three compound booleans
-    /// that used to live at lines ~528, ~531, and ~571 of this function
-    /// (see `git show d262afe^`):
-    /// - `on_disk_pre` = `!H && !A && T`          (on-disk pointer set before framework detection)
-    /// - `do_scaffold` = `!H && !A && !T`         (scaffold-on-disk after framework detection; also sets the on-disk pointer)
-    /// - `do_in_mem`   = `H || (A && !T)`         (in-memory runbook after framework detection)
-    ///
-    /// Post-refactor action tuple, driven by the variant this function returns
-    /// and the downstream `match mode`:
-    /// - `ExistingOnDisk`:  `(on_disk_pre=1, do_scaffold=0, do_in_mem=0)`
-    /// - `ScaffoldOnDisk`:  `(on_disk_pre=0, do_scaffold=1, do_in_mem=0)`  (note: `do_scaffold` also writes the on-disk pointer, separately from `on_disk_pre`)
-    /// - `InMemory`:        `(on_disk_pre=0, do_scaffold=0, do_in_mem=1)`
-    /// - `Neither`:         `(on_disk_pre=0, do_scaffold=0, do_in_mem=0)`
-    ///
-    /// Row-by-row equivalence:
-    ///
-    /// | H | A | T | pre-refactor (on_disk_pre, do_scaffold, do_in_mem) | variant          | post-refactor tuple |
-    /// |---|---|---|-----------------------------------------------------|------------------|---------------------|
-    /// | 0 | 0 | 0 | (0, 1, 0)                                           | `ScaffoldOnDisk` | (0, 1, 0) ✓         |
-    /// | 0 | 0 | 1 | (1, 0, 0)                                           | `ExistingOnDisk` | (1, 0, 0) ✓         |
-    /// | 0 | 1 | 0 | (0, 0, 1)                                           | `InMemory`       | (0, 0, 1) ✓         |
-    /// | 0 | 1 | 1 | (0, 0, 0)                                           | `Neither`        | (0, 0, 0) ✓         |
-    /// | 1 | 0 | 0 | (0, 0, 1)                                           | `InMemory`       | (0, 0, 1) ✓         |
-    /// | 1 | 0 | 1 | (0, 0, 1)                                           | `InMemory`       | (0, 0, 1) ✓         |
-    /// | 1 | 1 | 0 | (0, 0, 1)                                           | `InMemory`       | (0, 0, 1) ✓         |
-    /// | 1 | 1 | 1 | (0, 0, 1)                                           | `InMemory`       | (0, 0, 1) ✓         |
-    ///
-    /// All eight rows agree: the refactor is equivalent for every input
-    /// combination. The row worth staring at is `(0, 1, 1)`: both forms
-    /// produce the all-zero tuple, which means neither runbook path runs.
-    /// Whether that is a bug or intentional is a separate question (preserved
-    /// here, flagged as `Neither`).
     fn from_inputs(has_custom_artifacts_path: bool, anchor_compat: bool, txtx_exists: bool) -> Self {
         match (has_custom_artifacts_path, anchor_compat, txtx_exists) {
             // `--artifacts-path` always wins: the custom bin_path has to be

--- a/crates/cli/src/cli/simnet/mod.rs
+++ b/crates/cli/src/cli/simnet/mod.rs
@@ -504,6 +504,47 @@ fn log_events(
     Ok(())
 }
 
+/// How a simnet session decides to execute its deployment runbooks.
+///
+/// The previous implementation encoded this as three independent booleans
+/// (`has_custom_artifacts_path`, `cmd.anchor_compat`, `txtx_manifest_exists`)
+/// combined into ad-hoc predicates at the call sites. The truth table below
+/// lifts those predicates into one place so every decision downstream is a
+/// single `match` instead of a compound boolean. Semantics are byte-identical
+/// to the pre-refactor version, including the `Neither` fallthrough that the
+/// original logic produced for the anchor-compat-with-existing-txtx case
+/// (preserved deliberately; whether that case is a bug is a separate
+/// question).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RunbookExecutionMode {
+    /// A `txtx.yml` already exists on disk: execute it as-is.
+    ExistingOnDisk,
+    /// No `txtx.yml`: scaffold one on disk from the detected framework and
+    /// execute it. Requires framework detection to take effect.
+    ScaffoldOnDisk,
+    /// Execute an in-memory runbook. Triggered by `--artifacts-path` (custom
+    /// `bin_path` injection) or `--anchor-compat` without an existing
+    /// `txtx.yml`. Requires framework detection.
+    InMemory,
+    /// `--anchor-compat` set AND `txtx.yml` exists: the original code fell
+    /// through without setting either data pointer. Preserved as-is.
+    Neither,
+}
+
+impl RunbookExecutionMode {
+    fn from_inputs(has_custom_artifacts_path: bool, anchor_compat: bool, txtx_exists: bool) -> Self {
+        match (has_custom_artifacts_path, anchor_compat, txtx_exists) {
+            // `--artifacts-path` always wins: the custom bin_path has to be
+            // injected, which only the in-memory runbook can do.
+            (true, _, _) => Self::InMemory,
+            (false, true, false) => Self::InMemory,
+            (false, true, true) => Self::Neither,
+            (false, false, true) => Self::ExistingOnDisk,
+            (false, false, false) => Self::ScaffoldOnDisk,
+        }
+    }
+}
+
 async fn write_and_execute_iac(
     cmd: &StartSimnet,
     simnet_events_tx: &Sender<SimnetEvent>,
@@ -521,17 +562,15 @@ async fn write_and_execute_iac(
     let mut in_memory_runbook_data = None;
     let runbook_input = cmd.runbook_input.clone();
 
-    // If there were existing on-disk runbooks, we'll execute those instead of in-memory ones
-    // If there were no existing runbooks and the user requested autopilot, we'll generate and execute in-memory runbooks
-    // If there were no existing runbooks and the user did not request autopilot, we'll generate and execute on-disk runbooks
-    // When --artifacts-path is set, always use in-memory runbooks so the custom bin_path is injected
-    let has_custom_artifacts_path = cmd.artifacts_path.is_some();
-    let do_execute_in_memory_runbooks =
-        has_custom_artifacts_path || (cmd.anchor_compat && !txtx_manifest_exists);
-    if !has_custom_artifacts_path && !cmd.anchor_compat && txtx_manifest_exists {
-        let runbooks_ids_to_execute = cmd.runbooks.clone();
-        on_disk_runbook_data = Some((txtx_manifest_location.clone(), runbooks_ids_to_execute));
-    };
+    let mode = RunbookExecutionMode::from_inputs(
+        cmd.artifacts_path.is_some(),
+        cmd.anchor_compat,
+        txtx_manifest_exists,
+    );
+
+    if mode == RunbookExecutionMode::ExistingOnDisk {
+        on_disk_runbook_data = Some((txtx_manifest_location.clone(), cmd.runbooks.clone()));
+    }
 
     // Are we in a project directory?
     if let Ok(deployment) = detect_program_frameworks(
@@ -566,31 +605,28 @@ async fn write_and_execute_iac(
                 }
             }
 
-            // Is infrastructure-as-code (IaC) already setup?
-            let do_write_scaffold =
-                !has_custom_artifacts_path && !cmd.anchor_compat && !txtx_manifest_exists;
-            if do_write_scaffold {
-                // Scaffold IaC
-                scaffold_iac_layout(
-                    &framework,
-                    &programs,
-                    &base_location,
-                    cmd.skip_runbook_generation_prompts,
-                )?;
-                let runbooks_ids_to_execute = cmd.runbooks.clone();
-                on_disk_runbook_data =
-                    Some((txtx_manifest_location.clone(), runbooks_ids_to_execute));
-            }
-
-            if do_execute_in_memory_runbooks {
-                in_memory_runbook_data = Some(scaffold_in_memory_iac(
-                    &framework,
-                    &programs,
-                    &genesis_accounts,
-                    &accounts,
-                    &accounts_dir,
-                    cmd.artifacts_path.as_deref(),
-                )?);
+            match mode {
+                RunbookExecutionMode::ScaffoldOnDisk => {
+                    scaffold_iac_layout(
+                        &framework,
+                        &programs,
+                        &base_location,
+                        cmd.skip_runbook_generation_prompts,
+                    )?;
+                    on_disk_runbook_data =
+                        Some((txtx_manifest_location.clone(), cmd.runbooks.clone()));
+                }
+                RunbookExecutionMode::InMemory => {
+                    in_memory_runbook_data = Some(scaffold_in_memory_iac(
+                        &framework,
+                        &programs,
+                        &genesis_accounts,
+                        &accounts,
+                        &accounts_dir,
+                        cmd.artifacts_path.as_deref(),
+                    )?);
+                }
+                RunbookExecutionMode::ExistingOnDisk | RunbookExecutionMode::Neither => {}
             }
         }
 

--- a/crates/cli/src/cli/simnet/mod.rs
+++ b/crates/cli/src/cli/simnet/mod.rs
@@ -532,6 +532,45 @@ enum RunbookExecutionMode {
 }
 
 impl RunbookExecutionMode {
+    /// Truth table proving equivalence with the pre-refactor boolean form.
+    ///
+    /// Predicates:
+    /// - `H` = `has_custom_artifacts_path` (i.e. `cmd.artifacts_path.is_some()`)
+    /// - `A` = `anchor_compat`
+    /// - `T` = `txtx_exists`
+    ///
+    /// Pre-refactor action tuple, derived from the three compound booleans
+    /// that used to live at lines ~528, ~531, and ~571 of this function
+    /// (see `git show d262afe^`):
+    /// - `on_disk_pre` = `!H && !A && T`          (on-disk pointer set before framework detection)
+    /// - `do_scaffold` = `!H && !A && !T`         (scaffold-on-disk after framework detection; also sets the on-disk pointer)
+    /// - `do_in_mem`   = `H || (A && !T)`         (in-memory runbook after framework detection)
+    ///
+    /// Post-refactor action tuple, driven by the variant this function returns
+    /// and the downstream `match mode`:
+    /// - `ExistingOnDisk`:  `(on_disk_pre=1, do_scaffold=0, do_in_mem=0)`
+    /// - `ScaffoldOnDisk`:  `(on_disk_pre=0, do_scaffold=1, do_in_mem=0)`  (note: `do_scaffold` also writes the on-disk pointer, separately from `on_disk_pre`)
+    /// - `InMemory`:        `(on_disk_pre=0, do_scaffold=0, do_in_mem=1)`
+    /// - `Neither`:         `(on_disk_pre=0, do_scaffold=0, do_in_mem=0)`
+    ///
+    /// Row-by-row equivalence:
+    ///
+    /// | H | A | T | pre-refactor (on_disk_pre, do_scaffold, do_in_mem) | variant          | post-refactor tuple |
+    /// |---|---|---|-----------------------------------------------------|------------------|---------------------|
+    /// | 0 | 0 | 0 | (0, 1, 0)                                           | `ScaffoldOnDisk` | (0, 1, 0) ✓         |
+    /// | 0 | 0 | 1 | (1, 0, 0)                                           | `ExistingOnDisk` | (1, 0, 0) ✓         |
+    /// | 0 | 1 | 0 | (0, 0, 1)                                           | `InMemory`       | (0, 0, 1) ✓         |
+    /// | 0 | 1 | 1 | (0, 0, 0)                                           | `Neither`        | (0, 0, 0) ✓         |
+    /// | 1 | 0 | 0 | (0, 0, 1)                                           | `InMemory`       | (0, 0, 1) ✓         |
+    /// | 1 | 0 | 1 | (0, 0, 1)                                           | `InMemory`       | (0, 0, 1) ✓         |
+    /// | 1 | 1 | 0 | (0, 0, 1)                                           | `InMemory`       | (0, 0, 1) ✓         |
+    /// | 1 | 1 | 1 | (0, 0, 1)                                           | `InMemory`       | (0, 0, 1) ✓         |
+    ///
+    /// All eight rows agree: the refactor is equivalent for every input
+    /// combination. The row worth staring at is `(0, 1, 1)`: both forms
+    /// produce the all-zero tuple, which means neither runbook path runs.
+    /// Whether that is a bug or intentional is a separate question (preserved
+    /// here, flagged as `Neither`).
     fn from_inputs(has_custom_artifacts_path: bool, anchor_compat: bool, txtx_exists: bool) -> Self {
         match (has_custom_artifacts_path, anchor_compat, txtx_exists) {
             // `--artifacts-path` always wins: the custom bin_path has to be

--- a/crates/cli/src/cli/simnet/mod.rs
+++ b/crates/cli/src/cli/simnet/mod.rs
@@ -525,7 +525,11 @@ enum RunbookExecutionMode {
 }
 
 impl RunbookExecutionMode {
-    fn from_inputs(has_custom_artifacts_path: bool, anchor_compat: bool, txtx_exists: bool) -> Self {
+    fn from_inputs(
+        has_custom_artifacts_path: bool,
+        anchor_compat: bool,
+        txtx_exists: bool,
+    ) -> Self {
         match (has_custom_artifacts_path, anchor_compat, txtx_exists) {
             // `--artifacts-path` always wins: the custom bin_path has to be
             // injected, which only the in-memory runbook can do.

--- a/crates/core/src/rpc/full.rs
+++ b/crates/core/src/rpc/full.rs
@@ -28,17 +28,19 @@ use solana_rpc_client_api::response::Response as RpcResponse;
 use solana_sdk_ids::compute_budget;
 use solana_signature::Signature;
 use solana_system_interface::program as system_program;
-use solana_transaction::versioned::VersionedTransaction;
 use solana_transaction_error::TransactionError;
 use solana_transaction_status::{
     EncodedConfirmedTransactionWithStatusMeta, TransactionBinaryEncoding,
-    TransactionConfirmationStatus, TransactionStatus, UiConfirmedBlock, UiTransactionEncoding,
+    TransactionConfirmationStatus, TransactionStatus, UiConfirmedBlock,
 };
 use surfpool_types::{SimnetCommand, TransactionStatusEvent};
 
 use super::{
     RunloopContext, State, SurfnetRpcContext,
-    utils::{decode_and_deserialize, transform_tx_metadata_to_ui_accounts, verify_pubkey},
+    utils::{
+        decode_and_deserialize, decode_rpc_versioned_transaction,
+        transform_tx_metadata_to_ui_accounts, verify_pubkey,
+    },
 };
 use crate::{
     SURFPOOL_IDENTITY_PUBKEY,
@@ -1566,17 +1568,7 @@ impl Full for SurfpoolFullRpc {
         let rpc_start = std::time::Instant::now();
 
         let config = config.unwrap_or_default();
-        let tx_encoding = config
-            .base
-            .encoding
-            .unwrap_or(UiTransactionEncoding::Base58);
-        let binary_encoding = tx_encoding.into_binary_encoding().ok_or_else(|| {
-            Error::invalid_params(format!(
-                "unsupported encoding: {tx_encoding}. Supported encodings: base58, base64"
-            ))
-        })?;
-        let (_, unsanitized_tx) =
-            decode_and_deserialize::<VersionedTransaction>(data, binary_encoding)?;
+        let unsanitized_tx = decode_rpc_versioned_transaction(data, config.base.encoding)?;
         let signatures = unsanitized_tx.signatures.clone();
         let signature = signatures[0];
         // Clone the message before moving the transaction, as we'll need it for error reporting
@@ -1700,22 +1692,10 @@ impl Full for SurfpoolFullRpc {
             return SurfpoolError::sig_verify_replace_recent_blockhash_collision().into();
         }
 
-        let tx_encoding = config.encoding.unwrap_or(UiTransactionEncoding::Base58);
-        let binary_encoding = match tx_encoding.into_binary_encoding() {
-            Some(binary_encoding) => binary_encoding,
-            None => {
-                return Box::pin(async move {
-                    Err(Error::invalid_params(format!(
-                        "unsupported encoding: {tx_encoding}. Supported encodings: base58, base64"
-                    )))
-                });
-            }
+        let mut unsanitized_tx = match decode_rpc_versioned_transaction(data, config.encoding) {
+            Ok(tx) => tx,
+            Err(e) => return Box::pin(async move { Err(e) }),
         };
-        let (_, mut unsanitized_tx) =
-            match decode_and_deserialize::<VersionedTransaction>(data, binary_encoding) {
-                Ok(res) => res,
-                Err(e) => return Box::pin(async move { Err(e) }),
-            };
 
         let SurfnetRpcContext {
             svm_locker,
@@ -2584,12 +2564,12 @@ mod tests {
     };
     use solana_transaction::{
         Transaction,
-        versioned::{Legacy, TransactionVersion},
+        versioned::{Legacy, TransactionVersion, VersionedTransaction},
     };
     use solana_transaction_error::TransactionError;
     use solana_transaction_status::{
         EncodedTransaction, EncodedTransactionWithStatusMeta, UiCompiledInstruction, UiMessage,
-        UiRawMessage, UiTransaction,
+        UiRawMessage, UiTransaction, UiTransactionEncoding,
     };
     use surfpool_types::{SimnetCommand, TransactionConfirmationStatus};
     use test_case::test_case;

--- a/crates/core/src/rpc/utils.rs
+++ b/crates/core/src/rpc/utils.rs
@@ -218,22 +218,31 @@ pub fn transform_tx_metadata_to_ui_accounts(
         .collect()
 }
 
+/// Substrings that, when present in a lowercased error message, indicate the
+/// remote RPC method is not supported by the upstream (often a public endpoint
+/// that has gated methods behind a 410 Gone response or a custom refusal).
+const METHOD_NOT_SUPPORTED_NEEDLES: &[&str] = &[
+    "not supported",
+    "unsupported",
+    "unavailable",
+    "method blocked",
+    "invalid request",
+    "is blocked",
+    "if you need this method",
+    "client error 410",
+    "410 gone",
+    "(410 gone)",
+    " status 410",
+    "http 410",
+    "client error (410",
+];
+
 /// Returns true if the error indicates the remote method is not supported.
 pub fn is_method_not_supported_error<E: std::fmt::Display>(err: &E) -> bool {
     let msg = err.to_string().to_lowercase();
-    msg.contains("not supported")
-        || msg.contains("unsupported")
-        || msg.contains("unavailable")
-        || msg.contains("method blocked")
-        || msg.contains("invalid request")
-        || msg.contains("is blocked")
-        || msg.contains("if you need this method")
-        || msg.contains("client error 410")
-        || msg.contains("410 gone")
-        || msg.contains("(410 gone)")
-        || msg.contains(" status 410")
-        || msg.contains("http 410")
-        || msg.contains("client error (410")
+    METHOD_NOT_SUPPORTED_NEEDLES
+        .iter()
+        .any(|needle| msg.contains(needle))
 }
 
 pub fn get_default_transaction_config() -> RpcTransactionConfig {

--- a/crates/core/src/rpc/utils.rs
+++ b/crates/core/src/rpc/utils.rs
@@ -181,6 +181,30 @@ where
         .map(|output| (wire_output, output))
 }
 
+/// Decode the RPC `data` parameter of `sendTransaction` and
+/// `simulateTransaction` into a `solana_transaction::VersionedTransaction`.
+///
+/// Both methods accept a `UiTransactionEncoding` on their config that defaults
+/// to `Base58`, map it to the internal `TransactionBinaryEncoding`, and feed
+/// the result into `decode_and_deserialize`. The mapping can fail (the RPC
+/// only accepts base58 and base64), which is reported back as an
+/// `Error::invalid_params` listing the supported encodings.
+pub fn decode_rpc_versioned_transaction(
+    data: String,
+    encoding: Option<UiTransactionEncoding>,
+) -> Result<solana_transaction::versioned::VersionedTransaction> {
+    let tx_encoding = encoding.unwrap_or(UiTransactionEncoding::Base58);
+    let binary_encoding = tx_encoding.into_binary_encoding().ok_or_else(|| {
+        Error::invalid_params(format!(
+            "unsupported encoding: {tx_encoding}. Supported encodings: base58, base64"
+        ))
+    })?;
+    let (_, unsanitized_tx) = decode_and_deserialize::<
+        solana_transaction::versioned::VersionedTransaction,
+    >(data, binary_encoding)?;
+    Ok(unsanitized_tx)
+}
+
 pub fn transform_tx_metadata_to_ui_accounts(
     meta: TransactionMetadata,
     message: &VersionedMessage,

--- a/crates/core/src/storage/diesel_common.rs
+++ b/crates/core/src/storage/diesel_common.rs
@@ -1,0 +1,96 @@
+//! Shared helpers for the diesel-backed `Storage` implementations.
+//!
+//! `SqliteStorage` and `PostgresStorage` used to carry byte-identical copies
+//! of the serde_json-based key/value codec and of the `QueryableByName` row
+//! structs. The codec is pure serde and the row shape is identical across
+//! dialects (three `TEXT` columns plus one `BIGINT` for counts), so nothing
+//! about them is dialect-specific. This module consolidates them so the two
+//! backends only need to own the truly dialect-specific pieces: connection
+//! type, SQL placeholders (`?` vs `$N`), and upsert syntax.
+//!
+//! The free functions take a `backend_name: &'static str` (e.g. `"SQLite"` /
+//! `"PostgreSQL"`) so that any error the caller surfaces names the correct
+//! backend; the hand-written impls previously hard-coded this via a per-file
+//! `NAME` const.
+
+use serde::{Deserialize, Serialize};
+// The `QueryableByName` derive expands to paths rooted at `diesel::`, so we
+// also re-bind the re-exported crate under that name at the module level.
+use surfpool_db::diesel::{self, QueryableByName, sql_types::Text};
+
+use crate::storage::{StorageError, StorageResult};
+
+#[derive(QueryableByName, Debug)]
+pub(crate) struct KvRecord {
+    #[diesel(sql_type = Text)]
+    pub key: String,
+    #[diesel(sql_type = Text)]
+    pub value: String,
+}
+
+#[derive(QueryableByName, Debug)]
+pub(crate) struct ValueRecord {
+    #[diesel(sql_type = Text)]
+    pub value: String,
+}
+
+#[derive(QueryableByName, Debug)]
+pub(crate) struct KeyRecord {
+    #[diesel(sql_type = Text)]
+    pub key: String,
+}
+
+#[derive(QueryableByName, Debug)]
+pub(crate) struct CountRecord {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    pub count: i64,
+}
+
+pub(crate) fn serialize_key<K: Serialize>(
+    backend_name: &'static str,
+    table_name: &str,
+    key: &K,
+) -> StorageResult<String> {
+    trace!("Serializing key for table '{}'", table_name);
+    let result = serde_json::to_string(key)
+        .map_err(|e| StorageError::SerializeKeyError(backend_name.into(), e));
+    if let Ok(ref serialized) = result {
+        trace!("Key serialized successfully: {}", serialized);
+    }
+    result
+}
+
+pub(crate) fn serialize_value<V: Serialize>(
+    backend_name: &'static str,
+    table_name: &str,
+    value: &V,
+) -> StorageResult<String> {
+    trace!("Serializing value for table '{}'", table_name);
+    let result = serde_json::to_string(value)
+        .map_err(|e| StorageError::SerializeValueError(backend_name.into(), e));
+    if let Ok(ref serialized) = result {
+        trace!(
+            "Value serialized successfully, length: {} chars",
+            serialized.len()
+        );
+    }
+    result
+}
+
+pub(crate) fn deserialize_value<V: for<'de> Deserialize<'de>>(
+    backend_name: &'static str,
+    table_name: &str,
+    value_str: &str,
+) -> StorageResult<V> {
+    trace!(
+        "Deserializing value from table '{}', input length: {} chars",
+        table_name,
+        value_str.len()
+    );
+    let result = serde_json::from_str(value_str)
+        .map_err(|e| StorageError::DeserializeValueError(backend_name.into(), e));
+    if result.is_ok() {
+        trace!("Value deserialized successfully");
+    }
+    result
+}

--- a/crates/core/src/storage/diesel_common.rs
+++ b/crates/core/src/storage/diesel_common.rs
@@ -1,17 +1,15 @@
 //! Shared helpers for the diesel-backed `Storage` implementations.
 //!
-//! `SqliteStorage` and `PostgresStorage` used to carry byte-identical copies
-//! of the serde_json-based key/value codec and of the `QueryableByName` row
-//! structs. The codec is pure serde and the row shape is identical across
-//! dialects (three `TEXT` columns plus one `BIGINT` for counts), so nothing
-//! about them is dialect-specific. This module consolidates them so the two
-//! backends only need to own the truly dialect-specific pieces: connection
-//! type, SQL placeholders (`?` vs `$N`), and upsert syntax.
+//! Both `SqliteStorage` and `PostgresStorage` speak the same wire shape:
+//! the key/value codec is pure `serde_json`, and every row they load is one
+//! of four fixed `QueryableByName` shapes (three `TEXT` columns or a single
+//! `BIGINT` for counts). This module owns those pieces so the per-backend
+//! modules only carry the dialect-specific bits (connection type, SQL
+//! placeholders `?` vs `$N`, upsert syntax, WAL management).
 //!
-//! The free functions take a `backend_name: &'static str` (e.g. `"SQLite"` /
-//! `"PostgreSQL"`) so that any error the caller surfaces names the correct
-//! backend; the hand-written impls previously hard-coded this via a per-file
-//! `NAME` const.
+//! The codec helpers take a `backend_name: &'static str` (e.g. `"SQLite"` /
+//! `"PostgreSQL"`) so `StorageError` variants surfaced by the caller name
+//! the correct backend.
 
 use serde::{Deserialize, Serialize};
 // The `QueryableByName` derive expands to paths rooted at `diesel::`, so we

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+mod diesel_common;
 mod fifo_map;
 mod hash_map;
 mod overlay;

--- a/crates/core/src/storage/postgres.rs
+++ b/crates/core/src/storage/postgres.rs
@@ -6,14 +6,20 @@ use std::{
 use log::debug;
 use serde::{Deserialize, Serialize};
 use surfpool_db::diesel::{
-    self, QueryableByName, RunQueryDsl,
+    self, RunQueryDsl,
     connection::SimpleConnection,
     r2d2::{ConnectionManager, Pool},
     sql_query,
     sql_types::Text,
 };
 
-use crate::storage::{Storage, StorageConstructor, StorageError, StorageResult};
+use crate::storage::{
+    Storage, StorageConstructor, StorageError, StorageResult,
+    diesel_common::{
+        CountRecord, KeyRecord, KvRecord, ValueRecord, deserialize_value, serialize_key,
+        serialize_value,
+    },
+};
 
 /// Global shared connection pools keyed by database URL.
 /// This allows multiple PostgresStorage instances to share the same pool,
@@ -49,32 +55,6 @@ fn get_or_create_shared_pool(
 
     pools_guard.insert(database_url.to_string(), pool.clone());
     Ok(pool)
-}
-
-#[derive(QueryableByName, Debug)]
-struct KvRecord {
-    #[diesel(sql_type = Text)]
-    key: String,
-    #[diesel(sql_type = Text)]
-    value: String,
-}
-
-#[derive(QueryableByName, Debug)]
-struct ValueRecord {
-    #[diesel(sql_type = Text)]
-    value: String,
-}
-
-#[derive(QueryableByName, Debug)]
-struct KeyRecord {
-    #[diesel(sql_type = Text)]
-    key: String,
-}
-
-#[derive(QueryableByName, Debug)]
-struct CountRecord {
-    #[diesel(sql_type = diesel::sql_types::BigInt)]
-    count: i64,
 }
 
 #[derive(Clone)]
@@ -118,43 +98,6 @@ where
         Ok(())
     }
 
-    fn serialize_key(&self, key: &K) -> StorageResult<String> {
-        trace!("Serializing key for table '{}'", self.table_name);
-        let result =
-            serde_json::to_string(key).map_err(|e| StorageError::SerializeKeyError(NAME.into(), e));
-        if let Ok(ref serialized) = result {
-            trace!("Key serialized successfully: {}", serialized);
-        }
-        result
-    }
-
-    fn serialize_value(&self, value: &V) -> StorageResult<String> {
-        trace!("Serializing value for table '{}'", self.table_name);
-        let result = serde_json::to_string(value)
-            .map_err(|e| StorageError::SerializeValueError(NAME.into(), e));
-        if let Ok(ref serialized) = result {
-            trace!(
-                "Value serialized successfully, length: {} chars",
-                serialized.len()
-            );
-        }
-        result
-    }
-
-    fn deserialize_value(&self, value_str: &str) -> StorageResult<V> {
-        trace!(
-            "Deserializing value from table '{}', input length: {} chars",
-            self.table_name,
-            value_str.len()
-        );
-        let result = serde_json::from_str(value_str)
-            .map_err(|e| StorageError::DeserializeValueError(NAME.into(), e));
-        if result.is_ok() {
-            trace!("Value deserialized successfully");
-        }
-        result
-    }
-
     fn load_value_from_db(&self, key_str: &str) -> StorageResult<Option<V>> {
         debug!("Loading value from DB for key: {}", key_str);
         let query = sql_query(format!(
@@ -173,7 +116,7 @@ where
 
         if let Some(record) = records.into_iter().next() {
             debug!("Found record for key: {}", key_str);
-            let value = self.deserialize_value(&record.value)?;
+            let value = deserialize_value(NAME, &self.table_name, &record.value)?;
             Ok(Some(value))
         } else {
             debug!("No record found for key: {}", key_str);
@@ -189,8 +132,8 @@ where
 {
     fn store(&mut self, key: K, value: V) -> StorageResult<()> {
         debug!("Storing value in table '{}", self.table_name);
-        let key_str = self.serialize_key(&key)?;
-        let value_str = self.serialize_value(&value)?;
+        let key_str = serialize_key(NAME, &self.table_name, &key)?;
+        let value_str = serialize_value(NAME, &self.table_name, &value)?;
 
         // Use PostgreSQL UPSERT syntax with ON CONFLICT
         let query = sql_query(format!(
@@ -217,14 +160,14 @@ where
 
     fn get(&self, key: &K) -> StorageResult<Option<V>> {
         debug!("Getting value from table '{}", self.table_name);
-        let key_str = self.serialize_key(key)?;
+        let key_str = serialize_key(NAME, &self.table_name, key)?;
 
         self.load_value_from_db(&key_str)
     }
 
     fn take(&mut self, key: &K) -> StorageResult<Option<V>> {
         debug!("Taking value from table '{}'", self.table_name);
-        let key_str = self.serialize_key(key)?;
+        let key_str = serialize_key(NAME, &self.table_name, key)?;
 
         // If not in cache, try to load from database
         if let Some(value) = self.load_value_from_db(&key_str)? {

--- a/crates/core/src/storage/sqlite.rs
+++ b/crates/core/src/storage/sqlite.rs
@@ -9,14 +9,20 @@ use std::{
 use log::debug;
 use serde::{Deserialize, Serialize};
 use surfpool_db::diesel::{
-    self, QueryableByName, RunQueryDsl,
+    self, RunQueryDsl,
     connection::SimpleConnection,
     r2d2::{ConnectionManager, Pool},
     sql_query,
     sql_types::Text,
 };
 
-use crate::storage::{Storage, StorageConstructor, StorageError, StorageResult};
+use crate::storage::{
+    Storage, StorageConstructor, StorageError, StorageResult,
+    diesel_common::{
+        CountRecord, KeyRecord, KvRecord, ValueRecord, deserialize_value, serialize_key,
+        serialize_value,
+    },
+};
 
 /// Applies pragmas when each pool connection is created.
 #[derive(Debug)]
@@ -93,32 +99,6 @@ fn get_or_create_shared_pool(
 
     guard.insert(connection_string.to_string(), pool.clone());
     Ok(pool)
-}
-
-#[derive(QueryableByName, Debug)]
-struct KvRecord {
-    #[diesel(sql_type = Text)]
-    key: String,
-    #[diesel(sql_type = Text)]
-    value: String,
-}
-
-#[derive(QueryableByName, Debug)]
-struct ValueRecord {
-    #[diesel(sql_type = Text)]
-    value: String,
-}
-
-#[derive(QueryableByName, Debug)]
-struct KeyRecord {
-    #[diesel(sql_type = Text)]
-    key: String,
-}
-
-#[derive(QueryableByName, Debug)]
-struct CountRecord {
-    #[diesel(sql_type = diesel::sql_types::BigInt)]
-    count: i64,
 }
 
 #[derive(Clone)]
@@ -236,43 +216,6 @@ where
         Ok(())
     }
 
-    fn serialize_key(&self, key: &K) -> StorageResult<String> {
-        trace!("Serializing key for table '{}'", self.table_name);
-        let result =
-            serde_json::to_string(key).map_err(|e| StorageError::SerializeKeyError(NAME.into(), e));
-        if let Ok(ref serialized) = result {
-            trace!("Key serialized successfully: {}", serialized);
-        }
-        result
-    }
-
-    fn serialize_value(&self, value: &V) -> StorageResult<String> {
-        trace!("Serializing value for table '{}'", self.table_name);
-        let result = serde_json::to_string(value)
-            .map_err(|e| StorageError::SerializeValueError(NAME.into(), e));
-        if let Ok(ref serialized) = result {
-            trace!(
-                "Value serialized successfully, length: {} chars",
-                serialized.len()
-            );
-        }
-        result
-    }
-
-    fn deserialize_value(&self, value_str: &str) -> StorageResult<V> {
-        trace!(
-            "Deserializing value from table '{}', input length: {} chars",
-            self.table_name,
-            value_str.len()
-        );
-        let result = serde_json::from_str(value_str)
-            .map_err(|e| StorageError::DeserializeValueError(NAME.into(), e));
-        if result.is_ok() {
-            trace!("Value deserialized successfully");
-        }
-        result
-    }
-
     fn load_value_from_db(&self, key_str: &str) -> StorageResult<Option<V>> {
         debug!("Loading value from DB for key: {}", key_str);
         let query = sql_query(format!(
@@ -291,7 +234,7 @@ where
 
         if let Some(record) = records.into_iter().next() {
             debug!("Found record for key: {}", key_str);
-            let value = self.deserialize_value(&record.value)?;
+            let value = deserialize_value(NAME, &self.table_name, &record.value)?;
             Ok(Some(value))
         } else {
             debug!("No record found for key: {}", key_str);
@@ -307,8 +250,8 @@ where
 {
     fn store(&mut self, key: K, value: V) -> StorageResult<()> {
         debug!("Storing value in table '{}", self.table_name);
-        let key_str = self.serialize_key(&key)?;
-        let value_str = self.serialize_value(&value)?;
+        let key_str = serialize_key(NAME, &self.table_name, &key)?;
+        let value_str = serialize_value(NAME, &self.table_name, &value)?;
 
         // Use prepared statement with sql_query for better safety
         let query = sql_query(format!(
@@ -332,14 +275,14 @@ where
 
     fn get(&self, key: &K) -> StorageResult<Option<V>> {
         debug!("Getting value from table '{}", self.table_name);
-        let key_str = self.serialize_key(key)?;
+        let key_str = serialize_key(NAME, &self.table_name, key)?;
 
         self.load_value_from_db(&key_str)
     }
 
     fn take(&mut self, key: &K) -> StorageResult<Option<V>> {
         debug!("Taking value from table '{}'", self.table_name);
-        let key_str = self.serialize_key(key)?;
+        let key_str = serialize_key(NAME, &self.table_name, key)?;
 
         // If not in cache, try to load from database
         if let Some(value) = self.load_value_from_db(&key_str)? {

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -1216,10 +1216,29 @@ impl SurfnetSvm {
     ) -> SurfpoolResult<()> {
         let is_deleted_account = account == &Account::default();
 
-        self.sync_account_in_db(pubkey, account, is_deleted_account)?;
+        // Mirror the SVM state into the backing database. The inner SVM is
+        // already up to date by the time this function runs; the database is
+        // the side-effect target.
+        if is_deleted_account {
+            self.inner.delete_account_in_db(pubkey)?;
+        } else {
+            self.inner
+                .set_account_in_db(*pubkey, account.clone().into())?;
+        }
 
         if is_deleted_account {
-            self.mark_account_offline_and_unindex(pubkey)?;
+            // Record the account as offline so the surfnet does not re-fetch
+            // it from the upstream RPC, then drop any stale index entries
+            // that pointed at its prior on-chain state.
+            self.offline_accounts.store(
+                pubkey.to_string(),
+                OfflineAccountConfig {
+                    include_owned_accounts: false,
+                },
+            )?;
+            if let Some(old_account) = self.get_account(pubkey)? {
+                self.remove_from_indexes(pubkey, &old_account)?;
+            }
             return Ok(());
         }
 
@@ -1241,40 +1260,6 @@ impl SurfnetSvm {
             self.index_token_account_variant(pubkey, &pubkey_str, account)?;
             self.index_mint_account_variant(pubkey, account)?;
             self.index_token_2022_mint_extensions(pubkey, account)?;
-        }
-        Ok(())
-    }
-
-    /// Mirror a post-transaction account update from the inner SVM into the
-    /// backing database. The SVM already reflects the new state; only the
-    /// database needs the side-effect.
-    fn sync_account_in_db(
-        &mut self,
-        pubkey: &Pubkey,
-        account: &Account,
-        is_deleted: bool,
-    ) -> SurfpoolResult<()> {
-        if is_deleted {
-            self.inner.delete_account_in_db(pubkey)?;
-        } else {
-            self.inner
-                .set_account_in_db(*pubkey, account.clone().into())?;
-        }
-        Ok(())
-    }
-
-    /// Record that an account is now offline (so the surfnet knows not to
-    /// re-fetch it from the upstream RPC) and drop any stale index entries
-    /// for its prior on-chain state.
-    fn mark_account_offline_and_unindex(&mut self, pubkey: &Pubkey) -> SurfpoolResult<()> {
-        self.offline_accounts.store(
-            pubkey.to_string(),
-            OfflineAccountConfig {
-                include_owned_accounts: false,
-            },
-        )?;
-        if let Some(old_account) = self.get_account(pubkey)? {
-            self.remove_from_indexes(pubkey, &old_account)?;
         }
         Ok(())
     }

--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -295,6 +295,46 @@ pub struct SurfnetSvm {
     pub last_checkpoint_slot: u64,
 }
 
+/// Add `pubkey_str` to the pubkey-list at `key`, creating the entry when absent
+/// and deduplicating on insert. The shared-pubkey indexes (`accounts_by_owner`,
+/// `token_accounts_by_owner`, `token_accounts_by_mint`,
+/// `token_accounts_by_delegate`) map one pubkey-string to the list of account
+/// pubkey-strings that share the indexed trait; the `contains` guard prevents
+/// double-registration when `update_account_registries` is called on an
+/// unchanged account.
+fn add_pubkey_to_index(
+    index: &mut Box<dyn Storage<String, Vec<String>>>,
+    key: String,
+    pubkey_str: &str,
+) -> SurfpoolResult<()> {
+    let mut accounts = index.get(&key).ok().flatten().unwrap_or_default();
+    if !accounts.iter().any(|pk| pk == pubkey_str) {
+        accounts.push(pubkey_str.to_string());
+        index.store(key, accounts)?;
+    }
+    Ok(())
+}
+
+/// Remove `pubkey_str` from the pubkey-list at `key`. When the list becomes
+/// empty the entry is taken rather than stored, so downstream `keys()`
+/// iterations don't surface empty buckets.
+fn remove_pubkey_from_index(
+    index: &mut Box<dyn Storage<String, Vec<String>>>,
+    key: &str,
+    pubkey_str: &str,
+) -> SurfpoolResult<()> {
+    let key_owned = key.to_string();
+    if let Some(mut accounts) = index.get(&key_owned).ok().flatten() {
+        accounts.retain(|pk| pk != pubkey_str);
+        if accounts.is_empty() {
+            index.take(&key_owned)?;
+        } else {
+            index.store(key_owned, accounts)?;
+        }
+    }
+    Ok(())
+}
+
 impl SurfnetSvm {
     pub fn default() -> (Self, Receiver<SimnetEvent>, Receiver<GeyserEvent>) {
         Self::new(None, "0").unwrap()
@@ -1176,124 +1216,152 @@ impl SurfnetSvm {
     ) -> SurfpoolResult<()> {
         let is_deleted_account = account == &Account::default();
 
-        // When this function is called after processing a transaction, the account is already updated
-        // in the inner SVM. However, the database hasn't been updated yet, so we need to manually update the db.
-        if is_deleted_account {
-            // This amounts to deleting the account from the db if the account is deleted in the SVM
-            self.inner.delete_account_in_db(pubkey)?;
-        } else {
-            // Or updating the db account to match the SVM account if not deleted
-            self.inner
-                .set_account_in_db(*pubkey, account.clone().into())?;
-        }
+        self.sync_account_in_db(pubkey, account, is_deleted_account)?;
 
         if is_deleted_account {
-            self.offline_accounts.store(
-                pubkey.to_string(),
-                OfflineAccountConfig {
-                    include_owned_accounts: false,
-                },
-            )?;
-            if let Some(old_account) = self.get_account(pubkey)? {
-                self.remove_from_indexes(pubkey, &old_account)?;
-            }
+            self.mark_account_offline_and_unindex(pubkey)?;
             return Ok(());
         }
 
-        // only update our indexes if the account exists in the svm accounts db
+        // Drop any stale owner/mint/delegate entries for the prior version of
+        // the account before indexing the new one; otherwise a change of
+        // owner would leave the old owner's bucket pointing at `pubkey`.
         if let Some(old_account) = self.get_account(pubkey)? {
             self.remove_from_indexes(pubkey, &old_account)?;
         }
-        // add to owner index (check for duplicates)
-        let owner_key = account.owner.to_string();
+
         let pubkey_str = pubkey.to_string();
-        let mut owner_accounts = self
-            .accounts_by_owner
-            .get(&owner_key)
-            .ok()
-            .flatten()
-            .unwrap_or_default();
-        if !owner_accounts.contains(&pubkey_str) {
-            owner_accounts.push(pubkey_str.clone());
-            self.accounts_by_owner.store(owner_key, owner_accounts)?;
-        }
+        add_pubkey_to_index(
+            &mut self.accounts_by_owner,
+            account.owner.to_string(),
+            &pubkey_str,
+        )?;
 
-        // if it's a token account, update token-specific indexes
         if is_supported_token_program(&account.owner) {
-            if let Ok(token_account) = TokenAccount::unpack(&account.data) {
-                // index by owner -> check for duplicates
-                let owner_key = token_account.owner().to_string();
-                let mut token_owner_accounts = self
-                    .token_accounts_by_owner
-                    .get(&owner_key)
-                    .ok()
-                    .flatten()
-                    .unwrap_or_default();
-                if !token_owner_accounts.contains(&pubkey_str) {
-                    token_owner_accounts.push(pubkey_str.clone());
-                    self.token_accounts_by_owner
-                        .store(owner_key, token_owner_accounts)?;
-                }
-
-                // index by mint -> check for duplicates
-                let mint_key = token_account.mint().to_string();
-                let mut mint_accounts = self
-                    .token_accounts_by_mint
-                    .get(&mint_key)
-                    .ok()
-                    .flatten()
-                    .unwrap_or_default();
-                if !mint_accounts.contains(&pubkey_str) {
-                    mint_accounts.push(pubkey_str.clone());
-                    self.token_accounts_by_mint.store(mint_key, mint_accounts)?;
-                }
-
-                if let COption::Some(delegate) = token_account.delegate() {
-                    let delegate_key = delegate.to_string();
-                    let mut delegate_accounts = self
-                        .token_accounts_by_delegate
-                        .get(&delegate_key)
-                        .ok()
-                        .flatten()
-                        .unwrap_or_default();
-                    if !delegate_accounts.contains(&pubkey_str) {
-                        delegate_accounts.push(pubkey_str);
-                        self.token_accounts_by_delegate
-                            .store(delegate_key, delegate_accounts)?;
-                    }
-                }
-                self.token_accounts
-                    .store(pubkey.to_string(), token_account)?;
-            }
-
-            if let Ok(mint_account) = MintAccount::unpack(&account.data) {
-                self.token_mints.store(pubkey.to_string(), mint_account)?;
-            }
-
-            if let Ok(mint) =
-                StateWithExtensions::<spl_token_2022_interface::state::Mint>::unpack(&account.data)
-            {
-                let unix_timestamp = self.inner.get_sysvar::<Clock>().unix_timestamp;
-                let interest_bearing_config = mint
-                    .get_extension::<InterestBearingConfig>()
-                    .map(|x| (*x, unix_timestamp))
-                    .ok();
-                let scaled_ui_amount_config = mint
-                    .get_extension::<ScaledUiAmountConfig>()
-                    .map(|x| (*x, unix_timestamp))
-                    .ok();
-                let additional_data: SerializableAccountAdditionalData = AccountAdditionalDataV3 {
-                    spl_token_additional_data: Some(SplTokenAdditionalDataV2 {
-                        decimals: mint.base.decimals,
-                        interest_bearing_config,
-                        scaled_ui_amount_config,
-                    }),
-                }
-                .into();
-                self.account_associated_data
-                    .store(pubkey.to_string(), additional_data)?;
-            };
+            self.index_token_account_variant(pubkey, &pubkey_str, account)?;
+            self.index_mint_account_variant(pubkey, account)?;
+            self.index_token_2022_mint_extensions(pubkey, account)?;
         }
+        Ok(())
+    }
+
+    /// Mirror a post-transaction account update from the inner SVM into the
+    /// backing database. The SVM already reflects the new state; only the
+    /// database needs the side-effect.
+    fn sync_account_in_db(
+        &mut self,
+        pubkey: &Pubkey,
+        account: &Account,
+        is_deleted: bool,
+    ) -> SurfpoolResult<()> {
+        if is_deleted {
+            self.inner.delete_account_in_db(pubkey)?;
+        } else {
+            self.inner
+                .set_account_in_db(*pubkey, account.clone().into())?;
+        }
+        Ok(())
+    }
+
+    /// Record that an account is now offline (so the surfnet knows not to
+    /// re-fetch it from the upstream RPC) and drop any stale index entries
+    /// for its prior on-chain state.
+    fn mark_account_offline_and_unindex(&mut self, pubkey: &Pubkey) -> SurfpoolResult<()> {
+        self.offline_accounts.store(
+            pubkey.to_string(),
+            OfflineAccountConfig {
+                include_owned_accounts: false,
+            },
+        )?;
+        if let Some(old_account) = self.get_account(pubkey)? {
+            self.remove_from_indexes(pubkey, &old_account)?;
+        }
+        Ok(())
+    }
+
+    /// If `account.data` decodes as a token account, add it to the
+    /// owner/mint/delegate indexes and cache the unpacked `TokenAccount`.
+    /// A decode failure is treated as "not a token account" (not an error);
+    /// the enclosing call only dispatches here when the owner program is
+    /// already known to be a supported token program.
+    fn index_token_account_variant(
+        &mut self,
+        pubkey: &Pubkey,
+        pubkey_str: &str,
+        account: &Account,
+    ) -> SurfpoolResult<()> {
+        let Ok(token_account) = TokenAccount::unpack(&account.data) else {
+            return Ok(());
+        };
+        add_pubkey_to_index(
+            &mut self.token_accounts_by_owner,
+            token_account.owner().to_string(),
+            pubkey_str,
+        )?;
+        add_pubkey_to_index(
+            &mut self.token_accounts_by_mint,
+            token_account.mint().to_string(),
+            pubkey_str,
+        )?;
+        if let COption::Some(delegate) = token_account.delegate() {
+            add_pubkey_to_index(
+                &mut self.token_accounts_by_delegate,
+                delegate.to_string(),
+                pubkey_str,
+            )?;
+        }
+        self.token_accounts
+            .store(pubkey.to_string(), token_account)?;
+        Ok(())
+    }
+
+    /// If `account.data` decodes as a mint, cache the unpacked `MintAccount`.
+    fn index_mint_account_variant(
+        &mut self,
+        pubkey: &Pubkey,
+        account: &Account,
+    ) -> SurfpoolResult<()> {
+        let Ok(mint_account) = MintAccount::unpack(&account.data) else {
+            return Ok(());
+        };
+        self.token_mints.store(pubkey.to_string(), mint_account)?;
+        Ok(())
+    }
+
+    /// If `account.data` decodes as a Token-2022 mint with extensions,
+    /// snapshot the decimals and rate-limited extension state
+    /// (`InterestBearingConfig`, `ScaledUiAmountConfig`) into
+    /// `account_associated_data` so the RPC layer can serve UI-amount
+    /// conversions without re-parsing the raw account on every request.
+    fn index_token_2022_mint_extensions(
+        &mut self,
+        pubkey: &Pubkey,
+        account: &Account,
+    ) -> SurfpoolResult<()> {
+        let Ok(mint) =
+            StateWithExtensions::<spl_token_2022_interface::state::Mint>::unpack(&account.data)
+        else {
+            return Ok(());
+        };
+        let unix_timestamp = self.inner.get_sysvar::<Clock>().unix_timestamp;
+        let interest_bearing_config = mint
+            .get_extension::<InterestBearingConfig>()
+            .map(|x| (*x, unix_timestamp))
+            .ok();
+        let scaled_ui_amount_config = mint
+            .get_extension::<ScaledUiAmountConfig>()
+            .map(|x| (*x, unix_timestamp))
+            .ok();
+        let additional_data: SerializableAccountAdditionalData = AccountAdditionalDataV3 {
+            spl_token_additional_data: Some(SplTokenAdditionalDataV2 {
+                decimals: mint.base.decimals,
+                interest_bearing_config,
+                scaled_ui_amount_config,
+            }),
+        }
+        .into();
+        self.account_associated_data
+            .store(pubkey.to_string(), additional_data)?;
         Ok(())
     }
 
@@ -1302,61 +1370,32 @@ impl SurfnetSvm {
         pubkey: &Pubkey,
         old_account: &Account,
     ) -> SurfpoolResult<()> {
-        let owner_key = old_account.owner.to_string();
         let pubkey_str = pubkey.to_string();
-        if let Some(mut accounts) = self.accounts_by_owner.get(&owner_key).ok().flatten() {
-            accounts.retain(|pk| pk != &pubkey_str);
-            if accounts.is_empty() {
-                self.accounts_by_owner.take(&owner_key)?;
-            } else {
-                self.accounts_by_owner.store(owner_key, accounts)?;
-            }
-        }
+        remove_pubkey_from_index(
+            &mut self.accounts_by_owner,
+            &old_account.owner.to_string(),
+            &pubkey_str,
+        )?;
 
-        // if it was a token account, remove from token indexes
-        if is_supported_token_program(&old_account.owner) {
-            if let Some(old_token_account) = self.token_accounts.take(&pubkey.to_string())? {
-                let owner_key = old_token_account.owner().to_string();
-                if let Some(mut accounts) =
-                    self.token_accounts_by_owner.get(&owner_key).ok().flatten()
-                {
-                    accounts.retain(|pk| pk != &pubkey_str);
-                    if accounts.is_empty() {
-                        self.token_accounts_by_owner.take(&owner_key)?;
-                    } else {
-                        self.token_accounts_by_owner.store(owner_key, accounts)?;
-                    }
-                }
-
-                let mint_key = old_token_account.mint().to_string();
-                if let Some(mut accounts) =
-                    self.token_accounts_by_mint.get(&mint_key).ok().flatten()
-                {
-                    accounts.retain(|pk| pk != &pubkey_str);
-                    if accounts.is_empty() {
-                        self.token_accounts_by_mint.take(&mint_key)?;
-                    } else {
-                        self.token_accounts_by_mint.store(mint_key, accounts)?;
-                    }
-                }
-
-                if let COption::Some(delegate) = old_token_account.delegate() {
-                    let delegate_key = delegate.to_string();
-                    if let Some(mut accounts) = self
-                        .token_accounts_by_delegate
-                        .get(&delegate_key)
-                        .ok()
-                        .flatten()
-                    {
-                        accounts.retain(|pk| pk != &pubkey_str);
-                        if accounts.is_empty() {
-                            self.token_accounts_by_delegate.take(&delegate_key)?;
-                        } else {
-                            self.token_accounts_by_delegate
-                                .store(delegate_key, accounts)?;
-                        }
-                    }
-                }
+        if is_supported_token_program(&old_account.owner)
+            && let Some(old_token_account) = self.token_accounts.take(&pubkey_str)?
+        {
+            remove_pubkey_from_index(
+                &mut self.token_accounts_by_owner,
+                &old_token_account.owner().to_string(),
+                &pubkey_str,
+            )?;
+            remove_pubkey_from_index(
+                &mut self.token_accounts_by_mint,
+                &old_token_account.mint().to_string(),
+                &pubkey_str,
+            )?;
+            if let COption::Some(delegate) = old_token_account.delegate() {
+                remove_pubkey_from_index(
+                    &mut self.token_accounts_by_delegate,
+                    &delegate.to_string(),
+                    &pubkey_str,
+                )?;
             }
         }
         Ok(())

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -850,6 +850,83 @@ impl TokenProgramDiscriminant {
     }
 }
 
+/// Emits `Serialize`/`Deserialize` impls for the two-variant
+/// (`SplToken2022`, `SplToken`) packable enums `TokenAccount` and
+/// `MintAccount`. The algorithm is identical for both: prepend a
+/// discriminant byte, `pack_into_slice` into a fixed-length buffer, and
+/// base64-encode; reverse on the way in. The only things that vary per
+/// enum are the packed inner types and the human label used in error
+/// messages, so those are the macro parameters.
+macro_rules! impl_token_program_packable_serde {
+    ($enum_name:ident, $ty_2022:ty, $ty_legacy:ty, $label:literal) => {
+        impl Serialize for $enum_name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                let mut bytes = Vec::with_capacity(1 + <$ty_2022>::LEN);
+                match self {
+                    Self::SplToken2022(inner) => {
+                        bytes.push(TokenProgramDiscriminant::SplToken2022.as_byte());
+                        let mut dst = [0u8; <$ty_2022>::LEN];
+                        inner.pack_into_slice(&mut dst);
+                        bytes.extend_from_slice(&dst);
+                    }
+                    Self::SplToken(inner) => {
+                        bytes.push(TokenProgramDiscriminant::SplToken.as_byte());
+                        let mut dst = [0u8; <$ty_legacy>::LEN];
+                        inner.pack_into_slice(&mut dst);
+                        bytes.extend_from_slice(&dst);
+                    }
+                }
+                let encoded = BASE64_STANDARD.encode(&bytes);
+                serializer.serialize_str(&encoded)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $enum_name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let encoded = String::deserialize(deserializer)?;
+                let bytes = BASE64_STANDARD
+                    .decode(&encoded)
+                    .map_err(serde::de::Error::custom)?;
+
+                if bytes.is_empty() {
+                    return Err(serde::de::Error::custom(concat!(
+                        "Empty ",
+                        $label,
+                        " bytes"
+                    )));
+                }
+
+                let discriminant =
+                    TokenProgramDiscriminant::from_byte(bytes[0]).ok_or_else(|| {
+                        serde::de::Error::custom(format!(
+                            concat!("Unknown ", $label, " discriminant: {}"),
+                            bytes[0]
+                        ))
+                    })?;
+                let data = &bytes[1..];
+
+                match discriminant {
+                    TokenProgramDiscriminant::SplToken2022 => {
+                        let inner = <$ty_2022>::unpack(data).map_err(serde::de::Error::custom)?;
+                        Ok($enum_name::SplToken2022(inner))
+                    }
+                    TokenProgramDiscriminant::SplToken => {
+                        let inner =
+                            <$ty_legacy>::unpack(data).map_err(serde::de::Error::custom)?;
+                        Ok($enum_name::SplToken(inner))
+                    }
+                }
+            }
+        }
+    };
+}
+
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum TokenAccount {
     SplToken2022(spl_token_2022_interface::state::Account),
@@ -1009,64 +1086,12 @@ impl TokenAccount {
     }
 }
 
-impl Serialize for TokenAccount {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut bytes = Vec::with_capacity(1 + spl_token_2022_interface::state::Account::LEN);
-        match self {
-            Self::SplToken2022(account) => {
-                bytes.push(TokenProgramDiscriminant::SplToken2022.as_byte());
-                let mut dst = [0u8; spl_token_2022_interface::state::Account::LEN];
-                account.pack_into_slice(&mut dst);
-                bytes.extend_from_slice(&dst);
-            }
-            Self::SplToken(account) => {
-                bytes.push(TokenProgramDiscriminant::SplToken.as_byte());
-                let mut dst = [0u8; spl_token_interface::state::Account::LEN];
-                account.pack_into_slice(&mut dst);
-                bytes.extend_from_slice(&dst);
-            }
-        }
-        let encoded = BASE64_STANDARD.encode(&bytes);
-        serializer.serialize_str(&encoded)
-    }
-}
-
-impl<'de> Deserialize<'de> for TokenAccount {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let encoded = String::deserialize(deserializer)?;
-        let bytes = BASE64_STANDARD
-            .decode(&encoded)
-            .map_err(serde::de::Error::custom)?;
-
-        if bytes.is_empty() {
-            return Err(serde::de::Error::custom("Empty TokenAccount bytes"));
-        }
-
-        let discriminant = TokenProgramDiscriminant::from_byte(bytes[0]).ok_or_else(|| {
-            serde::de::Error::custom(format!("Unknown TokenAccount discriminant: {}", bytes[0]))
-        })?;
-        let data = &bytes[1..];
-
-        match discriminant {
-            TokenProgramDiscriminant::SplToken2022 => {
-                let account = spl_token_2022_interface::state::Account::unpack(data)
-                    .map_err(serde::de::Error::custom)?;
-                Ok(TokenAccount::SplToken2022(account))
-            }
-            TokenProgramDiscriminant::SplToken => {
-                let account = spl_token_interface::state::Account::unpack(data)
-                    .map_err(serde::de::Error::custom)?;
-                Ok(TokenAccount::SplToken(account))
-            }
-        }
-    }
-}
+impl_token_program_packable_serde!(
+    TokenAccount,
+    spl_token_2022_interface::state::Account,
+    spl_token_interface::state::Account,
+    "TokenAccount"
+);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OfflineAccountConfig {
@@ -1079,64 +1104,12 @@ pub enum MintAccount {
     SplToken(spl_token_interface::state::Mint),
 }
 
-impl Serialize for MintAccount {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut bytes = Vec::with_capacity(1 + spl_token_2022_interface::state::Mint::LEN);
-        match self {
-            Self::SplToken2022(mint) => {
-                bytes.push(TokenProgramDiscriminant::SplToken2022.as_byte());
-                let mut dst = [0u8; spl_token_2022_interface::state::Mint::LEN];
-                mint.pack_into_slice(&mut dst);
-                bytes.extend_from_slice(&dst);
-            }
-            Self::SplToken(mint) => {
-                bytes.push(TokenProgramDiscriminant::SplToken.as_byte());
-                let mut dst = [0u8; spl_token_interface::state::Mint::LEN];
-                mint.pack_into_slice(&mut dst);
-                bytes.extend_from_slice(&dst);
-            }
-        }
-        let encoded = BASE64_STANDARD.encode(&bytes);
-        serializer.serialize_str(&encoded)
-    }
-}
-
-impl<'de> Deserialize<'de> for MintAccount {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let encoded = String::deserialize(deserializer)?;
-        let bytes = BASE64_STANDARD
-            .decode(&encoded)
-            .map_err(serde::de::Error::custom)?;
-
-        if bytes.is_empty() {
-            return Err(serde::de::Error::custom("Empty MintAccount bytes"));
-        }
-
-        let discriminant = TokenProgramDiscriminant::from_byte(bytes[0]).ok_or_else(|| {
-            serde::de::Error::custom(format!("Unknown MintAccount discriminant: {}", bytes[0]))
-        })?;
-        let data = &bytes[1..];
-
-        match discriminant {
-            TokenProgramDiscriminant::SplToken2022 => {
-                let mint = spl_token_2022_interface::state::Mint::unpack(data)
-                    .map_err(serde::de::Error::custom)?;
-                Ok(MintAccount::SplToken2022(mint))
-            }
-            TokenProgramDiscriminant::SplToken => {
-                let mint = spl_token_interface::state::Mint::unpack(data)
-                    .map_err(serde::de::Error::custom)?;
-                Ok(MintAccount::SplToken(mint))
-            }
-        }
-    }
-}
+impl_token_program_packable_serde!(
+    MintAccount,
+    spl_token_2022_interface::state::Mint,
+    spl_token_interface::state::Mint,
+    "MintAccount"
+);
 
 impl MintAccount {
     pub fn unpack(bytes: &[u8]) -> SurfpoolResult<Self> {

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -896,9 +896,7 @@ macro_rules! impl_token_program_packable_serde {
 
                 if bytes.is_empty() {
                     return Err(serde::de::Error::custom(concat!(
-                        "Empty ",
-                        $label,
-                        " bytes"
+                        "Empty ", $label, " bytes"
                     )));
                 }
 
@@ -917,8 +915,7 @@ macro_rules! impl_token_program_packable_serde {
                         Ok($enum_name::SplToken2022(inner))
                     }
                     TokenProgramDiscriminant::SplToken => {
-                        let inner =
-                            <$ty_legacy>::unpack(data).map_err(serde::de::Error::custom)?;
+                        let inner = <$ty_legacy>::unpack(data).map_err(serde::de::Error::custom)?;
                         Ok($enum_name::SplToken(inner))
                     }
                 }


### PR DESCRIPTION
I ran [`rust-scope`](https://github.com/cds-rs/rs-scope) against `surfpool`
twice: once hunting for structural duplication, once for complexity
hotspots. Each commit addresses one finding. Collectively about 55 net
lines of DRY come off, and three of the hairier functions pick up phase
helpers. No observable behavior moves.

Commit messages carry the per-commit rationale. This doc is the reviewer's
plan: where to look closely, what I want pushed back on, and what to run.

## How to review

Any order works. If you only have bandwidth for one or two, prioritise
2.2 (hot path, widest behavior surface) and 2.1 (a behavior change
from review feedback, so worth a second look).

Sizes: XS (under a minute), S (a few minutes), M (a careful read), L
(deep dive).

Reviewed commits (unchanged since round one):

| # | Commit | What | Size |
|---|---|---|---|
| 1.1 | `eb878de` | 13-way `\|\|` chain to const needle slice | XS |
| 1.2 | `2c350dc` | Macro-generated `TokenAccount` / `MintAccount` serde | M |
| 1.3 | `2947cf8` | Shared `storage::diesel_common` for SQLite/Postgres | S |
| 2.1 | `d262afe` | `write_and_execute_iac`: three booleans to `RunbookExecutionMode` enum | S |
| 2.2 | `54f6c81` | `update_account_registries` + `remove_from_indexes` phase split | L |
| 2.3 | `080c229` | `simulate_transaction` + `send_transaction` share decode preamble | XS |
|     | `fc3c2d6` | (`docs(cli):` truth table on `from_inputs`; reverted by `1e6aaf1`, see below) | XS |

Follow-ups from round-one review (@MicaiahReid), additive on top of the
reviewed history:

| Commit | What | Size |
|---|---|---|
| `1e6aaf1` | Revert `fc3c2d6` (the maintainer judged the truth table not worth its review cost) | XS |
| `df723fd` | Strip past-state prose from enum doc and `diesel_common` module doc | XS |
| `3e73199` | Collapse `Neither` into `ExistingOnDisk` (behavior change) | S |
| `99fd3e4` | Inline `sync_account_in_db` and `mark_account_offline_and_unindex` | S |


**1.1 (needle slice, XS).** Check that `METHOD_NOT_SUPPORTED_NEEDLES` matches
the original `||` chain at `rpc/utils.rs:222` in both contents and order.
Nothing else has changed.

**1.2 (Token/Mint macro, M).** The macro
`impl_token_program_packable_serde!` at `crates/core/src/types.rs:860`
gets called twice, once for each enum. Verify the substitution by
reading the macro definition and one of the call sites side-by-side: the
four macro parameters (enum name, 2022 inner type, legacy inner type,
error-label string) should end up in obvious places in the generated
impl. If you have `cargo-expand` installed, `cargo expand -p
surfpool-core --lib types 2>/dev/null | sed -n '/impl Serialize for
TokenAccount/,/^}/p'` prints the actual expansion so you can diff it
against `git show 2c350dc^:crates/core/src/types.rs` without squinting.
The macro uses `concat!` to splice error labels at compile time;
confirm the error messages stay byte-identical to the originals.
*Push back on:* the lack of a round-trip test. If you'd rather not merge
without one, I'll add it as an extra commit.

**1.3 (storage helpers, S).** Confirm every deleted helper in `sqlite.rs` /
`postgres.rs` has a corresponding import from `diesel_common`, and the
per-file `NAME` const still reaches every error constructor. *Push back
on:* whether to push further (a `SqlDialect` trait or a SQL-template
macro). I stopped at the dialect-free boundary on purpose, but if the
team wants the next step, it's a reasonable follow-up. *Ask:* if you have
a live Postgres handy, please run
`DATABASE_URL=... cargo test -p surfpool-core --features postgres
storage::postgres`. I couldn't.

**2.1 (mode enum + `3e73199`, S).** Read commits `d262afe` (the
refactor) and `3e73199` (the Neither-collapse behavior change)
together. The final state dispatches `(false, _, true) =>
ExistingOnDisk`, which is a genuine behavior change: users running
`--anchor-compat` with an existing `txtx.yml` will now see that
`txtx.yml` execute instead of nothing. That's the intentional
reading per review feedback.

**2.2 (registries split + `99fd3e4`, L).** Biggest commit, on a hot
path. Review order:

1. The two free-function helpers (`add_pubkey_to_index`,
   `remove_pubkey_from_index`) near the top of `svm.rs`. They encode
   two invariants: dedup on insert, take on empty. If those are right,
   the callers are right.
2. The three phase methods that stayed
   (`index_token_account_variant`, `index_mint_account_variant`,
   `index_token_2022_mint_extensions`) against the original body at
   `git show 54f6c81^:crates/core/src/surfnet/svm.rs:1172`. Ordering
   matters: DB mirror first, then offline-marking-with-early-return on
   delete, then remove stale indexes, then add to new indexes.
3. The trickiest line:
   `if is_supported_token_program(&old_account.owner) && let Some(old_token_account) = self.token_accounts.take(&pubkey_str)?`
   uses `let chain` to avoid re-indenting the original nested `if let`.
   Short-circuit semantics are preserved (if the predicate is false,
   `take` does not run).

`99fd3e4` inlined the two shortest phase methods back per review
feedback. The three remaining phase methods are named by what they
decode and index, so adding another token-related step to any of them
doesn't need a rename. `add_pubkey_to_index` / `remove_pubkey_from_index`
also stay: a single rename couldn't serve all four call sites, which
each carry different semantic meaning (owner, token-owner, token-mint,
token-delegate).

Behavior check: `cargo test -p surfpool-core --lib
surfnet::svm::tests::test_inserting_account_updates` (3 backends).

**2.3 (decode extraction, XS).** The helper is 10 lines in `rpc/utils.rs`.
Verify the sync and async call sites both preserve the error path
end-to-end (same message, same error code). *Push back on:* the name
`decode_rpc_versioned_transaction` if it feels off.

## Tests I ran

```bash
cargo check --workspace --all-targets                               # clean
cargo test -p surfpool-core --lib storage::sqlite                   # 4/4
cargo test -p surfpool-core --lib \
  surfnet::svm::tests::test_inserting_account_updates               # 3/3
cargo test -p surfpool-core --lib rpc::                             # 136/136
```

Postgres integration tests: not run (need a live server). `postgres.rs` is
structurally symmetric with `sqlite.rs` post-refactor, so the same tests
should continue to pass. Hence the ask in 1.3.
