### PR TITLE
feat(cli,core): add optional sbpf-debugger feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3459,6 +3459,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdbstub"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4e02bf1b1a624d96925c608f1b268d82a76cbc587ce9e59f7c755e9ea11c75c"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if 1.0.4",
+ "log 0.4.33",
+ "managed",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5190,6 +5204,12 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "matches"
@@ -10264,6 +10284,7 @@ checksum = "7f84c593fa3d4131045b606dec5acf9d8eac73791bc786ca9911057aec8f43ec"
 dependencies = [
  "byteorder",
  "combine 3.8.1",
+ "gdbstub",
  "hash32",
  "libc",
  "log 0.4.33",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -86,6 +86,7 @@ sqlite = ["surfpool-core/sqlite"]
 postgres = ["surfpool-core/postgres"]
 version_check = []
 register-tracing = ["surfpool-core/register-tracing"]
+sbpf-debugger = ["surfpool-core/sbpf-debugger"]
 prometheus = ["surfpool-core/prometheus", "surfpool-types/prometheus"]
 
 [dev-dependencies]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -120,6 +120,7 @@ spl-token-metadata-interface = { workspace = true }
 
 [features]
 default = ["sqlite"]
+sbpf-debugger = ["litesvm/sbpf-debugger"]
 sqlite = ["surfpool-db/sqlite"]
 postgres = ["surfpool-db/postgres"]
 ignore_tests_ci = []


### PR DESCRIPTION
**The problem**

Since recently `LiteSVM` (https://github.com/LiteSVM/litesvm/releases/tag/v0.13.0, which aligns with `Agave 4.0`) supports step-debugging of Solana programs (thanks to https://github.com/LiteSVM/litesvm/pull/354) but there's no way to actually have this functionality in `surfpool`.

**What's changed**

This PR exposes the `LiteSVM` `sbpf-debugger` feature in `surfpool` (which in turn enables it in the `Agave` runtime) allowing users to step debug `SBPF` programs from **Rust** or **TypeScript** tests.

Allowing this feature by default would be best in terms of devex (single `surfpool` binary, i.e no need for second one having this feature enabled) but there's some reasoning before doing so.

In `Agave 4.0` for the debugger to work the runtime needs to change the SBPF execution into `interpreted` mode (i.e no `JIT`) (https://github.com/anza-xyz/agave/blob/14786d96e9b635fd5d57e503f3fa0397a8ef9a6d/program-runtime/src/vm.rs#L175). While this is the case for MacOS even without the debugger (it defaults to `interpreted` mode anyway because it's incompatible with `JIT` being typically `aarch64` nowadays), enabling the sbpf-debugger for `x86` users would mean they would also be switched to `interpreted` mode by the runtime (now they would use `JIT` unless the debugger is enabled). In other words having the feature enabled by default would unconditionally force all users to `interpreted` mode in `Agave 4.0`. Thanks to https://github.com/anza-xyz/agave/pull/11717 this mode switch is no longer unconditional in `Agave 4.1` and a more fine-grained control is achieved - `interpreted` mode would be used only in the cases where the feature is actually enabled and we've provided a debug port to the runtime.

As I can't decide myself alone if this fits I've kept the feature as optional providing the context behind its reasoning.

