### PR TITLE
fix(core): set parent_slot to slot - 1 for transaction blocks

### DIFF
--- a/crates/core/src/surfnet/svm.rs
+++ b/crates/core/src/surfnet/svm.rs
@@ -2332,7 +2332,7 @@ impl SurfnetSvm {
                     previous_blockhash: previous_chain_tip.hash.clone(),
                     block_time: self.updated_at as i64 / 1_000,
                     block_height: self.chain_tip.index,
-                    parent_slot: slot,
+                    parent_slot: slot.saturating_sub(1),
                     signatures: confirmed_signatures,
                 },
             )?;


### PR DESCRIPTION
Fixes #709

## Summary

Fixes `getBlock` returning `parentSlot == slot` for blocks that contain transactions. It should be `slot - 1`, matching empty blocks and normal Solana block metadata.

Photon and similar indexers require `parent_slot == last_indexed_slot` to advance; with the wrong value they stall on the first tx block.

## Test plan

- [ ] Start surfpool in clock mode, submit a tx, confirm `getBlock` returns `parentSlot == slot - 1`
- [ ] Photon indexer stays caught up after txs land