### PR TITLE
feat(sdk-node): stop embedded Surfnet on kit client disposal

### DIFF
--- a/crates/sdk-node/README.md
+++ b/crates/sdk-node/README.md
@@ -50,6 +50,15 @@ const slot = await client.rpc.getSlot().send();
 client.surfnet.stop();
 ```
 
+The embedded client is `Disposable`: disposing it stops the Surfnet, so you can
+use `using` instead of calling `stop()` yourself and a recreated client boots a
+fresh instance.
+
+```ts
+using client = await createClient().use(surfpool());
+// Surfnet stops automatically when `client` goes out of scope.
+```
+
 Surfnet startup options go under the `surfnet` key; everything else is
 forwarded to the standard local RPC plugin:
 

--- a/crates/sdk-node/scripts/kit-smoke.js
+++ b/crates/sdk-node/scripts/kit-smoke.js
@@ -60,3 +60,12 @@ test("embedded surfpool() boots a Surfnet and wires the full kit client", async 
   const funded = await client.rpc.getBalance(recipient).send();
   assert.equal(funded.value, 1_000_000_000n);
 });
+
+test("disposing the embedded client stops the Surfnet", async () => {
+  const client = await createClient().use(surfpool({ surfnet: { offline: true } }));
+  await client.rpc.getSlot().send();
+
+  client[Symbol.dispose]();
+
+  await assert.rejects(client.rpc.getSlot().send());
+});

--- a/crates/sdk-node/surfpool-sdk/kit/surfpool.ts
+++ b/crates/sdk-node/surfpool-sdk/kit/surfpool.ts
@@ -1,4 +1,4 @@
-import { type ClientWithPayer, createKeyPairSignerFromBytes, extendClient, pipe } from '@solana/kit';
+import { type ClientWithPayer, createKeyPairSignerFromBytes, extendClient, pipe, withCleanup } from '@solana/kit';
 import { solanaLocalRpc, type SolanaRpcConfig } from '@solana/kit-plugin-rpc';
 import type { SurfnetConfig } from '@solana/surfpool';
 
@@ -51,7 +51,7 @@ function surfpoolEmbedded(config: SurfpoolEmbeddedConfig = {}) {
         try {
             const payer = await createKeyPairSignerFromBytes(surfnet.payerSecretKey);
 
-            return pipe(
+            const configuredClient = pipe(
                 extendClient(client, {
                     cheatcodes: createSurfnetCheatcodesRpc(surfnet.rpcUrl, { headers: extractHeaders(rpcOptions) }),
                     rpcUrl: surfnet.rpcUrl,
@@ -65,6 +65,10 @@ function surfpoolEmbedded(config: SurfpoolEmbeddedConfig = {}) {
                     rpcUrl: surfnet.rpcUrl,
                 }),
             );
+
+            // Disposing the client stops the in-process Surfnet so its servers
+            // and ports are freed; recreating the client boots a fresh one.
+            return withCleanup(configuredClient, () => surfnet.stop());
         } catch (error) {
             // If setup fails, the Surfnet handle never reaches the caller, so
             // it must be stopped here to free its servers and ports. `stop()`
@@ -111,6 +115,8 @@ function surfpoolAttach(config: SurfpoolAttachConfig) {
  * `client.surfnet` for in-process helpers (`fundSol`, `deploy`, …), and a
  * typed cheatcodes RPC covering all `surfnet_*` methods as `client.cheatcodes`.
  * `identity` is left untouched — install your own with `.use(identity(...))`.
+ * The client is {@link Disposable}: disposing it stops the Surfnet, so a
+ * recreated client boots a fresh one.
  *
  * **Attach mode** (when `rpcUrl` is set): connects to an already-running
  * Surfpool instance (e.g. `surfpool start`) instead of booting one. No native

--- a/crates/sdk-node/surfpool-sdk/kit/surfpool.ts
+++ b/crates/sdk-node/surfpool-sdk/kit/surfpool.ts
@@ -68,20 +68,20 @@ function surfpoolEmbedded(config: SurfpoolEmbeddedConfig = {}) {
 
             // Disposing the client stops the in-process Surfnet so its servers
             // and ports are freed; recreating the client boots a fresh one.
-            if (typeof (globalThis as { DisposableStack?: unknown }).DisposableStack !== 'undefined') {
+            if (typeof DisposableStack !== 'undefined') {
                 return withCleanup(configuredClient, () => surfnet.stop());
             }
             // `withCleanup` needs the `DisposableStack` global (Node 24+). On
             // older runtimes register the disposer on `Symbol.dispose` directly,
             // chaining any existing one. Below Node 20 the symbol is absent and
             // the client is returned without a disposer.
-            const disposeSymbol = (Symbol as { dispose?: symbol }).dispose;
+            const disposeSymbol: symbol | undefined = (Symbol as { dispose?: symbol }).dispose;
             if (!disposeSymbol) {
                 return configuredClient;
             }
-            const existingDispose = (configuredClient as Record<symbol, (() => void) | undefined>)[disposeSymbol];
+            const existingDispose = (configuredClient as { [Symbol.dispose]?: () => void })[Symbol.dispose];
             return extendClient(configuredClient, {
-                [disposeSymbol]() {
+                [Symbol.dispose]() {
                     existingDispose?.call(configuredClient);
                     surfnet.stop();
                 },

--- a/crates/sdk-node/surfpool-sdk/kit/surfpool.ts
+++ b/crates/sdk-node/surfpool-sdk/kit/surfpool.ts
@@ -1,4 +1,4 @@
-import { type ClientWithPayer, createKeyPairSignerFromBytes, extendClient, pipe, withCleanup } from '@solana/kit';
+import { type ClientWithPayer, createKeyPairSignerFromBytes, extendClient, pipe } from '@solana/kit';
 import { solanaLocalRpc, type SolanaRpcConfig } from '@solana/kit-plugin-rpc';
 import type { SurfnetConfig } from '@solana/surfpool';
 
@@ -68,7 +68,19 @@ function surfpoolEmbedded(config: SurfpoolEmbeddedConfig = {}) {
 
             // Disposing the client stops the in-process Surfnet so its servers
             // and ports are freed; recreating the client boots a fresh one.
-            return withCleanup(configuredClient, () => surfnet.stop());
+            // Any existing disposer is chained ahead of the stop. Runtimes
+            // without `Symbol.dispose` (Node < 20) simply get no disposer.
+            const disposeSymbol = (Symbol as { dispose?: symbol }).dispose;
+            if (!disposeSymbol) {
+                return configuredClient;
+            }
+            const existingDispose = (configuredClient as Record<symbol, (() => void) | undefined>)[disposeSymbol];
+            return extendClient(configuredClient, {
+                [disposeSymbol]() {
+                    existingDispose?.call(configuredClient);
+                    surfnet.stop();
+                },
+            });
         } catch (error) {
             // If setup fails, the Surfnet handle never reaches the caller, so
             // it must be stopped here to free its servers and ports. `stop()`

--- a/crates/sdk-node/surfpool-sdk/kit/surfpool.ts
+++ b/crates/sdk-node/surfpool-sdk/kit/surfpool.ts
@@ -1,4 +1,4 @@
-import { type ClientWithPayer, createKeyPairSignerFromBytes, extendClient, pipe } from '@solana/kit';
+import { type ClientWithPayer, createKeyPairSignerFromBytes, extendClient, pipe, withCleanup } from '@solana/kit';
 import { solanaLocalRpc, type SolanaRpcConfig } from '@solana/kit-plugin-rpc';
 import type { SurfnetConfig } from '@solana/surfpool';
 
@@ -68,8 +68,13 @@ function surfpoolEmbedded(config: SurfpoolEmbeddedConfig = {}) {
 
             // Disposing the client stops the in-process Surfnet so its servers
             // and ports are freed; recreating the client boots a fresh one.
-            // Any existing disposer is chained ahead of the stop. Runtimes
-            // without `Symbol.dispose` (Node < 20) simply get no disposer.
+            if (typeof (globalThis as { DisposableStack?: unknown }).DisposableStack !== 'undefined') {
+                return withCleanup(configuredClient, () => surfnet.stop());
+            }
+            // `withCleanup` needs the `DisposableStack` global (Node 24+). On
+            // older runtimes register the disposer on `Symbol.dispose` directly,
+            // chaining any existing one. Below Node 20 the symbol is absent and
+            // the client is returned without a disposer.
             const disposeSymbol = (Symbol as { dispose?: symbol }).dispose;
             if (!disposeSymbol) {
                 return configuredClient;

--- a/crates/sdk-node/tsconfig.kit.json
+++ b/crates/sdk-node/tsconfig.kit.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "lib": ["ES2022", "DOM", "ESNext.Disposable"],
     "rootDir": "surfpool-sdk/kit",
     "outDir": "dist/kit",
     "baseUrl": ".",


### PR DESCRIPTION
## What

Makes the embedded `surfpool()` kit client `Disposable`: `surfnet.stop()` now runs when the client is disposed, freeing its RPC/WS ports. Recreating the client boots a fresh Surfnet (stop/start), matching the behavior the wallet plugin relies on.

Implements a suggestion from Anza: wrap the client in `withCleanup` so disposal stops the Surfnet, mirroring the existing stop-on-setup-failure path. Attach mode is untouched — it never owns a Surfnet.

## Changes

- `surfpool.ts` — wrap the embedded client in `withCleanup(client, () => surfnet.stop())`.
- `kit-smoke.js` — test that `client[Symbol.dispose]()` stops the Surfnet (subsequent RPC rejects).
- `README.md` — `using` example.
- `package-lock.json` — sync with the now-published `1.5.0` platform packages. The version-less optional stubs from #728 satisfied `npm ci` only while those packages were unpublished; now that they are on the registry, `npm ci` resolves them and rejects the stubs. Regenerated so they carry real version/resolved/integrity entries.

## Testing

`npm ci` + `npm test` → 20/20 pass (includes `typecheck:kit`).