### PR TITLE
chore(sdk-node): rename npm package to @solana/surfpool

### DIFF
--- a/.github/workflows/release_sdk_node_npm.yml
+++ b/.github/workflows/release_sdk_node_npm.yml
@@ -49,7 +49,7 @@ jobs:
           SHOULD_PUBLISH=false
 
           for ENTRY in \
-            "surfpool-sdk publish_root" \
+            "@solana/surfpool publish_root" \
             "surfpool-sdk-darwin-x64 publish_darwin_x64" \
             "surfpool-sdk-darwin-arm64 publish_darwin_arm64" \
             "surfpool-sdk-linux-x64-gnu publish_linux_x64_gnu"

--- a/.github/workflows/sdk_node.yml
+++ b/.github/workflows/sdk_node.yml
@@ -131,7 +131,7 @@ jobs:
           npm install "./$(basename "${{ steps.pack.outputs.root_pack }}")"
           node - <<'EOF'
           const assert = require("node:assert/strict");
-          const { Surfnet } = require("surfpool-sdk");
+          const { Surfnet } = require("@solana/surfpool");
 
           const keypair = Surfnet.newKeypair();
           assert.equal(keypair.secretKey.length, 64);

--- a/crates/sdk-node/README.md
+++ b/crates/sdk-node/README.md
@@ -1,4 +1,4 @@
-# `surfpool-sdk`
+# `@solana/surfpool`
 
 Node.js bindings for the Surfpool SDK, built with `napi-rs`.
 

--- a/crates/sdk-node/package-lock.json
+++ b/crates/sdk-node/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "surfpool-sdk",
+  "name": "@solana/surfpool",
   "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "surfpool-sdk",
+      "name": "@solana/surfpool",
       "version": "1.2.0",
       "license": "Apache-2.0",
       "devDependencies": {

--- a/crates/sdk-node/package.json
+++ b/crates/sdk-node/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "surfpool-sdk",
+  "name": "@solana/surfpool",
   "version": "1.2.0",
   "description": "Embed a Surfpool Solana runtime in your Node.js tests",
   "main": "dist/index.js",

--- a/crates/sdk-node/scripts/prepare-release.js
+++ b/crates/sdk-node/scripts/prepare-release.js
@@ -108,7 +108,7 @@ function main() {
     cwd: packageDir,
   });
 
-  console.log(`Prepared surfpool-sdk npm release ${version}`);
+  console.log(`Prepared @solana/surfpool npm release ${version}`);
 }
 
 main();


### PR DESCRIPTION
## Summary
- Rename the published npm package from `surfpool-sdk` to `@solana/surfpool`
- Update all in-repo references: smoke test `require`, `package-lock.json`, README header, release script log, and the publish workflow's already-published check
- Platform binary packages (`surfpool-sdk-darwin-x64`, `-darwin-arm64`, `-linux-x64-gnu`) remain unscoped

## Follow-up needed before next release
npm trusted publisher must be configured for `@solana/surfpool` on npmjs.com pointing to workflow `release_sdk_node_npm.yml` and environment `release`. Without it, the root publish step will fail OIDC auth.

## Test plan
- [ ] `npm ci` in `crates/sdk-node` succeeds (lockfile in sync)
- [ ] `sdk_node.yml` smoke test passes on CI (`require("@solana/surfpool")`)
- [ ] Dry-run `release_sdk_node_npm.yml` workflow before tagging next version