### PR TITLE
fix(core): add HTTP timeout to remote RPC client

### DIFF
--- a/crates/core/src/surfnet/remote.rs
+++ b/crates/core/src/surfnet/remote.rs
@@ -72,6 +72,7 @@ impl SurfnetRemoteClient {
             .danger_accept_invalid_certs(true)
             .tls_built_in_root_certs(false)
             .tls_built_in_webpki_certs(false)
+            .timeout(std::time::Duration::from_secs(30))
             .build()
         {
             Ok(client) => client,


### PR DESCRIPTION
The `reqwest::Client` in `SurfnetRemoteClient::new_unsafe()` is constructed without an HTTP timeout. If the upstream RPC endpoint is slow or unresponsive, any remote-fallback request blocks indefinitely with no error and no feedback to the caller.

This is reliably reproducible with `getTokenLargestAccounts` it's a heavy account-scanning method that public mainnet endpoints commonly hang on but the missing timeout affects every `local_then_remote` code path in `locker.rs` since they all go through the same client.

The fix adds `.timeout(Duration::from_secs(30))` to the reqwest client builder. 30 seconds is generous healthy RPC responses come back in under 5 seconds. This only catches the "endpoint is dead or hanging" case, and surfaces it as a reqwest timeout error instead of a silent infinite block.

**Reproduction:**

1. Start Surfpool with `--network=mainnet`
2. Mint any SPL token (e.g. via Metaplex `createNft`)
3. Call `getTokenLargestAccounts` on the new mint
4. Observe: the request never returns

After the fix, the request either succeeds within 30s or returns a timeout error.