### PR TITLE
fix(sdk-node): point optionalDependencies at @solana/surfpool-* bindings

### DIFF
--- a/.github/workflows/release_sdk_node_npm.yml
+++ b/.github/workflows/release_sdk_node_npm.yml
@@ -50,9 +50,9 @@ jobs:
 
           for ENTRY in \
             "@solana/surfpool publish_root" \
-            "surfpool-sdk-darwin-x64 publish_darwin_x64" \
-            "surfpool-sdk-darwin-arm64 publish_darwin_arm64" \
-            "surfpool-sdk-linux-x64-gnu publish_linux_x64_gnu"
+            "@solana/surfpool-darwin-x64 publish_darwin_x64" \
+            "@solana/surfpool-darwin-arm64 publish_darwin_arm64" \
+            "@solana/surfpool-linux-x64-gnu publish_linux_x64_gnu"
           do
             PACKAGE_NAME="${ENTRY% *}"
             OUTPUT_NAME="${ENTRY#* }"
@@ -126,6 +126,36 @@ jobs:
       - name: Smoke test package
         working-directory: crates/sdk-node
         run: npm run smoke
+
+      - name: Verify install from packed tarballs
+        working-directory: crates/sdk-node
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run create-npm-dir
+          # Place the freshly built binary into its platform package so `npm pack` includes it.
+          cp surfpool-sdk/surfpool-sdk.*.node "npm/${{ matrix.platform_dir }}/"
+          # Build TS so the root tarball ships dist/.
+          npm run build:ts
+          PACK_DIR="$(mktemp -d)"
+          ROOT_TARBALL="$(npm pack --silent --pack-destination "$PACK_DIR")"
+          ROOT_TARBALL_PATH="$PACK_DIR/$ROOT_TARBALL"
+          pushd "npm/${{ matrix.platform_dir }}" >/dev/null
+          PLATFORM_TARBALL="$(npm pack --silent --pack-destination "$PACK_DIR")"
+          PLATFORM_TARBALL_PATH="$PACK_DIR/$PLATFORM_TARBALL"
+          popd >/dev/null
+          # Confirm the root's optionalDependencies reference the @solana/ scoped platform packages.
+          node -e "
+            const o = require('./package.json').optionalDependencies || {};
+            const ok = Object.keys(o).every(k => k.startsWith('@solana/surfpool-'));
+            if (!ok) { console.error('optionalDependencies missing @solana/ scope:', o); process.exit(1); }
+          "
+          INSTALL_DIR="$(mktemp -d)"
+          pushd "$INSTALL_DIR" >/dev/null
+          npm init -y >/dev/null
+          npm install --no-audit --no-fund "$PLATFORM_TARBALL_PATH" "$ROOT_TARBALL_PATH"
+          node -e "require('@solana/surfpool'); console.log('require @solana/surfpool OK');"
+          popd >/dev/null
 
       - name: Upload native binary
         uses: actions/upload-artifact@v4

--- a/crates/sdk-node/package-lock.json
+++ b/crates/sdk-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solana/surfpool",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solana/surfpool",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",
@@ -16,9 +16,9 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "surfpool-sdk-darwin-arm64": "1.2.1",
-        "surfpool-sdk-darwin-x64": "1.2.1",
-        "surfpool-sdk-linux-x64-gnu": "1.2.1"
+        "@solana/surfpool-darwin-arm64": "1.2.2",
+        "@solana/surfpool-darwin-x64": "1.2.2",
+        "@solana/surfpool-linux-x64-gnu": "1.2.2"
       }
     },
     "node_modules/@napi-rs/cli": {
@@ -38,13 +38,13 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
-    "node_modules/surfpool-sdk-darwin-arm64": {
+    "node_modules/@solana/surfpool-darwin-arm64": {
       "optional": true
     },
-    "node_modules/surfpool-sdk-darwin-x64": {
+    "node_modules/@solana/surfpool-darwin-x64": {
       "optional": true
     },
-    "node_modules/surfpool-sdk-linux-x64-gnu": {
+    "node_modules/@solana/surfpool-linux-x64-gnu": {
       "optional": true
     },
     "node_modules/typescript": {

--- a/crates/sdk-node/package.json
+++ b/crates/sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/surfpool",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Embed a Surfpool Solana runtime in your Node.js tests",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -61,8 +61,8 @@
     "typescript": "^5.7.0"
   },
   "optionalDependencies": {
-    "surfpool-sdk-darwin-x64": "1.2.1",
-    "surfpool-sdk-darwin-arm64": "1.2.1",
-    "surfpool-sdk-linux-x64-gnu": "1.2.1"
+    "@solana/surfpool-darwin-x64": "1.2.2",
+    "@solana/surfpool-darwin-arm64": "1.2.2",
+    "@solana/surfpool-linux-x64-gnu": "1.2.2"
   }
 }

--- a/crates/sdk-node/scripts/prepare-release.js
+++ b/crates/sdk-node/scripts/prepare-release.js
@@ -5,9 +5,9 @@ const path = require("path");
 const { spawnSync } = require("child_process");
 
 const PLATFORM_PACKAGES = [
-  "surfpool-sdk-darwin-x64",
-  "surfpool-sdk-darwin-arm64",
-  "surfpool-sdk-linux-x64-gnu",
+  "@solana/surfpool-darwin-x64",
+  "@solana/surfpool-darwin-arm64",
+  "@solana/surfpool-linux-x64-gnu",
 ];
 
 const VERSION_PATTERN =


### PR DESCRIPTION
The rename to @solana/surfpool in [#643](https://github.com/solana-foundation/surfpool/issues/643) missed three spots that still reference the legacy surfpool-sdk-* names, so 1.2.1 publishes a root
whose optionalDependencies do not match the platform packages that
napi-rs and the workflow actually publish. Every install fails with
MODULE_NOT_FOUND on @solana/surfpool-<triple>.

- Update root optionalDependencies to @solana/surfpool-*.
- Update prepare-release.js PLATFORM_PACKAGES so future bumps stay
  consistent.
- Update the release workflow's existence-check loop to query the
  scoped platform packages.
- Bump to 1.2.2 (1.2.1 is burned with a broken root).
- Add a CI verify-install step that packs root + platform tarballs,
  installs them in a scratch dir, and requires @solana/surfpool to
  catch this regression on each runner.