### PR TITLE
fix(cli): remove fork daemon dependency + fix `start --daemon` flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3305,15 +3305,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
-name = "fork"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05dc8b302e04a1c27f4fe694439ef0f29779ca4edc205b7b58f00db04e29656d"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11905,7 +11896,6 @@ dependencies = [
  "dirs 6.0.0",
  "fern",
  "flate2",
- "fork",
  "futures 0.3.32",
  "hex",
  "hiro-system-kit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ diesel_derives = { version = "2.2.6", default-features = false }
 dirs = "6.0.0"
 dotenvy = "0.15.7"
 fern = { version = "0.7.1", default-features = false }
-fork = "0.2.0"
 futures = { version = "0.3.22", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 hiro-system-kit = { version = "0.3.4", default-features = false, features = [

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -91,6 +91,3 @@ prometheus = ["surfpool-core/prometheus", "surfpool-types/prometheus"]
 
 [dev-dependencies]
 tempfile = { workspace = true }
-
-[target.'cfg(not(target_os = "windows"))'.dependencies]
-fork = "0.2.0"

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -12,8 +12,6 @@ use chrono::Local;
 use clap::{ArgAction, Args, CommandFactory, Parser, Subcommand};
 use clap_complete::{Generator, Shell};
 use fern::colors::{Color, ColoredLevelConfig};
-#[cfg(not(target_os = "windows"))]
-use fork::{Fork, daemon};
 use hiro_system_kit::{self, Logger};
 use log::info;
 use solana_keypair::Keypair;
@@ -898,6 +896,11 @@ pub async fn handle_mcp_command(_ctx: &Context) -> Result<(), String> {
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
+unsafe extern "C" {
+    fn daemon(nochdir: i32, noclose: i32) -> i32;
+}
+
 fn handle_command(opts: Opts, ctx: &Context) -> Result<(), String> {
     match opts.command {
         Command::Simnet(mut cmd) => {
@@ -933,19 +936,15 @@ fn handle_command(opts: Opts, ctx: &Context) -> Result<(), String> {
             }
 
             if cmd.runtime.daemon {
-                #[cfg(not(target_os = "windows"))]
-                match daemon(false, false) {
-                    Ok(Fork::Child) => {
-                        info!("Starting surfpool in daemon mode");
+                #[cfg(target_os = "linux")]
+                unsafe {
+                    if daemon(0, 0) != 0 {
+                        return Err(format!(
+                            "Failed to start surfpool in daemon mode: {}",
+                            std::io::Error::last_os_error()
+                        ));
                     }
-                    Ok(Fork::Parent(pid)) => {
-                        info!("Parent exiting {pid}");
-                        return Ok(());
-                    }
-                    Err(e) => {
-                        info!("Failed to start surfpool in daemon mode: {}", e);
-                        return Ok(());
-                    }
+                    info!("Starting surfpool in daemon mode");
                 };
             }
             hiro_system_kit::nestable_block_on(simnet::handle_start_local_surfnet_command(cmd, ctx))

--- a/crates/sdk-node/package-lock.json
+++ b/crates/sdk-node/package-lock.json
@@ -411,6 +411,7 @@
       "integrity": "sha512-ZCeai4LRJQooUmJXvpgMEGFTrCdJnV1ODbDJ8oqFZ+Y4t/9x1baQsFFpruqsdRyeGv2Rr+X6jV7cldVD+hyzRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/accounts": "7.0.0",
         "@solana/addresses": "7.0.0",
@@ -1025,6 +1026,54 @@
         }
       }
     },
+    "node_modules/@solana/surfpool-darwin-arm64": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@solana/surfpool-darwin-arm64/-/surfpool-darwin-arm64-1.5.0.tgz",
+      "integrity": "sha512-RdjEN7WDAr1Vrp1CD+NAS3pwT//TJclX9zyxjhAMpmBofwDzlCO8/yqv2CbD77UOuB/y3UWz3MvEEHxZfetKsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/surfpool-darwin-x64": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@solana/surfpool-darwin-x64/-/surfpool-darwin-x64-1.5.0.tgz",
+      "integrity": "sha512-8ScgLVX32JX7HH0XkijZxlpsNAALuzaJQDUTjJ1aPazKzunliek27TP9ZkVzzBHypyiY59wpwNue9PUGnGKdIw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/surfpool-linux-x64-gnu": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@solana/surfpool-linux-x64-gnu/-/surfpool-linux-x64-gnu-1.5.0.tgz",
+      "integrity": "sha512-d+wUCBdzw7U4inKoe+Lj7XlH8Nmd6A00IZOsG3R61NQbqhRVp7zFpVCCzV00RvgAOsSedkI87I6B4ehAuyGPAg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@solana/sysvars": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-7.0.0.tgz",
@@ -1199,6 +1248,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1235,15 +1285,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@solana/surfpool-darwin-x64": {
-      "optional": true
-    },
-    "node_modules/@solana/surfpool-darwin-arm64": {
-      "optional": true
-    },
-    "node_modules/@solana/surfpool-linux-x64-gnu": {
-      "optional": true
     }
   }
 }


### PR DESCRIPTION
Closes #703

- Removes the `fork` crate dependency from CLI daemon startup.
- Uses the libc daemon FFI directly on Linux.
- Returns a proper error when daemon startup fails instead of continuing silently.

I tried passing `1` as the 2nd arg, just to see the logs, and it does not crash as it does in issue #703
