### PR TITLE
fix(core): handle local-only signatures in getSignaturesForAddress before/until

### DIFF
--- a/crates/core/src/surfnet/locker.rs
+++ b/crates/core/src/surfnet/locker.rs
@@ -69,6 +69,7 @@ use crate::{
     error::{SurfpoolError, SurfpoolResult},
     helpers::time_travel::calculate_time_travel_clock,
     rpc::utils::{convert_transaction_metadata_from_canonical, verify_pubkey},
+    storage::StorageResult,
     surfnet::FINALIZATION_SLOT_THRESHOLD,
     types::{
         GeyserAccountUpdate, OfflineAccountConfig, RemoteRpcResult, SurfnetTransactionStatus,
@@ -762,6 +763,38 @@ impl SurfnetSvmLocker {
     }
 }
 
+/// Builds the `getSignaturesForAddress` config for the remote leg of a local-then-remote
+/// query, given whether the caller's `before` / `until` reference locally-stored signatures
+/// and how many slots remain under the caller's `limit` after local results were collected.
+///
+/// Surfpool's local transactions are treated as strictly newer than anything on the upstream
+/// chain, so a local-only pagination boundary must be rewritten before being forwarded:
+///   - `before` local-only  => drop the boundary; remote signatures are all older anyway.
+///   - `until` local-only   => every remote signature would be excluded; return `None` to
+///                              skip the remote call entirely.
+///   - neither local-only   => forward the caller's boundaries unchanged.
+///
+/// The returned config always pins `limit` to `remaining_limit` so the remote can't push the
+/// combined result past the caller's requested cap.
+fn signatures_for_address_remote_config(
+    config: Option<&RpcSignaturesForAddressConfig>,
+    before_is_local: bool,
+    until_is_local: bool,
+    remaining_limit: usize,
+) -> Option<RpcSignaturesForAddressConfig> {
+    if until_is_local {
+        return None;
+    }
+    let base = config.cloned().unwrap_or_default();
+    Some(RpcSignaturesForAddressConfig {
+        before: if before_is_local { None } else { base.before },
+        until: base.until,
+        limit: Some(remaining_limit),
+        commitment: base.commitment,
+        min_context_slot: base.min_context_slot,
+    })
+}
+
 /// Get signatures for Addresses
 impl SurfnetSvmLocker {
     /// Returns local `getSignaturesForAddress` results in the same newest-first order expected by
@@ -914,8 +947,37 @@ impl SurfnetSvmLocker {
             inner: mut combined_results,
         } = results;
         if combined_results.len() < limit {
-            let mut remote_results = client.get_signatures_for_address(pubkey, config).await?;
-            combined_results.append(&mut remote_results);
+            let (before_is_local, until_is_local) =
+                self.with_svm_reader(|svm_reader| -> StorageResult<(bool, bool)> {
+                    let is_local = |sig: &String| -> StorageResult<bool> {
+                        Ok(svm_reader.transactions.get(sig)?.is_some())
+                    };
+                    let before_local = match config.and_then(|c| c.before.as_ref()) {
+                        Some(sig) => is_local(sig)?,
+                        None => false,
+                    };
+                    let until_local = match config.and_then(|c| c.until.as_ref()) {
+                        Some(sig) => is_local(sig)?,
+                        None => false,
+                    };
+                    Ok((before_local, until_local))
+                })?;
+
+            let remaining_limit = limit - combined_results.len();
+            if let Some(remote_config) = signatures_for_address_remote_config(
+                config,
+                before_is_local,
+                until_is_local,
+                remaining_limit,
+            ) {
+                let mut remote_results = client
+                    .get_signatures_for_address(pubkey, Some(&remote_config))
+                    .await?;
+                combined_results.append(&mut remote_results);
+                // Belt-and-suspenders: enforce the caller's cap even if the remote returned
+                // more than the requested slice.
+                combined_results.truncate(limit);
+            }
         }
 
         Ok(SvmAccessContext::new(
@@ -5229,6 +5291,98 @@ mod tests {
         let sigs: HashSet<String> = result.inner.iter().map(|s| s.signature.clone()).collect();
         assert!(sigs.contains(&sig_a.to_string()));
         assert!(sigs.contains(&sig_b.to_string()));
+    }
+
+    #[test]
+    fn remote_config_passes_through_when_no_boundary_is_local() {
+        let sig_before = Signature::new_unique().to_string();
+        let sig_until = Signature::new_unique().to_string();
+        let config = RpcSignaturesForAddressConfig {
+            before: Some(sig_before.clone()),
+            until: Some(sig_until.clone()),
+            limit: Some(42),
+            commitment: None,
+            min_context_slot: Some(7),
+        };
+
+        let translated = signatures_for_address_remote_config(Some(&config), false, false, 42)
+            .expect("remote call should not be skipped");
+
+        assert_eq!(translated.before.as_deref(), Some(sig_before.as_str()));
+        assert_eq!(translated.until.as_deref(), Some(sig_until.as_str()));
+        assert_eq!(translated.limit, Some(42));
+        assert_eq!(translated.min_context_slot, Some(7));
+    }
+
+    #[test]
+    fn remote_config_drops_local_before_boundary() {
+        let sig_before = Signature::new_unique().to_string();
+        let sig_until = Signature::new_unique().to_string();
+        let config = RpcSignaturesForAddressConfig {
+            before: Some(sig_before.clone()),
+            until: Some(sig_until.clone()),
+            limit: Some(100),
+            commitment: None,
+            min_context_slot: None,
+        };
+
+        let translated = signatures_for_address_remote_config(Some(&config), true, false, 100)
+            .expect("remote call should not be skipped");
+
+        assert!(
+            translated.before.is_none(),
+            "local `before` must not leak to the remote"
+        );
+        assert_eq!(translated.until.as_deref(), Some(sig_until.as_str()));
+        assert_eq!(translated.limit, Some(100));
+    }
+
+    #[test]
+    fn remote_config_skipped_when_until_is_local() {
+        let config = RpcSignaturesForAddressConfig {
+            before: None,
+            until: Some(Signature::new_unique().to_string()),
+            limit: Some(100),
+            commitment: None,
+            min_context_slot: None,
+        };
+
+        assert!(
+            signatures_for_address_remote_config(Some(&config), false, true, 100).is_none(),
+            "a local `until` boundary excludes the entire remote stream — the call must be skipped"
+        );
+        // And the same when both boundaries are local.
+        assert!(signatures_for_address_remote_config(Some(&config), true, true, 100).is_none());
+    }
+
+    #[test]
+    fn remote_config_pins_remote_limit_to_remaining_slots() {
+        // Caller asked for 100, local already produced 30 → remote should be capped at 70 so
+        // the combined stream cannot exceed the caller-requested limit.
+        let config = RpcSignaturesForAddressConfig {
+            before: None,
+            until: None,
+            limit: Some(100),
+            commitment: None,
+            min_context_slot: None,
+        };
+
+        let translated = signatures_for_address_remote_config(Some(&config), false, false, 70)
+            .expect("remote call should not be skipped");
+        assert_eq!(translated.limit, Some(70));
+    }
+
+    #[test]
+    fn remote_config_handles_missing_caller_config() {
+        let translated = signatures_for_address_remote_config(None, false, false, 250)
+            .expect("remote call should not be skipped");
+        assert_eq!(
+            translated.limit,
+            Some(250),
+            "even without a caller config, the remote must respect the remaining slot budget"
+        );
+        assert!(translated.before.is_none());
+        assert!(translated.until.is_none());
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -5385,9 +5385,8 @@ async fn test_get_signatures_for_address_local_then_remote(test_type: TestType) 
 
     // Step 2: bring up the local surfnet, configured to fork the datasource, and seed 2 LOCAL
     // airdrops for `target`. These signatures only ever land in the local surfnet's storage.
-    let (local_url, _local_locker) =
-        start_surfnet(vec![], Some(datasource_url), another_test_type)
-            .expect("start local surfnet");
+    let (local_url, _local_locker) = start_surfnet(vec![], Some(datasource_url), another_test_type)
+        .expect("start local surfnet");
     let local_rpc = RpcClient::new(local_url);
     let mut local_sigs: Vec<Signature> = Vec::new();
     for i in 0..2u64 {
@@ -5516,7 +5515,10 @@ async fn test_get_signatures_for_address_local_then_remote(test_type: TestType) 
             .await
             .expect("scenario E: getSignaturesForAddress(before=datasource) must succeed");
         let got: Vec<String> = result.iter().map(|s| s.signature.clone()).collect();
-        let expected: Vec<String> = datasource_sigs[1..].iter().map(Signature::to_string).collect();
+        let expected: Vec<String> = datasource_sigs[1..]
+            .iter()
+            .map(Signature::to_string)
+            .collect();
         assert_eq!(
             got, expected,
             "scenario E: a non-local `before` must be forwarded to the remote unchanged"

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -5316,6 +5316,214 @@ async fn test_closed_accounts(test_type: TestType) {
     }
 }
 
+/// Regression test for #618: when a `getSignaturesForAddress` call against a forked surfnet uses
+/// a pagination boundary (`before` / `until`) that references a transaction that exists only on
+/// the local surfnet, surfpool used to forward the boundary unchanged to the upstream, which
+/// either returned an error (strict providers) or silently mis-paginated (lenient providers
+/// like surfpool itself).
+///
+/// To exercise the real `get_signatures_for_address_local_then_remote` glue, we spin up TWO
+/// surfnets in this test: one acts as the upstream "datasource" and the other forks it. Both
+/// surfnets receive airdrops for the same `target` pubkey; the datasource airdrops become
+/// "remote-only" signatures from the local surfnet's perspective, and the local airdrops become
+/// "local-only" signatures invisible to the datasource.
+#[test_case(TestType::sqlite(); "with on-disk sqlite db")]
+#[test_case(TestType::in_memory(); "with in-memory sqlite db")]
+#[test_case(TestType::no_db(); "with no db")]
+#[cfg_attr(feature = "postgres", test_case(TestType::postgres(); "with postgres db"))]
+#[cfg_attr(feature = "ignore_tests_ci", ignore = "flaky CI tests")]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_signatures_for_address_local_then_remote(test_type: TestType) {
+    use solana_client::rpc_client::GetConfirmedSignaturesForAddress2Config;
+    use solana_signature::Signature;
+
+    // Each surfnet needs an isolated storage instance; clone the TestType variant just like
+    // `test_closed_accounts` does so the two SVMs don't share a sqlite file or surfnet_id.
+    let another_test_type = match &test_type {
+        TestType::OnDiskSqlite(_) => TestType::sqlite(),
+        TestType::InMemorySqlite => TestType::in_memory(),
+        TestType::NoDb => TestType::no_db(),
+        #[cfg(feature = "postgres")]
+        TestType::Postgres { url, .. } => TestType::Postgres {
+            url: url.clone(),
+            surfnet_id: crate::storage::tests::random_surfnet_id(),
+        },
+    };
+
+    let target = Pubkey::new_unique();
+
+    // Step 1: bring up the datasource surfnet (offline; no upstream of its own) and seed it
+    // with 3 airdrops for `target`. Each airdrop stores one signature referencing `target`.
+    //
+    // Note: litesvm's `airdrop` synthesises a `transfer(airdrop_kp, target, lamports)` tx and
+    // signs over the *current* blockhash. With `slot_time = 1ms` consecutive airdrops can land
+    // in the same slot, share the same blockhash, and — because Ed25519 signatures are
+    // deterministic — collapse to the same signature. Varying `lamports` per call guarantees a
+    // distinct message (and therefore a distinct signature) regardless of slot timing.
+    let (datasource_url, _datasource_locker) =
+        start_surfnet(vec![], None, test_type).expect("start datasource surfnet");
+    let datasource_rpc = RpcClient::new(datasource_url.clone());
+    let mut datasource_sigs: Vec<Signature> = Vec::new();
+    for i in 0..3u64 {
+        let sig = datasource_rpc
+            .request_airdrop(&target, LAMPORTS_PER_SOL + i)
+            .await
+            .expect("airdrop on datasource");
+        datasource_sigs.push(sig);
+    }
+    // `request_airdrop` returns sigs in creation order; `getSignaturesForAddress` is newest-first.
+    datasource_sigs.reverse();
+    assert_eq!(
+        datasource_sigs
+            .iter()
+            .map(Signature::to_string)
+            .collect::<std::collections::HashSet<_>>()
+            .len(),
+        datasource_sigs.len(),
+        "datasource airdrops must produce distinct signatures"
+    );
+
+    // Step 2: bring up the local surfnet, configured to fork the datasource, and seed 2 LOCAL
+    // airdrops for `target`. These signatures only ever land in the local surfnet's storage.
+    let (local_url, _local_locker) =
+        start_surfnet(vec![], Some(datasource_url), another_test_type)
+            .expect("start local surfnet");
+    let local_rpc = RpcClient::new(local_url);
+    let mut local_sigs: Vec<Signature> = Vec::new();
+    for i in 0..2u64 {
+        let sig = local_rpc
+            .request_airdrop(&target, LAMPORTS_PER_SOL + 100 + i)
+            .await
+            .expect("airdrop on local");
+        local_sigs.push(sig);
+    }
+    local_sigs.reverse();
+    assert_eq!(
+        local_sigs
+            .iter()
+            .map(Signature::to_string)
+            .collect::<std::collections::HashSet<_>>()
+            .len(),
+        local_sigs.len(),
+        "local airdrops must produce distinct signatures"
+    );
+    // local_sigs[0] is the newer local signature; local_sigs[1] is the older one.
+
+    // Scenario A: `before` is a local-only signature.
+    // Pre-fix surfpool forwarded `before=local_sigs[0]` to the datasource, which had never seen
+    // that signature — so the datasource's local lookup returned an empty window and the caller
+    // saw only `[local_sigs[1]]` (or `-32603` against a strict provider). Post-fix, the local
+    // boundary is dropped on the remote leg, so the upstream contributes its full 3 sigs.
+    {
+        let result = local_rpc
+            .get_signatures_for_address_with_config(
+                &target,
+                GetConfirmedSignaturesForAddress2Config {
+                    before: Some(local_sigs[0]),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("scenario A: getSignaturesForAddress(before=local) must succeed");
+        let got: Vec<String> = result.iter().map(|s| s.signature.clone()).collect();
+        let mut expected: Vec<String> = vec![local_sigs[1].to_string()];
+        expected.extend(datasource_sigs.iter().map(Signature::to_string));
+        assert_eq!(
+            got, expected,
+            "scenario A: expected [older-local, datasource-sigs...] when paginating past the newer local sig"
+        );
+    }
+
+    // Scenario B: `until` is a local-only signature.
+    // Pre-fix surfpool forwarded `until=local_sigs[1]` to the datasource, which didn't recognise
+    // it and so returned its FULL signature list — leaking 3 datasource sigs the caller never
+    // wanted. Post-fix, the entire remote call is skipped because every remote signature is
+    // older than the (local) boundary by construction.
+    {
+        let result = local_rpc
+            .get_signatures_for_address_with_config(
+                &target,
+                GetConfirmedSignaturesForAddress2Config {
+                    until: Some(local_sigs[1]),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("scenario B: getSignaturesForAddress(until=local) must succeed");
+        let got: Vec<String> = result.iter().map(|s| s.signature.clone()).collect();
+        assert_eq!(
+            got,
+            vec![local_sigs[0].to_string()],
+            "scenario B: a local `until` must skip the remote leg entirely"
+        );
+    }
+
+    // Scenario C: limit truncation across the local/remote boundary.
+    // The fix caps the remote leg at `limit - local_count` and truncates the combined result.
+    // Pre-fix the remote leg used the caller's full `limit` and nothing truncated the union, so
+    // a caller asking for 3 received `local_count + limit` = 2 + 3 = 5 signatures.
+    {
+        let result = local_rpc
+            .get_signatures_for_address_with_config(
+                &target,
+                GetConfirmedSignaturesForAddress2Config {
+                    limit: Some(3),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("scenario C: getSignaturesForAddress(limit=3) must succeed");
+        assert_eq!(
+            result.len(),
+            3,
+            "scenario C: combined result must respect the caller's limit"
+        );
+        let got: Vec<String> = result.iter().map(|s| s.signature.clone()).collect();
+        let expected = vec![
+            local_sigs[0].to_string(),
+            local_sigs[1].to_string(),
+            datasource_sigs[0].to_string(),
+        ];
+        assert_eq!(got, expected, "scenario C: unexpected merged ordering");
+    }
+
+    // Scenario D (sanity): no boundary — local sigs come first, then the datasource sigs.
+    {
+        let result = local_rpc
+            .get_signatures_for_address(&target)
+            .await
+            .expect("scenario D: getSignaturesForAddress(no config) must succeed");
+        let got: Vec<String> = result.iter().map(|s| s.signature.clone()).collect();
+        let mut expected: Vec<String> = local_sigs.iter().map(Signature::to_string).collect();
+        expected.extend(datasource_sigs.iter().map(Signature::to_string));
+        assert_eq!(
+            got, expected,
+            "scenario D: local sigs must precede datasource sigs in the merged stream"
+        );
+    }
+
+    // Scenario E (sanity): `before` is a DATASOURCE signature, not a local one.
+    // The fix must forward the boundary to the remote unchanged in this case.
+    {
+        let result = local_rpc
+            .get_signatures_for_address_with_config(
+                &target,
+                GetConfirmedSignaturesForAddress2Config {
+                    before: Some(datasource_sigs[0]),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("scenario E: getSignaturesForAddress(before=datasource) must succeed");
+        let got: Vec<String> = result.iter().map(|s| s.signature.clone()).collect();
+        let expected: Vec<String> = datasource_sigs[1..].iter().map(Signature::to_string).collect();
+        assert_eq!(
+            got, expected,
+            "scenario E: a non-local `before` must be forwarded to the remote unchanged"
+        );
+    }
+}
+
 #[test_case(TestType::sqlite(); "with on-disk sqlite db")]
 #[test_case(TestType::in_memory(); "with in-memory sqlite db")]
 #[test_case(TestType::no_db(); "with no db")]


### PR DESCRIPTION
## Summary
- Fixes #618: `getSignaturesForAddress` returned `-32603 Internal error` whenever `before` or `until` referenced a transaction produced locally on the surfnet.
- The local-then-remote handler in `SurfnetSvmLocker::get_signatures_for_address_local_then_remote` forwarded the caller's config unchanged, so the upstream RPC (which knows nothing about local txs) failed with `-32020 Transaction not found`.
- Surfpool already treats local transactions as strictly newer than remote ones (local-then-remote append order). That lets us translate the pagination boundary before delegating to the remote:
  * local `before` → drop `before` for the remote call (remote sigs are all older than the boundary)
  * local `until` → skip the remote call entirely (every remote sig is older and would be excluded)
  * neither local → forward the caller's config unchanged
- Extracted the translation into a pure helper (`signatures_for_address_remote_config`) with unit tests covering each branch.

## Reproduction (before the fix)
With `surfpool start` (default mainnet fork):
```bash
SIG=$(curl -s -XPOST -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"requestAirdrop","params":["9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",1000000000]}' \
  http://127.0.0.1:8899 | jq -r .result)

curl -s -XPOST -H 'Content-Type: application/json' \
  -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"getSignaturesForAddress\",\"params\":[\"9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM\",{\"limit\":10,\"before\":\"$SIG\"}]}" \
  http://127.0.0.1:8899
# {"error":{"code":-32603,"message":"Internal error","data":"Failed to fetch signatures for address from remote: RPC response error -32020: Transaction <SIG> not found; "}}
```
After the fix the same call returns 10 mainnet signatures, and `until=<local sig>` correctly returns an empty list instead of erroring.

## Test plan
- [x] `cargo build -p surfpool-core`
- [x] `cargo test -p surfpool-core --lib remote_config` (4 new unit tests)
- [x] `cargo test -p surfpool-core --lib signatures_for_address` (existing local-path tests still pass)
- [x] End-to-end smoke test against `surfpool start` (default mainnet fork): airdrop + `before=<local sig>` returns remote history; `until=<local sig>` returns empty without contacting remote.
