### PR TITLE
fix(sdk): boot Surfnet with mainnet feature set so p-token activates

### DIFF
--- a/.github/workflows/release_sdk_node_npm.yml
+++ b/.github/workflows/release_sdk_node_npm.yml
@@ -50,9 +50,9 @@ jobs:
 
           for ENTRY in \
             "@solana/surfpool publish_root" \
-            "surfpool-sdk-darwin-x64 publish_darwin_x64" \
-            "surfpool-sdk-darwin-arm64 publish_darwin_arm64" \
-            "surfpool-sdk-linux-x64-gnu publish_linux_x64_gnu"
+            "@solana/surfpool-darwin-x64 publish_darwin_x64" \
+            "@solana/surfpool-darwin-arm64 publish_darwin_arm64" \
+            "@solana/surfpool-linux-x64-gnu publish_linux_x64_gnu"
           do
             PACKAGE_NAME="${ENTRY% *}"
             OUTPUT_NAME="${ENTRY#* }"
@@ -126,6 +126,36 @@ jobs:
       - name: Smoke test package
         working-directory: crates/sdk-node
         run: npm run smoke
+
+      - name: Verify install from packed tarballs
+        working-directory: crates/sdk-node
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run create-npm-dir
+          # Place the freshly built binary into its platform package so `npm pack` includes it.
+          cp surfpool-sdk/surfpool-sdk.*.node "npm/${{ matrix.platform_dir }}/"
+          # Build TS so the root tarball ships dist/.
+          npm run build:ts
+          PACK_DIR="$(mktemp -d)"
+          ROOT_TARBALL="$(npm pack --silent --pack-destination "$PACK_DIR")"
+          ROOT_TARBALL_PATH="$PACK_DIR/$ROOT_TARBALL"
+          pushd "npm/${{ matrix.platform_dir }}" >/dev/null
+          PLATFORM_TARBALL="$(npm pack --silent --pack-destination "$PACK_DIR")"
+          PLATFORM_TARBALL_PATH="$PACK_DIR/$PLATFORM_TARBALL"
+          popd >/dev/null
+          # Confirm the root's optionalDependencies reference the @solana/ scoped platform packages.
+          node -e "
+            const o = require('./package.json').optionalDependencies || {};
+            const ok = Object.keys(o).every(k => k.startsWith('@solana/surfpool-'));
+            if (!ok) { console.error('optionalDependencies missing @solana/ scope:', o); process.exit(1); }
+          "
+          INSTALL_DIR="$(mktemp -d)"
+          pushd "$INSTALL_DIR" >/dev/null
+          npm init -y >/dev/null
+          npm install --no-audit --no-fund "$PLATFORM_TARBALL_PATH" "$ROOT_TARBALL_PATH"
+          node -e "require('@solana/surfpool'); console.log('require @solana/surfpool OK');"
+          popd >/dev/null
 
       - name: Upload native binary
         uses: actions/upload-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11537,6 +11537,7 @@ dependencies = [
  "solana-commitment-config",
  "solana-epoch-info",
  "solana-hash 3.1.0",
+ "solana-instruction 3.1.0",
  "solana-keypair",
  "solana-message 3.0.1",
  "solana-program-pack 3.0.0",

--- a/crates/sdk-node/package-lock.json
+++ b/crates/sdk-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solana/surfpool",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solana/surfpool",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",
@@ -16,9 +16,9 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "surfpool-sdk-darwin-arm64": "1.2.1",
-        "surfpool-sdk-darwin-x64": "1.2.1",
-        "surfpool-sdk-linux-x64-gnu": "1.2.1"
+        "@solana/surfpool-darwin-arm64": "1.2.2",
+        "@solana/surfpool-darwin-x64": "1.2.2",
+        "@solana/surfpool-linux-x64-gnu": "1.2.2"
       }
     },
     "node_modules/@napi-rs/cli": {
@@ -38,13 +38,13 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
-    "node_modules/surfpool-sdk-darwin-arm64": {
+    "node_modules/@solana/surfpool-darwin-arm64": {
       "optional": true
     },
-    "node_modules/surfpool-sdk-darwin-x64": {
+    "node_modules/@solana/surfpool-darwin-x64": {
       "optional": true
     },
-    "node_modules/surfpool-sdk-linux-x64-gnu": {
+    "node_modules/@solana/surfpool-linux-x64-gnu": {
       "optional": true
     },
     "node_modules/typescript": {

--- a/crates/sdk-node/package.json
+++ b/crates/sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/surfpool",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Embed a Surfpool Solana runtime in your Node.js tests",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -61,8 +61,8 @@
     "typescript": "^5.7.0"
   },
   "optionalDependencies": {
-    "surfpool-sdk-darwin-x64": "1.2.1",
-    "surfpool-sdk-darwin-arm64": "1.2.1",
-    "surfpool-sdk-linux-x64-gnu": "1.2.1"
+    "@solana/surfpool-darwin-x64": "1.2.2",
+    "@solana/surfpool-darwin-arm64": "1.2.2",
+    "@solana/surfpool-linux-x64-gnu": "1.2.2"
   }
 }

--- a/crates/sdk-node/scripts/prepare-release.js
+++ b/crates/sdk-node/scripts/prepare-release.js
@@ -5,9 +5,9 @@ const path = require("path");
 const { spawnSync } = require("child_process");
 
 const PLATFORM_PACKAGES = [
-  "surfpool-sdk-darwin-x64",
-  "surfpool-sdk-darwin-arm64",
-  "surfpool-sdk-linux-x64-gnu",
+  "@solana/surfpool-darwin-x64",
+  "@solana/surfpool-darwin-arm64",
+  "@solana/surfpool-linux-x64-gnu",
 ];
 
 const VERSION_PATTERN =

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -39,6 +39,7 @@ surfpool-core = { workspace = true }
 surfpool-types = { workspace = true }
 
 [dev-dependencies]
+solana-instruction = { workspace = true }
 solana-program-pack = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-transaction = { workspace = true }

--- a/crates/sdk/src/cheatcodes/tests.rs
+++ b/crates/sdk/src/cheatcodes/tests.rs
@@ -455,11 +455,13 @@ async fn withdraw_excess_lamports_executes_against_surfnet() {
         recent_blockhash,
     );
 
-    if let Err(err) = client.send_and_confirm_transaction(&tx) {
-        let msg = err.to_string();
+    let sim = client.simulate_transaction(&tx).unwrap().value;
+    if let Some(err) = sim.err {
+        let msg = format!("{err:?}");
         assert!(
             !msg.contains("Custom(12)") && !msg.contains("custom program error: 0xc"),
-            "WithdrawExcessLamports returned InvalidInstruction: {msg}"
+            "WithdrawExcessLamports returned InvalidInstruction: {msg}\nlogs: {:?}",
+            sim.logs
         );
     }
 }

--- a/crates/sdk/src/cheatcodes/tests.rs
+++ b/crates/sdk/src/cheatcodes/tests.rs
@@ -418,3 +418,48 @@ fn resolve_target_dir_walks_up_to_project_root_target() {
         temp.path().join("target").canonicalize().unwrap()
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn withdraw_excess_lamports_executes_against_surfnet() {
+    use solana_instruction::{AccountMeta, Instruction};
+    use solana_message::Message;
+    use solana_signer::Signer;
+    use solana_transaction::Transaction;
+
+    const WITHDRAW_EXCESS_LAMPORTS: u8 = 38;
+
+    let _guard = test_lock();
+    let surfnet = Surfnet::start().await.unwrap();
+    let client = surfnet.rpc_client();
+    let payer = surfnet.payer();
+
+    let source = crate::Keypair::new();
+    surfnet
+        .cheatcodes()
+        .fund_sol(&source.pubkey(), 1_000_000_000)
+        .unwrap();
+
+    let ix = Instruction {
+        program_id: spl_token_program_id(),
+        accounts: vec![
+            AccountMeta::new(source.pubkey(), false),
+            AccountMeta::new(payer.pubkey(), false),
+            AccountMeta::new_readonly(payer.pubkey(), true),
+        ],
+        data: vec![WITHDRAW_EXCESS_LAMPORTS],
+    };
+    let recent_blockhash = client.get_latest_blockhash().unwrap();
+    let tx = Transaction::new(
+        &[payer],
+        Message::new(&[ix], Some(&payer.pubkey())),
+        recent_blockhash,
+    );
+
+    if let Err(err) = client.send_and_confirm_transaction(&tx) {
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("Custom(12)") && !msg.contains("custom program error: 0xc"),
+            "WithdrawExcessLamports returned InvalidInstruction: {msg}"
+        );
+    }
+}

--- a/crates/sdk/src/surfnet.rs
+++ b/crates/sdk/src/surfnet.rs
@@ -167,7 +167,7 @@ impl SurfnetBuilder {
             instruction_profiling_enabled: surfpool_config.simnets[0].instruction_profiling_enabled,
             max_profiles: surfpool_config.simnets[0].max_profiles,
             log_bytes_limit: surfpool_config.simnets[0].log_bytes_limit,
-            feature_config: surfpool_types::SvmFeatureConfig::default(),
+            feature_config: surfpool_types::SvmFeatureConfig::default_mainnet_features(),
             skip_blockhash_check,
         };
         let (surfnet_svm, simnet_events_rx, geyser_events_rx) = SurfnetSvm::new(svm_config)

--- a/crates/types/src/features.rs
+++ b/crates/types/src/features.rs
@@ -158,8 +158,6 @@ impl SvmFeatureConfig {
             reenable_zk_elgamal_proof_program::id(),
             // remaining_compute_units syscall not yet on mainnet
             remaining_compute_units_syscall_enabled::id(),
-            // SPL token / p-token replacement not yet on mainnet
-            replace_spl_token_with_p_token::id(),
             // Stake minimum delegation raise not yet on mainnet
             stake_raise_minimum_delegation_to_1_sol::id(),
             // Stricter ABI and runtime constraints not yet on mainnet
@@ -457,6 +455,10 @@ mod tests {
             None
         );
         assert_eq!(config.is_enabled(&loosen_cpi_size_restriction::id()), None);
+        assert_eq!(
+            config.is_enabled(&replace_spl_token_with_p_token::id()),
+            None
+        );
     }
 
     // ==================== Serialization tests ====================


### PR DESCRIPTION
## Summary

Fixes TOO-379. A fresh `Surfnet::start()` boots with no feature gates active, so the legacy `spl_token` binary runs at `Tokenkeg…` and `WithdrawExcessLamports` returns `Custom(12) InvalidInstruction`. Two related causes:

- `default_mainnet_features()` still listed `replace_spl_token_with_p_token` in the disable vector with a "not yet on mainnet" comment from before p-token v0.6 launched.
- The SDK boot path passed `SvmFeatureConfig::default()` (empty) into `SurfnetSvm::new`, which short-circuits `apply_feature_config` when the config equals `SvmFeatureConfig::default()`. With the empty default, the disable/enable lists never applied — every feature gate stayed at agave's `FeatureSet::default()` (all off).

Drop p-token from the disable list and have the SDK builder pass `default_mainnet_features()` so the apply path actually runs.

## Test plan

- [x] `cargo test -p surfpool-types --lib` — `test_mainnet_features_active_features_not_in_disable` now asserts p-token is treated as live mainnet
- [x] `cargo test -p surfpool-sdk --lib` — new `withdraw_excess_lamports_executes_against_surfnet` boots a default `Surfnet`, sends a `WithdrawExcessLamports` tx via RPC, asserts no `Custom(12)`. Verified to fail pre-fix and pass post-fix.
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets` (warnings only, no errors)
