### PR TITLE
ci: skip release workflows on forks

### DIFF
--- a/.github/workflows/release_cli.yaml
+++ b/.github/workflows/release_cli.yaml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   get_release_info:
     name: Get Release Info
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.new_release_tag.outputs.TAG }}
@@ -50,6 +51,7 @@ jobs:
 
   dist_surfpool:
     name: Build Surfpool Distributions
+    if: github.event.repository.fork == false
     runs-on: ${{ matrix.os }}
     outputs:
       LINUX_X64_SHA: ${{ steps.linux_x64_sha.outputs.LINUX_X64_SHA }}

--- a/.github/workflows/release_crates.yaml
+++ b/.github/workflows/release_crates.yaml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   publish:
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     environment: release
 


### PR DESCRIPTION
Add fork repository guards to the release binary and crate publishing workflows so release jobs are skipped when the workflow runs from a fork.