### PR TITLE
fix(cli): add pinocchio to Framework::FromStr and replace todo!() with unimplemented!()

### DIFF
--- a/crates/cli/src/types/mod.rs
+++ b/crates/cli/src/types/mod.rs
@@ -19,7 +19,7 @@ impl Framework {
     pub fn get_interpolated_program_deployment_template(&self, program_name: &str) -> String {
         match self {
             Framework::Anchor => get_interpolated_anchor_program_deployment_template(program_name),
-            Framework::Typhoon => todo!(),
+            Framework::Typhoon => unimplemented!("Typhoon framework templates are not yet implemented"),
             Framework::Native | Framework::Steel | Framework::Pinocchio => {
                 get_interpolated_native_program_deployment_template(program_name)
             }
@@ -34,7 +34,7 @@ impl Framework {
             Framework::Anchor => {
                 get_in_memory_interpolated_anchor_program_deployment_template(program_name)
             }
-            Framework::Typhoon => todo!(),
+            Framework::Typhoon => unimplemented!("Typhoon framework templates are not yet implemented"),
             Framework::Native | Framework::Steel | Framework::Pinocchio => {
                 get_in_memory_interpolated_native_program_deployment_template(program_name)
             }
@@ -91,6 +91,7 @@ impl std::str::FromStr for Framework {
             "anchor" => Ok(Framework::Anchor),
             "native" => Ok(Framework::Native),
             "steel" => Ok(Framework::Steel),
+            "pinocchio" => Ok(Framework::Pinocchio),
             "typhoon" => Ok(Framework::Typhoon),
             _ => Err(format!("Unknown framework: {}", s)),
         }

--- a/crates/cli/src/types/mod.rs
+++ b/crates/cli/src/types/mod.rs
@@ -19,7 +19,9 @@ impl Framework {
     pub fn get_interpolated_program_deployment_template(&self, program_name: &str) -> String {
         match self {
             Framework::Anchor => get_interpolated_anchor_program_deployment_template(program_name),
-            Framework::Typhoon => unimplemented!("Typhoon framework templates are not yet implemented"),
+            Framework::Typhoon => {
+                unimplemented!("Typhoon framework templates are not yet implemented")
+            }
             Framework::Native | Framework::Steel | Framework::Pinocchio => {
                 get_interpolated_native_program_deployment_template(program_name)
             }
@@ -34,7 +36,9 @@ impl Framework {
             Framework::Anchor => {
                 get_in_memory_interpolated_anchor_program_deployment_template(program_name)
             }
-            Framework::Typhoon => unimplemented!("Typhoon framework templates are not yet implemented"),
+            Framework::Typhoon => {
+                unimplemented!("Typhoon framework templates are not yet implemented")
+            }
             Framework::Native | Framework::Steel | Framework::Pinocchio => {
                 get_in_memory_interpolated_native_program_deployment_template(program_name)
             }


### PR DESCRIPTION
## Problem

`Framework::FromStr` in `crates/cli/src/types/mod.rs` had two issues:

- `"pinocchio"` was missing from the match, so `--framework pinocchio` always
  returned `Unknown framework: pinocchio` even though `Framework::Pinocchio`
  is fully implemented everywhere else.
- The `Typhoon` arms in both template methods used `todo!()`, which gives a
  misleading "not yet implemented" panic with no context.

## Changes

- Add `"pinocchio" => Ok(Framework::Pinocchio)` to `FromStr`
- Replace `todo!()` with `unimplemented!("Typhoon framework templates are not yet implemented")`
  in both `get_interpolated_program_deployment_template` and
  `get_in_memory_interpolated_program_deployment_template`

## Why `unimplemented!()` over `todo!()`

`todo!()` implies the code is actively being worked on.
`unimplemented!()` correctly signals that this feature doesn't exist yet,
giving a clear message if someone calls it instead of a bare panic.

## Test plan

- [x] `cargo test -p surfpool-cli` — 18/18 passing
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo check -p surfpool-cli` — clean
- [x] `cargo clippy --all-targets` — 0 new warnings (pre-existing warnings unrelated to this change)


Closes #688