### PR TITLE
fix(ci): update Rust cache configuration in workflows

### DIFF
--- a/.github/workflows/release_sdk_node_npm.yml
+++ b/.github/workflows/release_sdk_node_npm.yml
@@ -105,6 +105,8 @@ jobs:
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2
         with:
+          prefix-key: v1-rust
+          cache-bin: false
           workspaces: |
             . -> target
 

--- a/.github/workflows/sdk_node.yml
+++ b/.github/workflows/sdk_node.yml
@@ -59,6 +59,8 @@ jobs:
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2
         with:
+          prefix-key: v1-rust
+          cache-bin: false
           workspaces: |
             . -> target
 


### PR DESCRIPTION
CI runs have been [failing](https://github.com/solana-foundation/surfpool/actions/runs/25870995585/job/76025883241?pr=663) due to some CI cacheing. This PR aims to resolve by changing the cache rules for the cargo bin