### PR TITLE
fix(cli/core): improve error messaging and help text for postgres fea…

### DIFF
--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -247,7 +247,7 @@ pub struct StartSimnet {
     /// A set of inputs to use for the runbook (eg. surfpool start --runbook-input myInputs.json)
     #[arg(long = "runbook-input", short = 'i')]
     pub runbook_input: Vec<String>,
-    /// Surfnet database connection URL for persistent Surfnets. For an in-memory sqlite database, use ":memory:". For an on-disk sqlite database, use a filename ending in '.sqlite'.
+    /// Surfnet database connection URL for persistent Surfnets. For an in-memory sqlite database, use ":memory:". For an on-disk sqlite database, use a filename ending in '.sqlite'. PostgreSQL URLs (postgres:// or postgresql://) require building from source with the `postgres` feature flag enabled.
     #[arg(long = "db")]
     pub db: Option<String>,
     /// Unique identifier for this surfnet instance. Used to isolate database storage when multiple surfnets share the same database. Defaults to "default".

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -104,7 +104,7 @@ where
 pub enum StorageError {
     #[error("Sqlite storage is not enabled in this build")]
     SqliteNotEnabled,
-    #[error("Postgres storage is not enabled in this build")]
+    #[error("Postgres storage is not enabled in this build. To use PostgreSQL, build surfpool from source with the `postgres` feature flag:\n  git clone https://github.com/solana-foundation/surfpool.git && cd surfpool\n  cargo surfpool-install --features postgres\nPre-built binaries and the official Docker image do not include PostgreSQL support.")]
     PostgresNotEnabled,
     #[error("Invalid Postgres database URL: {0}")]
     InvalidPostgresUrl(String),


### PR DESCRIPTION
…ture flag (#636)

Pre-built binaries and Docker images do not include PostgreSQL support since it requires the `postgres` Rust feature flag. Users who tried passing a postgres:// URL to --db received an unhelpful error with no guidance on how to enable it.

- Update StorageError::PostgresNotEnabled to include build-from-source instructions using `cargo surfpool-install --features postgres`
- Update --db CLI help text to document that PostgreSQL URLs require building from source with the `postgres` feature flag