### PR TITLE
chore(sdk-node): bump @solana/surfpool to 1.6.0

### DIFF
--- a/crates/sdk-node/package-lock.json
+++ b/crates/sdk-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solana/surfpool",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solana/surfpool",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",
@@ -19,9 +19,9 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@solana/surfpool-darwin-arm64": "1.5.0",
-        "@solana/surfpool-darwin-x64": "1.5.0",
-        "@solana/surfpool-linux-x64-gnu": "1.5.0"
+        "@solana/surfpool-darwin-arm64": "1.6.0",
+        "@solana/surfpool-darwin-x64": "1.6.0",
+        "@solana/surfpool-linux-x64-gnu": "1.6.0"
       },
       "peerDependencies": {
         "@solana/kit": "^7.0.0",
@@ -1235,6 +1235,15 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@solana/surfpool-darwin-x64": {
+      "optional": true
+    },
+    "node_modules/@solana/surfpool-darwin-arm64": {
+      "optional": true
+    },
+    "node_modules/@solana/surfpool-linux-x64-gnu": {
+      "optional": true
     }
   }
 }

--- a/crates/sdk-node/package.json
+++ b/crates/sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/surfpool",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Embed a Surfpool Solana runtime in your Node.js tests",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -93,8 +93,8 @@
     }
   },
   "optionalDependencies": {
-    "@solana/surfpool-darwin-x64": "1.5.0",
-    "@solana/surfpool-darwin-arm64": "1.5.0",
-    "@solana/surfpool-linux-x64-gnu": "1.5.0"
+    "@solana/surfpool-darwin-x64": "1.6.0",
+    "@solana/surfpool-darwin-arm64": "1.6.0",
+    "@solana/surfpool-linux-x64-gnu": "1.6.0"
   }
 }


### PR DESCRIPTION
Bumps the `@solana/surfpool` node SDK to **1.6.0**.

**Background:** 
`1.5.0` was never published to npm — its publish approval flow ([run 29422570066](https://github.com/solana-foundation/surfpool/actions/runs/29422570066)) has sat in `waiting` since 2026-07-15 and was never approved (npm latest is still `1.4.0`). The kit plugin + confidential-transfer changes are already on `main` but stuck under the `1.5.0` label, so a bump is needed to actually ship them.

Bumping to `1.6.0` gives them a clean minor release and keeps the SDK aligned with the upcoming CLI/crates `1.6.0`.

This also regenerates `package-lock.json` with the optional platform-package stubs (via `prepare-release.js`) that the current lock is missing — that gap failed the most recent publish at `npm ci` under npm 11.

**Changes:**
- `package.json` — `version` + `optionalDependencies` → `1.6.0`
- `package-lock.json` — regenerated with platform stubs
