### PR TITLE
feat(sdk-node): expose feature-gate config in Node SDK

### DIFF
--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -583,11 +583,7 @@ impl StartSimnet {
     pub fn feature_config(&self) -> SvmFeatureConfig {
         let mut config = if self.svm.all_features {
             // Enable all SVM features from agave-feature-set (override mainnet defaults)
-            let mut cfg = SvmFeatureConfig::default();
-            for pubkey in agave_feature_set::FEATURE_NAMES.keys() {
-                cfg = cfg.enable(*pubkey);
-            }
-            cfg
+            SvmFeatureConfig::all_features_enabled()
         } else {
             // No overrides → run with the mainnet baseline (applied by LiteSVM
             // when the SVM is constructed).

--- a/crates/sdk-node/package-lock.json
+++ b/crates/sdk-node/package-lock.json
@@ -16,9 +16,9 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "surfpool-sdk-darwin-arm64": "1.3.0",
-        "surfpool-sdk-darwin-x64": "1.3.0",
-        "surfpool-sdk-linux-x64-gnu": "1.3.0"
+        "@solana/surfpool-darwin-arm64": "1.3.0",
+        "@solana/surfpool-darwin-x64": "1.3.0",
+        "@solana/surfpool-linux-x64-gnu": "1.3.0"
       }
     },
     "node_modules/@napi-rs/cli": {

--- a/crates/sdk-node/package-lock.json
+++ b/crates/sdk-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solana/surfpool",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solana/surfpool",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",
@@ -16,9 +16,9 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@solana/surfpool-darwin-arm64": "1.2.2",
-        "@solana/surfpool-darwin-x64": "1.2.2",
-        "@solana/surfpool-linux-x64-gnu": "1.2.2"
+        "surfpool-sdk-darwin-arm64": "1.3.0",
+        "surfpool-sdk-darwin-x64": "1.3.0",
+        "surfpool-sdk-linux-x64-gnu": "1.3.0"
       }
     },
     "node_modules/@napi-rs/cli": {

--- a/crates/sdk-node/package.json
+++ b/crates/sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/surfpool",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Embed a Surfpool Solana runtime in your Node.js tests",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -61,8 +61,8 @@
     "typescript": "^5.7.0"
   },
   "optionalDependencies": {
-    "@solana/surfpool-darwin-x64": "1.2.2",
-    "@solana/surfpool-darwin-arm64": "1.2.2",
-    "@solana/surfpool-linux-x64-gnu": "1.2.2"
+    "surfpool-sdk-darwin-x64": "1.3.0",
+    "surfpool-sdk-darwin-arm64": "1.3.0",
+    "surfpool-sdk-linux-x64-gnu": "1.3.0"
   }
 }

--- a/crates/sdk-node/package.json
+++ b/crates/sdk-node/package.json
@@ -61,8 +61,8 @@
     "typescript": "^5.7.0"
   },
   "optionalDependencies": {
-    "surfpool-sdk-darwin-x64": "1.3.0",
-    "surfpool-sdk-darwin-arm64": "1.3.0",
-    "surfpool-sdk-linux-x64-gnu": "1.3.0"
+    "@solana/surfpool-darwin-x64": "1.3.0",
+    "@solana/surfpool-darwin-arm64": "1.3.0",
+    "@solana/surfpool-linux-x64-gnu": "1.3.0"
   }
 }

--- a/crates/sdk-node/scripts/smoke.js
+++ b/crates/sdk-node/scripts/smoke.js
@@ -33,6 +33,20 @@ test("startWithConfig supports custom payer, extra airdrops, instanceId, and dra
   assert.ok(Array.isArray(events));
 });
 
+test("startWithConfig accepts feature-gate enable/disable lists", async () => {
+  const surfnet = Surfnet.startWithConfig({
+    enableFeatures: ["enable-loader-v4"],
+    disableFeatures: ["blake3_syscall_enabled"],
+  });
+  assert.ok(surfnet.instanceId.length > 0);
+
+  // Unknown feature name should reject with InvalidArg.
+  assert.throws(
+    () => Surfnet.startWithConfig({ enableFeatures: ["not-a-real-feature"] }),
+    /Invalid enableFeatures/,
+  );
+});
+
 test("SOL account helpers can set and reset account state", async () => {
   const surfnet = Surfnet.start();
   const address = Surfnet.newKeypair().publicKey;

--- a/crates/sdk-node/src/lib.rs
+++ b/crates/sdk-node/src/lib.rs
@@ -96,9 +96,8 @@ impl Surfnet {
             builder = builder.payer(parse_keypair(&secret_key, "payerSecretKey")?);
         }
         if config.all_features.unwrap_or(false) {
-            builder = builder.feature_config(
-                surfpool_types::SvmFeatureConfig::all_features_enabled(),
-            );
+            builder =
+                builder.feature_config(surfpool_types::SvmFeatureConfig::all_features_enabled());
         }
         if let Some(names) = config.enable_features {
             for name in &names {

--- a/crates/sdk-node/src/lib.rs
+++ b/crates/sdk-node/src/lib.rs
@@ -11,7 +11,7 @@ use surfpool_sdk::{
     BlockProductionMode, SimnetEvent, Surfnet as NativeSurfnet,
     cheatcodes::builders::{DeployProgram, ResetAccount, SetTokenAccount, StreamAccount},
 };
-use surfpool_types::ClockCommand;
+use surfpool_types::{ClockCommand, parse_feature_pubkey};
 
 /// Silent `log::Log` impl. Installed once at first surfnet boot so parity-ws
 /// (the WebSocket server backing the pubsub endpoint) skips its hardcoded
@@ -94,6 +94,23 @@ impl Surfnet {
         }
         if let Some(secret_key) = config.payer_secret_key {
             builder = builder.payer(parse_keypair(&secret_key, "payerSecretKey")?);
+        }
+        if config.all_features.unwrap_or(false) {
+            builder = builder.feature_config(
+                surfpool_types::SvmFeatureConfig::all_features_enabled(),
+            );
+        }
+        if let Some(names) = config.enable_features {
+            for name in &names {
+                let pubkey = parse_feature_name(name, "enableFeatures")?;
+                builder = builder.enable_feature(pubkey);
+            }
+        }
+        if let Some(names) = config.disable_features {
+            for name in &names {
+                let pubkey = parse_feature_name(name, "disableFeatures")?;
+                builder = builder.disable_feature(pubkey);
+            }
         }
 
         let inner =
@@ -493,6 +510,12 @@ pub struct SurfnetConfig {
     pub airdrop_sol: Option<f64>,
     pub airdrop_addresses: Option<Vec<String>>,
     pub payer_secret_key: Option<Vec<u8>>,
+    /// Feature gates to enable (base58 pubkey or kebab-case name).
+    pub enable_features: Option<Vec<String>>,
+    /// Feature gates to disable (base58 pubkey or kebab-case name).
+    pub disable_features: Option<Vec<String>>,
+    /// Activate all known agave feature gates. Applied before explicit enable/disable.
+    pub all_features: Option<bool>,
 }
 
 #[napi(object)]
@@ -774,6 +797,11 @@ fn parse_pubkeys(values: &[String], field_name: &str) -> Result<Vec<Pubkey>> {
         .iter()
         .map(|value| parse_pubkey(value, field_name))
         .collect()
+}
+
+fn parse_feature_name(value: &str, field_name: &str) -> Result<Pubkey> {
+    parse_feature_pubkey(value)
+        .map_err(|e| Error::new(Status::InvalidArg, format!("Invalid {field_name}: {e}")))
 }
 
 fn parse_keypair(bytes: &[u8], field_name: &str) -> Result<Keypair> {

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -29,4 +29,4 @@ pub use solana_pubkey::Pubkey;
 pub use solana_rpc_client::rpc_client::RpcClient;
 pub use solana_signer::Signer;
 pub use surfnet::{Surfnet, SurfnetBuilder};
-pub use surfpool_types::{BlockProductionMode, SimnetCommand, SimnetEvent};
+pub use surfpool_types::{BlockProductionMode, SimnetCommand, SimnetEvent, SvmFeatureConfig};

--- a/crates/sdk/src/surfnet.rs
+++ b/crates/sdk/src/surfnet.rs
@@ -16,6 +16,7 @@ use surfpool_core::surfnet::{
 };
 use surfpool_types::{
     BlockProductionMode, RpcConfig, SimnetCommand, SimnetConfig, SimnetEvent, SurfpoolConfig,
+    SvmFeatureConfig,
 };
 
 use crate::{
@@ -48,6 +49,7 @@ pub struct SurfnetBuilder {
     airdrop_lamports: u64,
     skip_blockhash_check: bool,
     payer: Option<Keypair>,
+    feature_config: SvmFeatureConfig,
 }
 
 impl Default for SurfnetBuilder {
@@ -61,6 +63,7 @@ impl Default for SurfnetBuilder {
             airdrop_lamports: 10_000_000_000, // 10 SOL
             skip_blockhash_check: false,
             payer: None,
+            feature_config: SvmFeatureConfig::default(),
         }
     }
 }
@@ -116,6 +119,24 @@ impl SurfnetBuilder {
         self
     }
 
+    /// Enable an SVM feature gate at startup. Mirrors the CLI's `--feature` flag.
+    pub fn enable_feature(mut self, feature: Pubkey) -> Self {
+        self.feature_config = self.feature_config.enable(feature);
+        self
+    }
+
+    /// Disable an SVM feature gate at startup. Mirrors the CLI's `--disable-feature` flag.
+    pub fn disable_feature(mut self, feature: Pubkey) -> Self {
+        self.feature_config = self.feature_config.disable(feature);
+        self
+    }
+
+    /// Replace the feature config wholesale. Default: [`SvmFeatureConfig::default_mainnet_features`].
+    pub fn feature_config(mut self, config: SvmFeatureConfig) -> Self {
+        self.feature_config = config;
+        self
+    }
+
     /// Start the surfnet with the configured options.
     pub async fn start(self) -> SurfnetResult<Surfnet> {
         let SurfnetBuilder {
@@ -127,6 +148,7 @@ impl SurfnetBuilder {
             airdrop_lamports,
             skip_blockhash_check,
             payer,
+            feature_config,
         } = self;
         let payer = payer.unwrap_or_else(Keypair::new);
 
@@ -167,7 +189,7 @@ impl SurfnetBuilder {
             instruction_profiling_enabled: surfpool_config.simnets[0].instruction_profiling_enabled,
             max_profiles: surfpool_config.simnets[0].max_profiles,
             log_bytes_limit: surfpool_config.simnets[0].log_bytes_limit,
-            feature_config: surfpool_types::SvmFeatureConfig::default(),
+            feature_config,
             skip_blockhash_check,
         };
         let (surfnet_svm, simnet_events_rx, geyser_events_rx) = SurfnetSvm::new(svm_config)

--- a/crates/types/src/features.rs
+++ b/crates/types/src/features.rs
@@ -166,6 +166,17 @@ impl SvmFeatureConfig {
             None
         }
     }
+
+    /// Returns a config with every known agave feature gate explicitly enabled.
+    ///
+    /// Mirrors the CLI's `--features-all` flag.
+    pub fn all_features_enabled() -> Self {
+        let mut cfg = Self::default();
+        for pubkey in FEATURE_NAMES.keys() {
+            cfg = cfg.enable(*pubkey);
+        }
+        cfg
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Closes [DEV-526](https://linear.app/solana-fndn/issue/DEV-526/expose-feature-gate-config-in-surfpool-sdk-node-sdk).

- Adds `enableFeatures`, `disableFeatures`, and `allFeatures` to the napi `SurfnetConfig`, parsed via the existing `parse_feature_pubkey()` helper (kebab-case name, snake_case name, or base58 pubkey).
- Threads through new `SurfnetBuilder::{enable_feature, disable_feature, feature_config}` methods into SVM init.
- Builder default now seeds `SvmFeatureConfig::default_mainnet_features()` so single-feature overrides layer on a mainnet baseline instead of flipping every gate on (matches CLI semantics — previously, `.enable_feature(X)` would activate every known gate, not just `X`).
- Bumps `@solana/surfpool` to **1.3.0**.

## Usage

```ts
import { Surfnet } from '@solana/surfpool';

// Enable v1 transactions (SIMD-0385) on top of the mainnet feature baseline.
const surfnet = Surfnet.startWithConfig({
  enableFeatures: ['enable-loader-v4'],
  // Optional: also accepts base58 pubkeys, snake_case names,
  // or a top-level `allFeatures: true` to flip every known gate on.
});

console.log(surfnet.rpcUrl);
// ...send a versioned transaction, etc.
```

Unknown feature names reject at startup with an `InvalidArg` error listing the available gates.

## Test plan

- [x] `cargo test -p surfpool-types --lib features` — 22/22 pass
- [x] `cargo test -p surfpool-sdk --lib` — 19/19 pass
- [x] `cd crates/sdk-node && npm run build && npm test` — 6/6 pass (incl. new feature-gate case + invalid-name rejection)
- [ ] Follow-up: bump `surfpool-sdk` dep in `@solana/kit-plugin-surfpool` from `^1.2.0` → `^1.3.0` once published, and add a kit-tools V1-transaction test that fails without `enableFeatures` and passes with it.