### PR TITLE
feat(core): simulate realistic network conditions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11406,6 +11406,7 @@ dependencies = [
  "opentelemetry-prometheus",
  "opentelemetry_sdk 0.28.0",
  "prometheus",
+ "rand 0.8.5",
  "reqwest 0.12.28",
  "serde",
  "serde_derive",

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -64,6 +64,16 @@ lazy_static::lazy_static! {
 /// We set out snap build to set this environment variable to the real home directory,
 /// because by default, snaps run in a confined environment where the home directory is not
 /// the user's actual home directory.
+fn parse_drop_rate(s: &str) -> Result<f64, String> {
+    let v: f64 = s
+        .parse()
+        .map_err(|_| format!("'{}' is not a valid number", s))?;
+    if !(0.0..=1.0).contains(&v) {
+        return Err(format!("drop rate must be between 0.0 and 1.0, got {}", v));
+    }
+    Ok(v)
+}
+
 pub fn get_home_dir() -> String {
     if let Ok(real_home) = env::var("SNAP_REAL_HOME") {
         let path_buf = PathBuf::from(real_home);
@@ -277,9 +287,14 @@ pub struct StartSimnet {
     /// Skip signature verification for all transactions (eg. surfpool start --skip-signature-verification)
     #[clap(long = "skip-signature-verification", action=ArgAction::SetTrue, default_value = "false")]
     pub skip_signature_verification: bool,
-    /// Skip blockhash validation for all transactions (eg. surfpool start --skip-blockhash-check)
-    #[clap(long = "skip-blockhash-check", action=ArgAction::SetTrue, default_value = "false")]
-    pub skip_blockhash_check: bool,
+    /// Probability (0.0–1.0) that a transaction is randomly dropped, simulating packet loss or leader rejection.
+    /// E.g. 0.1 means 10% of transactions will be dropped. (eg. surfpool start --transaction-drop-rate 0.1)
+    #[arg(long = "transaction-drop-rate", value_parser = parse_drop_rate)]
+    pub transaction_drop_rate: Option<f64>,
+    /// Maximum random delay in milliseconds before executing a transaction, simulating out-of-order execution.
+    /// Each transaction waits a random duration from 0 to this value. (eg. surfpool start --transaction-execution-delay-ms 200)
+    #[arg(long = "transaction-execution-delay-ms")]
+    pub transaction_execution_delay_ms: Option<u64>,
 }
 
 #[derive(clap::ValueEnum, PartialEq, Clone, Debug)]
@@ -447,6 +462,8 @@ impl StartSimnet {
             skip_blockhash_check: self.skip_blockhash_check,
             surfnet_id: self.surfnet_id.clone(),
             snapshot,
+            transaction_drop_rate: self.transaction_drop_rate,
+            transaction_execution_delay_ms: self.transaction_execution_delay_ms,
         }
     }
 

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -287,6 +287,9 @@ pub struct StartSimnet {
     /// Skip signature verification for all transactions (eg. surfpool start --skip-signature-verification)
     #[clap(long = "skip-signature-verification", action=ArgAction::SetTrue, default_value = "false")]
     pub skip_signature_verification: bool,
+    /// Skip blockhash validation for all transactions (eg. surfpool start --skip-blockhash-check)
+    #[clap(long = "skip-blockhash-check", action=ArgAction::SetTrue, default_value = "false")]
+    pub skip_blockhash_check: bool,
     /// Probability (0.0–1.0) that a transaction is randomly dropped, simulating packet loss or leader rejection.
     /// E.g. 0.1 means 10% of transactions will be dropped. (eg. surfpool start --transaction-drop-rate 0.1)
     #[arg(long = "transaction-drop-rate", value_parser = parse_drop_rate)]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -42,6 +42,7 @@ libloading = { workspace = true }
 litesvm = { workspace = true }
 litesvm-token = { workspace = true }
 log = { workspace = true }
+rand = "0.8"
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }                                  # must match the serde version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251

--- a/crates/core/src/rpc/full.rs
+++ b/crates/core/src/rpc/full.rs
@@ -1671,6 +1671,18 @@ impl Full for SurfpoolFullRpc {
                     m.record_transaction(true, rpc_start.elapsed().as_millis() as u64);
                 }
             }
+            Ok(TransactionStatusEvent::Dropped) => {
+                #[cfg(feature = "prometheus")]
+                if let Some(m) = crate::telemetry::metrics() {
+                    m.record_transaction(false, rpc_start.elapsed().as_millis() as u64);
+                    m.record_rpc_request("sendTransaction", rpc_start.elapsed().as_millis() as u64);
+                }
+                return Err(Error {
+                    data: None,
+                    message: "Transaction dropped: simulated network condition".to_string(),
+                    code: jsonrpc_core::ErrorCode::ServerError(-32002),
+                });
+            }
         }
 
         #[cfg(feature = "prometheus")]

--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -348,6 +348,8 @@ pub async fn start_block_production_runloop(
         expiry_duration_ms.map(|expiry_val| Utc::now().timestamp_millis() as u64 + expiry_val);
     let global_skip_sig_verify = simnet_config.skip_signature_verification;
     let ix_profiling_initially_enabled = simnet_config.instruction_profiling_enabled;
+    let transaction_drop_rate = simnet_config.transaction_drop_rate;
+    let transaction_execution_delay_ms = simnet_config.transaction_execution_delay_ms;
     loop {
         let mut do_produce_block = false;
 
@@ -483,6 +485,23 @@ pub async fn start_block_production_runloop(
                         continue
                     }
                     SimnetCommand::ProcessTransaction(_key, transaction, status_tx, skip_preflight, skip_sig_verify_override) => {
+                       // Randomly drop the transaction to simulate real-world packet loss / leader rejection
+                       if let Some(drop_rate) = transaction_drop_rate {
+                           if rand::random::<f64>() < drop_rate {
+                               let _ = svm_locker.simnet_events_tx().send(SimnetEvent::warn(
+                                   format!("Transaction dropped (simulated, drop_rate={})", drop_rate)
+                               ));
+                               let _ = status_tx.send(surfpool_types::TransactionStatusEvent::Dropped);
+                               continue;
+                           }
+                       }
+                       // Apply random execution delay to simulate out-of-order processing
+                       if let Some(max_delay_ms) = transaction_execution_delay_ms {
+                           if max_delay_ms > 0 {
+                                   let delay = rand::random::<u64>() % (max_delay_ms + 1);
+                               tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                           }
+                       }
                        let skip_sig_verify = skip_sig_verify_override.unwrap_or(global_skip_sig_verify);
                        let sigverify = !skip_sig_verify;
                        if let Err(e) = svm_locker.process_transaction(&remote_client_with_commitment, transaction, status_tx, skip_preflight, sigverify).await {

--- a/crates/core/src/runloops/mod.rs
+++ b/crates/core/src/runloops/mod.rs
@@ -498,7 +498,7 @@ pub async fn start_block_production_runloop(
                        // Apply random execution delay to simulate out-of-order processing
                        if let Some(max_delay_ms) = transaction_execution_delay_ms {
                            if max_delay_ms > 0 {
-                                   let delay = rand::random::<u64>() % (max_delay_ms + 1);
+                                   let delay = rand::random::<u64>() % max_delay_ms.saturating_add(1);
                                tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
                            }
                        }

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -9109,3 +9109,223 @@ async fn test_send_transaction_skip_sig_verify_processes_and_updates_state(test_
         final_payer_balance.value,
     );
 }
+
+fn make_sol_transfer_tx(payer: &Keypair, recipient: &Pubkey, blockhash: Hash) -> String {
+    let msg = Message::new_with_blockhash(
+        &[system_instruction::transfer(
+            &payer.pubkey(),
+            recipient,
+            1_000,
+        )],
+        Some(&payer.pubkey()),
+        &blockhash,
+    );
+    let tx = VersionedTransaction::try_new(VersionedMessage::Legacy(msg), &[payer])
+        .expect("failed to create tx");
+    let encoded = bincode::serialize(&tx).expect("failed to serialize tx");
+    bs58::encode(encoded).into_string()
+}
+
+#[test_case(TestType::no_db(); "with no db")]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_transaction_drop_rate_always_drops(test_type: TestType) {
+    let payer = Keypair::new();
+    let recipient = Pubkey::new_unique();
+    let bind_host = "127.0.0.1";
+    let bind_port = get_free_port().unwrap();
+    let ws_port = get_free_port().unwrap();
+
+    let config = SurfpoolConfig {
+        simnets: vec![SimnetConfig {
+            airdrop_addresses: vec![payer.pubkey()],
+            airdrop_token_amount: LAMPORTS_PER_SOL,
+            transaction_drop_rate: Some(1.0), // always drop
+            ..SimnetConfig::default()
+        }],
+        rpc: RpcConfig {
+            bind_host: bind_host.to_string(),
+            bind_port,
+            ws_port,
+            ..Default::default()
+        },
+        ..SurfpoolConfig::default()
+    };
+
+    let (surfnet_svm, simnet_events_rx, geyser_events_rx) = test_type.initialize_svm();
+    let (simnet_commands_tx, simnet_commands_rx) = unbounded();
+    let svm_locker = SurfnetSvmLocker::new(surfnet_svm);
+
+    let _handle = hiro_system_kit::thread_named("test").spawn(move || {
+        let future = start_local_surfnet_runloop(
+            svm_locker,
+            config,
+            simnet_commands_tx,
+            simnet_commands_rx,
+            geyser_events_rx,
+        );
+        if let Err(e) = hiro_system_kit::nestable_block_on(future) {
+            panic!("{e:?}");
+        }
+    });
+
+    wait_for_ready_and_connected(&simnet_events_rx);
+
+    let full_client =
+        http::connect::<FullClient>(format!("http://{bind_host}:{bind_port}").as_str())
+            .await
+            .expect("failed to connect");
+
+    let blockhash = full_client
+        .get_latest_blockhash(None)
+        .await
+        .map(|r| Hash::from_str(r.value.blockhash.as_str()).unwrap())
+        .expect("failed to get blockhash");
+
+    let data = make_sol_transfer_tx(&payer, &recipient, blockhash);
+    let result = full_client.send_transaction(data, None).await;
+
+    assert!(result.is_err(), "expected transaction to be dropped");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("dropped"),
+        "expected 'dropped' in error, got: {err_msg}"
+    );
+}
+
+#[test_case(TestType::no_db(); "with no db")]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_transaction_drop_rate_never_drops(test_type: TestType) {
+    let payer = Keypair::new();
+    let recipient = Pubkey::new_unique();
+    let bind_host = "127.0.0.1";
+    let bind_port = get_free_port().unwrap();
+    let ws_port = get_free_port().unwrap();
+
+    let config = SurfpoolConfig {
+        simnets: vec![SimnetConfig {
+            airdrop_addresses: vec![payer.pubkey()],
+            airdrop_token_amount: LAMPORTS_PER_SOL,
+            transaction_drop_rate: Some(0.0), // never drop
+            ..SimnetConfig::default()
+        }],
+        rpc: RpcConfig {
+            bind_host: bind_host.to_string(),
+            bind_port,
+            ws_port,
+            ..Default::default()
+        },
+        ..SurfpoolConfig::default()
+    };
+
+    let (surfnet_svm, simnet_events_rx, geyser_events_rx) = test_type.initialize_svm();
+    let (simnet_commands_tx, simnet_commands_rx) = unbounded();
+    let svm_locker = SurfnetSvmLocker::new(surfnet_svm);
+
+    let _handle = hiro_system_kit::thread_named("test").spawn(move || {
+        let future = start_local_surfnet_runloop(
+            svm_locker,
+            config,
+            simnet_commands_tx,
+            simnet_commands_rx,
+            geyser_events_rx,
+        );
+        if let Err(e) = hiro_system_kit::nestable_block_on(future) {
+            panic!("{e:?}");
+        }
+    });
+
+    wait_for_ready_and_connected(&simnet_events_rx);
+
+    let full_client =
+        http::connect::<FullClient>(format!("http://{bind_host}:{bind_port}").as_str())
+            .await
+            .expect("failed to connect");
+
+    let blockhash = full_client
+        .get_latest_blockhash(None)
+        .await
+        .map(|r| Hash::from_str(r.value.blockhash.as_str()).unwrap())
+        .expect("failed to get blockhash");
+
+    let data = make_sol_transfer_tx(&payer, &recipient, blockhash);
+    let result = full_client.send_transaction(data, None).await;
+
+    assert!(
+        result.is_ok(),
+        "expected transaction to succeed, got: {:?}",
+        result.err()
+    );
+}
+
+#[test_case(TestType::no_db(); "with no db")]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_transaction_execution_delay(test_type: TestType) {
+    let payer = Keypair::new();
+    let recipient = Pubkey::new_unique();
+    let bind_host = "127.0.0.1";
+    let bind_port = get_free_port().unwrap();
+    let ws_port = get_free_port().unwrap();
+    let delay_ms = 200u64;
+
+    let config = SurfpoolConfig {
+        simnets: vec![SimnetConfig {
+            airdrop_addresses: vec![payer.pubkey()],
+            airdrop_token_amount: LAMPORTS_PER_SOL,
+            transaction_execution_delay_ms: Some(delay_ms),
+            ..SimnetConfig::default()
+        }],
+        rpc: RpcConfig {
+            bind_host: bind_host.to_string(),
+            bind_port,
+            ws_port,
+            ..Default::default()
+        },
+        ..SurfpoolConfig::default()
+    };
+
+    let (surfnet_svm, simnet_events_rx, geyser_events_rx) = test_type.initialize_svm();
+    let (simnet_commands_tx, simnet_commands_rx) = unbounded();
+    let svm_locker = SurfnetSvmLocker::new(surfnet_svm);
+
+    let _handle = hiro_system_kit::thread_named("test").spawn(move || {
+        let future = start_local_surfnet_runloop(
+            svm_locker,
+            config,
+            simnet_commands_tx,
+            simnet_commands_rx,
+            geyser_events_rx,
+        );
+        if let Err(e) = hiro_system_kit::nestable_block_on(future) {
+            panic!("{e:?}");
+        }
+    });
+
+    wait_for_ready_and_connected(&simnet_events_rx);
+
+    let full_client =
+        http::connect::<FullClient>(format!("http://{bind_host}:{bind_port}").as_str())
+            .await
+            .expect("failed to connect");
+
+    let blockhash = full_client
+        .get_latest_blockhash(None)
+        .await
+        .map(|r| Hash::from_str(r.value.blockhash.as_str()).unwrap())
+        .expect("failed to get blockhash");
+
+    let data = make_sol_transfer_tx(&payer, &recipient, blockhash);
+    let start = std::time::Instant::now();
+    let result = full_client.send_transaction(data, None).await;
+    let elapsed = start.elapsed();
+
+    assert!(
+        result.is_ok(),
+        "expected transaction to succeed with delay set, got: {:?}",
+        result.err()
+    );
+    assert!(
+        elapsed.as_millis() < 5000,
+        "transaction took too long: {}ms",
+        elapsed.as_millis()
+    );
+}

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -831,6 +831,9 @@ async fn test_transaction_with_ed25519_instruction(test_type: TestType) {
         Ok(TransactionStatusEvent::VerificationFailure(error)) => {
             panic!("Transaction verification failed: {}", error);
         }
+        Ok(TransactionStatusEvent::Dropped) => {
+            panic!("Transaction was unexpectedly dropped");
+        }
         Err(e) => {
             panic!("Failed to receive transaction status: {:?}", e);
         }
@@ -1558,6 +1561,9 @@ async fn test_get_transaction_profile(test_type: TestType) {
         }
         Ok(TransactionStatusEvent::VerificationFailure(error)) => {
             panic!("Transaction verification failed: {}", error);
+        }
+        Ok(TransactionStatusEvent::Dropped) => {
+            panic!("Transaction was unexpectedly dropped");
         }
         Err(e) => {
             panic!("Failed to receive transaction status: {:?}", e);

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -9115,7 +9115,7 @@ fn make_sol_transfer_tx(payer: &Keypair, recipient: &Pubkey, blockhash: Hash) ->
         &[system_instruction::transfer(
             &payer.pubkey(),
             recipient,
-            1_000,
+            LAMPORTS_PER_SOL / 10,
         )],
         Some(&payer.pubkey()),
         &blockhash,

--- a/crates/types/src/types.rs
+++ b/crates/types/src/types.rs
@@ -537,6 +537,7 @@ pub enum TransactionStatusEvent {
     SimulationFailure((TransactionError, TransactionMetadata)),
     ExecutionFailure((TransactionError, TransactionMetadata)),
     VerificationFailure(String),
+    Dropped,
 }
 
 #[derive(Debug)]
@@ -617,6 +618,14 @@ pub struct SimnetConfig {
     /// Snapshot accounts to preload at startup.
     /// Keys are pubkey strings, values can be None to fetch from remote RPC.
     pub snapshot: BTreeMap<String, Option<AccountSnapshot>>,
+    /// Probability (0.0–1.0) that any given transaction will be randomly dropped,
+    /// simulating real-world packet loss or leader rejection.
+    #[serde(default)]
+    pub transaction_drop_rate: Option<f64>,
+    /// Maximum random delay in milliseconds applied before executing each transaction,
+    /// simulating out-of-order execution under high throughput.
+    #[serde(default)]
+    pub transaction_execution_delay_ms: Option<u64>,
 }
 
 impl Default for SimnetConfig {
@@ -636,6 +645,8 @@ impl Default for SimnetConfig {
             skip_blockhash_check: false,
             surfnet_id: "default".to_string(),
             snapshot: BTreeMap::new(),
+            transaction_drop_rate: None,
+            transaction_execution_delay_ms: None,
         }
     }
 }


### PR DESCRIPTION
Closes #529
  - Add `--transaction-drop-rate <0.0-1.0>` flag: randomly drops transactions with the given probability, simulating
  packet loss or leader rejection
  - Add `--transaction-execution-delay-ms <ms>` flag: applies a random delay (0 to N ms) before executing each
  transaction, simulating out-of-order processing under high throughput
  - Add `TransactionStatusEvent::Dropped` variant returned to the RPC client when a transaction is dropped

 Usage:
  ```bash
  surfpool start --transaction-drop-rate 0.1 --transaction-execution-delay-ms 200
