### PR TITLE
feat(sdk): add Surfnet.stop() for graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11542,6 +11542,7 @@ name = "surfpool-sdk-node"
 version = "1.2.0"
 dependencies = [
  "hiro-system-kit",
+ "log 0.4.29",
  "napi",
  "napi-build",
  "napi-derive",

--- a/crates/sdk-node/Cargo.toml
+++ b/crates/sdk-node/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib"]
 napi = { version = "2", features = ["napi4", "napi6"] }
 napi-derive = "2.16"
 hiro-system-kit = { workspace = true }
+log = "0.4"
 surfpool-sdk = { workspace = true }
 surfpool-types = { workspace = true }
 solana-keypair = { workspace = true }

--- a/crates/sdk-node/README.md
+++ b/crates/sdk-node/README.md
@@ -2,6 +2,24 @@
 
 Node.js bindings for the Surfpool SDK, built with `napi-rs`.
 
+## Usage
+
+```ts
+import { Surfnet } from "surfpool-sdk";
+
+const surfnet = Surfnet.start();
+console.log(surfnet.rpcUrl); // http://127.0.0.1:xxxxx
+
+// ... run tests / interact with the local validator ...
+
+// Graceful shutdown: closes HTTP + WebSocket RPC servers and frees ports.
+surfnet.stop();
+```
+
+`stop()` is idempotent and synchronous; it blocks briefly while servers close.
+Wire it into test teardown (e.g. `afterAll`) to avoid `connection reset` /
+`broken pipe` warnings caused by the OS yanking sockets at process exit.
+
 ## Development
 
 ```bash

--- a/crates/sdk-node/scripts/smoke.js
+++ b/crates/sdk-node/scripts/smoke.js
@@ -164,6 +164,29 @@ test("deploy() accepts explicit bytes and deployProgram() discovers workspace ar
   }
 });
 
+test("stop() shuts down the runtime and frees the port", async () => {
+  const surfnet = Surfnet.start();
+  const rpcUrl = surfnet.rpcUrl;
+  const port = Number(new URL(rpcUrl).port);
+
+  await surfnetRpc(rpcUrl, "getVersion");
+
+  surfnet.stop();
+  surfnet.stop(); // idempotent
+
+  await assert.rejects(
+    surfnetRpc(rpcUrl, "getVersion"),
+    "expected RPC to fail after stop()",
+  );
+
+  const probe = require("node:net").createServer();
+  await new Promise((resolve, reject) => {
+    probe.once("error", reject);
+    probe.listen(port, "127.0.0.1", resolve);
+  });
+  await new Promise((resolve) => probe.close(resolve));
+});
+
 function sampleIdl(programId) {
   return {
     address: programId,

--- a/crates/sdk-node/src/lib.rs
+++ b/crates/sdk-node/src/lib.rs
@@ -97,6 +97,15 @@ impl Surfnet {
         self.inner.instance_id().to_string()
     }
 
+    /// Gracefully shut down the surfnet, closing the HTTP + WebSocket RPC
+    /// servers and freeing their ports. Blocks briefly while servers close.
+    /// Throws if shutdown is not confirmed within the timeout (the port may
+    /// still be bound). On success, subsequent calls are a no-op.
+    #[napi]
+    pub fn stop(&mut self) -> Result<()> {
+        self.inner.stop().map_err(sdk_error_to_napi)
+    }
+
     /// Drain and return currently buffered simnet events.
     #[napi]
     pub fn drain_events(&self) -> Vec<SimnetEventValue> {

--- a/crates/sdk-node/src/lib.rs
+++ b/crates/sdk-node/src/lib.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate napi_derive;
 
-use std::{convert::TryFrom, path::PathBuf};
+use std::{convert::TryFrom, path::PathBuf, sync::Once};
 
 use napi::{Error, Result, Status};
 use solana_keypair::Keypair;
@@ -12,6 +12,38 @@ use surfpool_sdk::{
     cheatcodes::builders::{DeployProgram, ResetAccount, SetTokenAccount, StreamAccount},
 };
 use surfpool_types::ClockCommand;
+
+/// Silent `log::Log` impl. Installed once at first surfnet boot so parity-ws
+/// (the WebSocket server backing the pubsub endpoint) skips its hardcoded
+/// `println!("Encountered an error: ...\nEnable a logger to see more
+/// information.")` fallback whenever a client closes uncleanly. parity-ws
+/// only ignores ECONNRESET when `errno == 104` (Linux); on macOS ECONNRESET
+/// is 54, so the fallback fires on every client-side reset and pollutes
+/// stderr in test runners. Installing any `log` impl makes
+/// `log_enabled!(Error)` return true, which suppresses the println.
+struct NullLogger;
+
+impl log::Log for NullLogger {
+    fn enabled(&self, _: &log::Metadata) -> bool {
+        true
+    }
+    fn log(&self, _: &log::Record) {}
+    fn flush(&self) {}
+}
+
+static NULL_LOGGER: NullLogger = NullLogger;
+static INIT_LOGGER: Once = Once::new();
+
+fn install_null_logger_once() {
+    INIT_LOGGER.call_once(|| {
+        // Best-effort: if a host has already installed a logger, leave it
+        // alone (including its max level). We only need this when nobody
+        // else has registered one.
+        if log::set_logger(&NULL_LOGGER).is_ok() {
+            log::set_max_level(log::LevelFilter::Error);
+        }
+    });
+}
 
 /// A running Surfpool instance with RPC/WS endpoints on dynamic ports.
 #[napi]
@@ -24,6 +56,7 @@ impl Surfnet {
     /// Start a surfnet with default settings (offline, transaction-mode blocks, 10 SOL payer).
     #[napi(factory)]
     pub fn start() -> Result<Self> {
+        install_null_logger_once();
         let inner = hiro_system_kit::nestable_block_on(NativeSurfnet::start())
             .map_err(sdk_error_to_napi)?;
         Ok(Self { inner })
@@ -32,6 +65,7 @@ impl Surfnet {
     /// Start a surfnet with custom configuration.
     #[napi(factory)]
     pub fn start_with_config(config: SurfnetConfig) -> Result<Self> {
+        install_null_logger_once();
         let mut builder = NativeSurfnet::builder();
 
         if let Some(offline) = config.offline {

--- a/crates/sdk-node/surfpool-sdk/index.ts
+++ b/crates/sdk-node/surfpool-sdk/index.ts
@@ -87,6 +87,16 @@ export class Surfnet {
     return this.inner.instanceId;
   }
 
+  /**
+   * Gracefully shut down the surfnet, closing the HTTP + WebSocket RPC
+   * servers and freeing their ports. Blocks briefly while servers close.
+   * Throws if shutdown is not confirmed within the timeout (the port may
+   * still be bound). On success, subsequent calls are a no-op.
+   */
+  stop(): void {
+    this.inner.stop();
+  }
+
   /** Drain buffered simnet events into plain JS objects. */
   drainEvents(): SimnetEventValue[] {
     return this.inner.drainEvents();

--- a/crates/sdk/src/surfnet.rs
+++ b/crates/sdk/src/surfnet.rs
@@ -210,6 +210,7 @@ impl SurfnetBuilder {
             simnet_events_rx,
             svm_locker,
             instance_id: uuid::Uuid::new_v4().to_string(),
+            stopped: false,
         })
     }
 }
@@ -231,6 +232,7 @@ pub struct Surfnet {
     #[allow(dead_code)] // retained for future direct profiling access
     svm_locker: SurfnetSvmLocker,
     instance_id: String,
+    stopped: bool,
 }
 
 impl Surfnet {
@@ -285,11 +287,61 @@ impl Surfnet {
     pub fn instance_id(&self) -> &str {
         &self.instance_id
     }
+
+    /// Gracefully shut down the surfnet, closing the HTTP + WebSocket RPC
+    /// servers and freeing their ports.
+    ///
+    /// Blocks until both RPC servers acknowledge shutdown or the timeout
+    /// elapses. Returns an error if shutdown is not confirmed within the
+    /// timeout (the port may still be bound) — callers that need a
+    /// guaranteed-free port should treat this as fatal. On success, the
+    /// instance is marked stopped and subsequent calls are a no-op.
+    ///
+    /// Note: this drains the simnet events channel while waiting. Don't call
+    /// `events()` / `drain_events()` concurrently from another thread or
+    /// shutdown acknowledgements may be lost, causing this call to time out.
+    pub fn stop(&mut self) -> SurfnetResult<()> {
+        if self.stopped {
+            return Ok(());
+        }
+
+        self.simnet_commands_tx
+            .send(SimnetCommand::Terminate(None))
+            .map_err(|e| {
+                SurfnetError::Runtime(format!("failed to send terminate command: {e}"))
+            })?;
+
+        let timeout = Duration::from_secs(5);
+        let deadline = Instant::now() + timeout;
+        let mut shutdowns_seen = 0;
+        while shutdowns_seen < 2 {
+            let remaining = match deadline.checked_duration_since(Instant::now()) {
+                Some(d) => d,
+                None => break,
+            };
+            match self.simnet_events_rx.recv_timeout(remaining) {
+                Ok(SimnetEvent::Shutdown) => shutdowns_seen += 1,
+                Ok(_) => continue,
+                Err(_) => break,
+            }
+        }
+
+        if shutdowns_seen < 2 {
+            return Err(SurfnetError::Runtime(format!(
+                "surfnet shutdown not confirmed within {timeout:?}: {shutdowns_seen} of 2 RPC servers acknowledged. The port may still be bound."
+            )));
+        }
+
+        self.stopped = true;
+        Ok(())
+    }
 }
 
 impl Drop for Surfnet {
     fn drop(&mut self) {
-        let _ = self.simnet_commands_tx.send(SimnetCommand::Terminate(None));
+        if !self.stopped {
+            let _ = self.simnet_commands_tx.send(SimnetCommand::Terminate(None));
+        }
     }
 }
 

--- a/crates/sdk/src/surfnet.rs
+++ b/crates/sdk/src/surfnet.rs
@@ -307,9 +307,7 @@ impl Surfnet {
 
         self.simnet_commands_tx
             .send(SimnetCommand::Terminate(None))
-            .map_err(|e| {
-                SurfnetError::Runtime(format!("failed to send terminate command: {e}"))
-            })?;
+            .map_err(|e| SurfnetError::Runtime(format!("failed to send terminate command: {e}")))?;
 
         let timeout = Duration::from_secs(5);
         let deadline = Instant::now() + timeout;


### PR DESCRIPTION
## Summary
- Add `Surfnet::stop(&mut self)` to the Rust SDK that sends `SimnetCommand::Terminate` and blocks until both RPC servers (HTTP + WS) acknowledge shutdown via `SimnetEvent::Shutdown`, with a 5s timeout.
- Returns an error when shutdown is not confirmed so callers can treat unfreed ports as fatal instead of silently leaking sockets.
- Surface `stop()` through the napi binding and TypeScript wrapper so consumers can call `surfnet.stop()` from `afterAll` test teardown.
- `Drop` keeps its best-effort `Terminate` send when `stop()` was not called or failed.
- Install a no-op `log::Log` on first surfnet boot in `sdk-node` to silence parity-ws's hardcoded `println!` fallback that fires on every client-side WS reset on macOS (parity-ws only ignores ECONNRESET when `errno == 104` (Linux); macOS ECONNRESET is 54). Only registers when no logger is already installed, leaving host-configured loggers untouched.

## Test Plan
- `cargo test -p surfpool-sdk -p surfpool-sdk-node` — passes (22 + 0 tests).
- `npm test` in `crates/sdk-node/` — passes (6/6) including a new smoke test that calls `stop()` twice (idempotency on success), confirms the RPC fails after, and verifies the port is rebindable.
- Full workspace `cargo test --workspace` — pre-existing flake in `surfpool-core` unrelated to this change (verified by stashing the diff).
- Verified `sdk-node` consumers no longer see `Encountered an error: ... Enable a logger to see more information.` on stderr during normal client disconnects on macOS.

Closes DEV-467

(Replaces #641)