### PR TITLE
fix(sdk-node): add optional platform stubs to lockfile to unblock npm publish

### DIFF
--- a/crates/sdk-node/package-lock.json
+++ b/crates/sdk-node/package-lock.json
@@ -1235,6 +1235,15 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@solana/surfpool-darwin-x64": {
+      "optional": true
+    },
+    "node_modules/@solana/surfpool-darwin-arm64": {
+      "optional": true
+    },
+    "node_modules/@solana/surfpool-linux-x64-gnu": {
+      "optional": true
     }
   }
 }


### PR DESCRIPTION
Adds the three optional platform-package stub entries to `package-lock.json` so the publish job's `npm ci` (npm 11, strict) stays in sync. Ships `@solana/surfpool` **1.5.0** — version unchanged.

## Why

`1.5.0` was never published to npm — its original publish approval flow ([run 29422570066](https://github.com/solana-foundation/surfpool/actions/runs/29422570066)) has sat in `waiting` since 2026-07-15 and was never approved (npm latest is still `1.4.0`).

A later run ([30565967240](https://github.com/solana-foundation/surfpool/actions/runs/30565967240)) was approved but failed at `npm ci`: the lockfile was missing the optional `@solana/surfpool-darwin-*` / `-linux-x64-gnu` entries, which npm 11 rejects. The platform packages publish in the same release, so `npm install` drops them — `prepare-release.js` re-injects them as stubs.

## Change

- `package-lock.json` — regenerated via `prepare-release.js`; adds 3 optional platform stubs. No version change.
