### PR TITLE
test(core): if you spawn it, you stop it!

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,10 @@ jobs:
       - name: Run Cargo fmt
         run: cargo +nightly fmt --all -- --check
       - name: Run Cargo clippy
-        run: cargo clippy --all-targets
+        # --workspace, because default-members is crates/cli: without it the
+        # other eight crates are linted only as libraries, and their test code
+        # not at all.
+        run: cargo clippy --workspace --all-targets
   build:
     runs-on: ubuntu-latest
     services:

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -1,7 +1,7 @@
 use std::{str::FromStr, sync::Arc, time::Duration};
 
 use base64::Engine;
-use crossbeam_channel::{unbounded, unbounded as crossbeam_unbounded};
+use crossbeam_channel::{Sender, unbounded, unbounded as crossbeam_unbounded};
 use ed25519_dalek::Signer as DalekSigner;
 use jsonrpc_core::{
     Error, Result as JsonRpcResult,
@@ -78,12 +78,73 @@ use crate::{
     runloops::start_local_surfnet_runloop,
     storage::tests::TestType,
     surfnet::{
-        FINALIZATION_SLOT_THRESHOLD, PluginCommand, SignatureSubscriptionType,
+        FINALIZATION_SLOT_THRESHOLD, GeyserEvent, PluginCommand, SignatureSubscriptionType,
         locker::SurfnetSvmLocker, svm::SurfnetSvm,
     },
     tests::helpers::get_free_port,
     types::{TimeTravelConfig, TransactionLoadedAddresses},
 };
+
+/// A running surfnet and the thread it runs on. Dropping it stops the runloop.
+struct RunloopGuard {
+    commands: Sender<SimnetCommand>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Drop for RunloopGuard {
+    fn drop(&mut self) {
+        let _ = self.commands.send(SimnetCommand::Terminate(None));
+        let Some(thread) = self.thread.take() else {
+            return;
+        };
+        // Bounded rather than a plain join: a runloop that never reached its
+        // command loop would never see the Terminate, and a drop that blocks
+        // forever turns a failing test into a hanging one.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while !thread.is_finished() && std::time::Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+}
+
+/// Starts a runloop on its own thread and hands back the guard that stops it.
+///
+/// Bind the guard for as long as the test needs the surfnet, conventionally
+/// `let _runloop = spawn_runloop(...)`. A plain `let _ =` drops it there and
+/// then, which stops the runloop before the test has used it.
+#[must_use = "the runloop stops when the guard drops"]
+fn spawn_runloop(
+    svm_locker: SurfnetSvmLocker,
+    config: SurfpoolConfig,
+    commands: (
+        Sender<SimnetCommand>,
+        crossbeam_channel::Receiver<SimnetCommand>,
+    ),
+    geyser_events_rx: crossbeam_channel::Receiver<GeyserEvent>,
+) -> RunloopGuard {
+    let (simnet_commands_tx, simnet_commands_rx) = commands;
+    let stop = simnet_commands_tx.clone();
+
+    let thread = hiro_system_kit::thread_named("test")
+        .spawn(move || {
+            let future = start_local_surfnet_runloop(
+                svm_locker,
+                config,
+                simnet_commands_tx,
+                simnet_commands_rx,
+                geyser_events_rx,
+            );
+            if let Err(e) = hiro_system_kit::nestable_block_on(future) {
+                panic!("{e:?}");
+            }
+        })
+        .expect("failed to spawn surfnet runloop");
+
+    RunloopGuard {
+        commands: stop,
+        thread: Some(thread),
+    }
+}
 
 fn wait_for_ready_and_connected(simnet_events_rx: &crossbeam_channel::Receiver<SimnetEvent>) {
     let mut ready = false;
@@ -126,18 +187,12 @@ async fn test_simnet_ready(test_type: TestType) {
 
     let svm_locker = SurfnetSvmLocker::new(surfnet_svm);
 
-    let _handle = hiro_system_kit::thread_named("test").spawn(move || {
-        let future = start_local_surfnet_runloop(
-            svm_locker,
-            config,
-            simnet_commands_tx,
-            simnet_commands_rx,
-            geyser_events_rx,
-        );
-        if let Err(e) = hiro_system_kit::nestable_block_on(future) {
-            panic!("{e:?}");
-        }
-    });
+    let _runloop = spawn_runloop(
+        svm_locker,
+        config,
+        (simnet_commands_tx, simnet_commands_rx),
+        geyser_events_rx,
+    );
 
     // One event, not a loop: both arms leave immediately, so what this asserts
     // is that the first thing the runloop says is a startup event rather than
@@ -180,25 +235,23 @@ async fn test_simnet_ticks(test_type: TestType) {
     let (test_tx, test_rx) = unbounded();
     let svm_locker = SurfnetSvmLocker::new(surfnet_svm);
 
-    let _handle = hiro_system_kit::thread_named("test").spawn(move || {
-        let future = start_local_surfnet_runloop(
-            svm_locker,
-            config,
-            simnet_commands_tx,
-            simnet_commands_rx,
-            geyser_events_rx,
-        );
-        if let Err(e) = hiro_system_kit::nestable_block_on(future) {
-            panic!("{e:?}");
-        }
-    });
+    let _runloop = spawn_runloop(
+        svm_locker,
+        config,
+        (simnet_commands_tx, simnet_commands_rx),
+        geyser_events_rx,
+    );
 
     let _ = hiro_system_kit::thread_named("ticks").spawn(move || {
         let mut ticks = 0;
         loop {
             match simnet_events_rx.recv() {
                 Ok(SimnetEvent::SystemClockUpdated(_)) => ticks += 1,
-                _ => (),
+                Ok(_) => (),
+                // The runloop has stopped and the channel is closed: recv()
+                // returns immediately from here on, so this loop would spin a
+                // core for the rest of the run.
+                Err(_) => break,
             }
 
             if ticks > 100 {
@@ -248,18 +301,12 @@ async fn test_simnet_some_sol_transfers(test_type: TestType) {
 
     let svm_locker = SurfnetSvmLocker::new(surfnet_svm);
 
-    let _handle = hiro_system_kit::thread_named("test").spawn(move || {
-        let future = start_local_surfnet_runloop(
-            svm_locker,
-            config,
-            simnet_commands_tx,
-            simnet_commands_rx,
-            geyser_events_rx,
-        );
-        if let Err(e) = hiro_system_kit::nestable_block_on(future) {
-            panic!("{e:?}");
-        }
-    });
+    let _runloop = spawn_runloop(
+        svm_locker,
+        config,
+        (simnet_commands_tx, simnet_commands_rx),
+        geyser_events_rx,
+    );
 
     wait_for_ready_and_connected(&simnet_events_rx);
 
@@ -406,19 +453,12 @@ async fn test_add_alt_entries_fetching(test_type: TestType) {
 
     let svm_locker = Arc::new(RwLock::new(surfnet_svm));
 
-    let moved_svm_locker = svm_locker.clone();
-    let _handle = hiro_system_kit::thread_named("test").spawn(move || {
-        let future = start_local_surfnet_runloop(
-            SurfnetSvmLocker(moved_svm_locker),
-            config,
-            simnet_commands_tx,
-            simnet_commands_rx,
-            geyser_events_rx,
-        );
-        if let Err(e) = hiro_system_kit::nestable_block_on(future) {
-            panic!("{e:?}");
-        }
-    });
+    let _runloop = spawn_runloop(
+        SurfnetSvmLocker(svm_locker.clone()),
+        config,
+        (simnet_commands_tx, simnet_commands_rx),
+        geyser_events_rx,
+    );
     let svm_locker = SurfnetSvmLocker(svm_locker);
 
     wait_for_ready_and_connected(&simnet_events_rx);
@@ -578,19 +618,12 @@ async fn test_simulate_add_alt_entries_fetching(test_type: TestType) {
 
     let svm_locker = Arc::new(RwLock::new(surfnet_svm));
 
-    let moved_svm_locker = svm_locker.clone();
-    let _handle = hiro_system_kit::thread_named("test").spawn(move || {
-        let future = start_local_surfnet_runloop(
-            SurfnetSvmLocker(moved_svm_locker),
-            config,
-            simnet_commands_tx,
-            simnet_commands_rx,
-            geyser_events_rx,
-        );
-        if let Err(e) = hiro_system_kit::nestable_block_on(future) {
-            panic!("{e:?}");
-        }
-    });
+    let _runloop = spawn_runloop(
+        SurfnetSvmLocker(svm_locker.clone()),
+        config,
+        (simnet_commands_tx, simnet_commands_rx),
+        geyser_events_rx,
+    );
     let svm_locker = SurfnetSvmLocker(svm_locker);
 
     wait_for_ready_and_connected(&simnet_events_rx);
@@ -713,19 +746,12 @@ async fn test_simulate_transaction_no_signers(test_type: TestType) {
 
     let svm_locker = Arc::new(RwLock::new(surfnet_svm));
 
-    let moved_svm_locker = svm_locker.clone();
-    let _handle = hiro_system_kit::thread_named("test").spawn(move || {
-        let future = start_local_surfnet_runloop(
-            SurfnetSvmLocker(moved_svm_locker),
-            config,
-            simnet_commands_tx,
-            simnet_commands_rx,
-            geyser_events_rx,
-        );
-        if let Err(e) = hiro_system_kit::nestable_block_on(future) {
-            panic!("{e:?}");
-        }
-    });
+    let _runloop = spawn_runloop(
+        SurfnetSvmLocker(svm_locker.clone()),
+        config,
+        (simnet_commands_tx, simnet_commands_rx),
+        geyser_events_rx,
+    );
     let svm_locker = SurfnetSvmLocker(svm_locker);
 
     wait_for_ready_and_connected(&simnet_events_rx);
@@ -909,21 +935,12 @@ async fn test_load_snapshot_program_is_invokable() {
     let (surfnet_svm, simnet_events_rx, geyser_events_rx) = TestType::no_db().initialize_svm();
     let (simnet_commands_tx, simnet_commands_rx) = unbounded();
     let svm_locker = SurfnetSvmLocker::new(surfnet_svm);
-    let runloop_locker = svm_locker.clone();
-    let _handle = hiro_system_kit::thread_named("test_load_snapshot_program_is_invokable")
-        .spawn(move || {
-            let future = start_local_surfnet_runloop(
-                runloop_locker,
-                config,
-                simnet_commands_tx,
-                simnet_commands_rx,
-                geyser_events_rx,
-            );
-            if let Err(e) = hiro_system_kit::nestable_block_on(future) {
-                panic!("{e:?}");
-            }
-        })
-        .expect("failed to spawn surfnet runloop");
+    let _runloop = spawn_runloop(
+        svm_locker.clone(),
+        config,
+        (simnet_commands_tx, simnet_commands_rx),
+        geyser_events_rx,
+    );
 
     loop {
         match simnet_events_rx.recv_timeout(Duration::from_secs(5)) {
@@ -4036,6 +4053,10 @@ async fn test_get_local_signatures_with_limit(test_type: TestType) {
 // Clock Control Tests (pauseClock, resumeClock, timeTravel)
 // ============================================================================
 
+/// Boots a simnet and waits for it to be ready.
+///
+/// The [`RunloopGuard`] comes back with the handles because it has to outlive
+/// them: held here, it would stop the runloop as this function returns.
 fn boot_simnet(
     block_production_mode: BlockProductionMode,
     slot_time: Option<u64>,
@@ -4044,6 +4065,7 @@ fn boot_simnet(
     SurfnetSvmLocker,
     crossbeam_channel::Sender<SimnetCommand>,
     crossbeam_channel::Receiver<SimnetEvent>,
+    RunloopGuard,
 ) {
     let bind_host = "127.0.0.1";
     let bind_port = get_free_port().unwrap();
@@ -4071,20 +4093,12 @@ fn boot_simnet(
 
     let svm_locker = SurfnetSvmLocker::new(surfnet_svm);
 
-    let svm_locker_cc: SurfnetSvmLocker = svm_locker.clone();
-    let simnet_commands_tx_cc = simnet_commands_tx.clone();
-    let _handle = hiro_system_kit::thread_named("test").spawn(move || {
-        let future = start_local_surfnet_runloop(
-            svm_locker_cc,
-            config,
-            simnet_commands_tx_cc,
-            simnet_commands_rx,
-            geyser_events_rx,
-        );
-        if let Err(e) = hiro_system_kit::nestable_block_on(future) {
-            panic!("{e:?}");
-        }
-    });
+    let runloop = spawn_runloop(
+        svm_locker.clone(),
+        config,
+        (simnet_commands_tx.clone(), simnet_commands_rx),
+        geyser_events_rx,
+    );
 
     loop {
         if let Ok(SimnetEvent::Ready(_)) =
@@ -4094,7 +4108,7 @@ fn boot_simnet(
         }
     }
 
-    (svm_locker, simnet_commands_tx, simnet_events_rx)
+    (svm_locker, simnet_commands_tx, simnet_events_rx, runloop)
 }
 
 #[test_case(TestType::sqlite(); "with on-disk sqlite db")]
@@ -4103,7 +4117,7 @@ fn boot_simnet(
 #[cfg_attr(feature = "postgres", test_case(TestType::postgres(); "with postgres db"))]
 fn test_time_travel_resume_paused_clock(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
-    let (svm_locker, simnet_cmd_tx, _) =
+    let (svm_locker, simnet_cmd_tx, _, _runloop) =
         boot_simnet(BlockProductionMode::Clock, Some(100), test_type);
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
 
@@ -4182,7 +4196,7 @@ fn test_time_travel_resume_paused_clock(test_type: TestType) {
 fn test_time_travel_absolute_timestamp(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
     let slot_time = 100;
-    let (svm_locker, simnet_cmd_tx, simnet_events_rx) = boot_simnet(
+    let (svm_locker, simnet_cmd_tx, simnet_events_rx, _runloop) = boot_simnet(
         BlockProductionMode::Clock,
         Some(slot_time.clone()),
         test_type,
@@ -4269,7 +4283,7 @@ fn test_time_travel_absolute_timestamp(test_type: TestType) {
 #[cfg_attr(feature = "postgres", test_case(TestType::postgres(); "with postgres db"))]
 fn test_time_travel_absolute_slot(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
-    let (svm_locker, simnet_cmd_tx, simnet_events_rx) =
+    let (svm_locker, simnet_cmd_tx, simnet_events_rx, _runloop) =
         boot_simnet(BlockProductionMode::Clock, Some(400), test_type);
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
 
@@ -4347,7 +4361,7 @@ fn test_time_travel_absolute_slot(test_type: TestType) {
 #[cfg_attr(feature = "postgres", test_case(TestType::postgres(); "with postgres db"))]
 fn test_time_travel_absolute_epoch(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
-    let (svm_locker, simnet_cmd_tx, simnet_events_rx) =
+    let (svm_locker, simnet_cmd_tx, simnet_events_rx, _runloop) =
         boot_simnet(BlockProductionMode::Clock, Some(400), test_type);
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
 
@@ -4428,7 +4442,7 @@ fn test_time_travel_absolute_epoch(test_type: TestType) {
 #[cfg_attr(feature = "postgres", test_case(TestType::postgres(); "with postgres db"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_ix_profiling_with_alt_tx(test_type: TestType) {
-    let (svm_locker, _simnet_cmd_tx, _simnet_events_rx) =
+    let (svm_locker, _simnet_cmd_tx, _simnet_events_rx, _runloop) =
         boot_simnet(BlockProductionMode::Clock, Some(400), test_type);
 
     let p1 = Keypair::new();
@@ -4717,7 +4731,7 @@ async fn test_ix_profiling_with_alt_tx(test_type: TestType) {
 #[cfg_attr(feature = "postgres", test_case(TestType::postgres(); "with postgres db"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn it_should_delete_accounts_with_no_lamports(test_type: TestType) {
-    let (svm_locker, _simnet_cmd_tx, _simnet_events_rx) =
+    let (svm_locker, _simnet_cmd_tx, _simnet_events_rx, _runloop) =
         boot_simnet(BlockProductionMode::Clock, Some(400), test_type);
     let p1 = Keypair::new();
     let p2 = Keypair::new();
@@ -4769,7 +4783,7 @@ async fn it_should_delete_accounts_with_no_lamports(test_type: TestType) {
 #[cfg_attr(feature = "postgres", test_case(TestType::postgres(); "with postgres db"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_compute_budget_profiling(test_type: TestType) {
-    let (svm_locker, _simnet_cmd_tx, _simnet_events_rx) =
+    let (svm_locker, _simnet_cmd_tx, _simnet_events_rx, _runloop) =
         boot_simnet(BlockProductionMode::Clock, Some(400), test_type);
     let p1 = Keypair::new();
     let p2 = Keypair::new();
@@ -5273,7 +5287,7 @@ fn test_reset_network_keeps_latest_blockhash_valid(test_type: TestType) {
 #[cfg_attr(feature = "postgres", test_case(TestType::postgres(); "with postgres db"))]
 fn test_reset_network_time_travel_timestamp(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
-    let (svm_locker, simnet_cmd_tx, simnet_events_rx) =
+    let (svm_locker, simnet_cmd_tx, simnet_events_rx, _runloop) =
         boot_simnet(BlockProductionMode::Clock, Some(400), test_type);
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
 
@@ -5326,7 +5340,7 @@ fn test_reset_network_time_travel_timestamp(test_type: TestType) {
 #[cfg_attr(feature = "postgres", test_case(TestType::postgres(); "with postgres db"))]
 fn test_reset_network_time_travel_slot(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
-    let (svm_locker, simnet_cmd_tx, simnet_events_rx) =
+    let (svm_locker, simnet_cmd_tx, simnet_events_rx, _runloop) =
         boot_simnet(BlockProductionMode::Clock, Some(400), test_type);
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
 
@@ -5383,7 +5397,7 @@ fn test_reset_network_time_travel_slot(test_type: TestType) {
 #[cfg_attr(feature = "postgres", test_case(TestType::postgres(); "with postgres db"))]
 fn test_reset_network_time_travel_epoch(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
-    let (svm_locker, simnet_cmd_tx, simnet_events_rx) =
+    let (svm_locker, simnet_cmd_tx, simnet_events_rx, _runloop) =
         boot_simnet(BlockProductionMode::Clock, Some(400), test_type);
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
 
@@ -5434,11 +5448,18 @@ fn test_reset_network_time_travel_epoch(test_type: TestType) {
     );
 }
 
+/// Starts a surfnet on free ports and waits for it to be ready and connected,
+/// returning its RPC URL alongside the locker.
+///
+/// The [`RunloopGuard`] comes back for the same reason it does from
+/// [`boot_simnet`]. A test that starts two surfnets binds two guards; the
+/// second shadowing the first is fine, since a shadowed binding still lives to
+/// the end of the scope.
 fn start_surfnet(
     airdrop_addresses: Vec<Pubkey>,
     datasource_rpc_url: Option<String>,
     test_type: TestType,
-) -> Result<(String, SurfnetSvmLocker), String> {
+) -> Result<(String, SurfnetSvmLocker, RunloopGuard), String> {
     let bind_host = "127.0.0.1";
     let bind_port = get_free_port().unwrap();
     let ws_port = get_free_port().unwrap();
@@ -5465,20 +5486,12 @@ fn start_surfnet(
     let (surfnet_svm, simnet_events_rx, geyser_events_rx) = test_type.initialize_svm();
     let (simnet_commands_tx, simnet_commands_rx) = unbounded();
     let svm_locker = SurfnetSvmLocker::new(surfnet_svm);
-    let svm_locker_cc: SurfnetSvmLocker = svm_locker.clone();
-
-    let _handle = std::thread::spawn(move || {
-        let future = start_local_surfnet_runloop(
-            svm_locker_cc,
-            config,
-            simnet_commands_tx,
-            simnet_commands_rx,
-            geyser_events_rx,
-        );
-        if let Err(e) = hiro_system_kit::nestable_block_on(future) {
-            panic!("{e:?}");
-        }
-    });
+    let runloop = spawn_runloop(
+        svm_locker.clone(),
+        config,
+        (simnet_commands_tx, simnet_commands_rx),
+        geyser_events_rx,
+    );
 
     let mut ready = false;
     // don't wait for connection in offline mode
@@ -5498,7 +5511,11 @@ fn start_surfnet(
         }
     }
 
-    Ok((format!("http://{}:{}", bind_host, bind_port), svm_locker))
+    Ok((
+        format!("http://{}:{}", bind_host, bind_port),
+        svm_locker,
+        runloop,
+    ))
 }
 
 #[test_case(TestType::sqlite(); "with on-disk sqlite db")]
@@ -5521,12 +5538,12 @@ async fn test_closed_accounts(test_type: TestType) {
         },
     };
     // Start datasource surfnet first, which will only have accounts we airdrop to
-    let (datasource_surfnet_url, _datasource_svm_locker) =
+    let (datasource_surfnet_url, _datasource_svm_locker, _runloop) =
         start_surfnet(vec![pubkey], None, test_type).expect("Failed to start datasource surfnet");
     println!("Datasource surfnet started at {}", datasource_surfnet_url);
 
     // Now start the test surfnet which forks the datasource surfnet
-    let (surfnet_url, surfnet_svm_locker) =
+    let (surfnet_url, surfnet_svm_locker, _runloop) =
         start_surfnet(vec![], Some(datasource_surfnet_url), another_test_type)
             .expect("Failed to start surfnet");
     println!("Surfnet started at {}", surfnet_url);
@@ -5681,7 +5698,7 @@ async fn test_get_signatures_for_address_local_then_remote(test_type: TestType) 
     // in the same slot, share the same blockhash, and — because Ed25519 signatures are
     // deterministic — collapse to the same signature. Varying `lamports` per call guarantees a
     // distinct message (and therefore a distinct signature) regardless of slot timing.
-    let (datasource_url, _datasource_locker) =
+    let (datasource_url, _datasource_locker, _runloop) =
         start_surfnet(vec![], None, test_type).expect("start datasource surfnet");
     let datasource_rpc = RpcClient::new(datasource_url.clone());
     let mut datasource_sigs: Vec<Signature> = Vec::new();
@@ -5706,8 +5723,9 @@ async fn test_get_signatures_for_address_local_then_remote(test_type: TestType) 
 
     // Step 2: bring up the local surfnet, configured to fork the datasource, and seed 2 LOCAL
     // airdrops for `target`. These signatures only ever land in the local surfnet's storage.
-    let (local_url, _local_locker) = start_surfnet(vec![], Some(datasource_url), another_test_type)
-        .expect("start local surfnet");
+    let (local_url, _local_locker, _runloop) =
+        start_surfnet(vec![], Some(datasource_url), another_test_type)
+            .expect("start local surfnet");
     let local_rpc = RpcClient::new(local_url);
     let mut local_sigs: Vec<Signature> = Vec::new();
     for i in 0..2u64 {
@@ -5867,7 +5885,7 @@ async fn test_offline_account_including_owned_accounts(test_type: TestType) {
         },
     };
 
-    let (datasource_surfnet_url, datasource_svm_locker) =
+    let (datasource_surfnet_url, datasource_svm_locker, _runloop) =
         start_surfnet(vec![], None, test_type).expect("Failed to start datasource surfnet");
 
     datasource_svm_locker
@@ -5900,7 +5918,7 @@ async fn test_offline_account_including_owned_accounts(test_type: TestType) {
         })
         .expect("Failed to seed datasource accounts");
 
-    let (surfnet_url, surfnet_svm_locker) =
+    let (surfnet_url, surfnet_svm_locker, _runloop) =
         start_surfnet(vec![], Some(datasource_surfnet_url), another_test_type)
             .expect("Failed to start surfnet");
     let rpc_client = RpcClient::new(surfnet_url);
@@ -5967,7 +5985,7 @@ async fn test_offline_account_without_owned_accounts(test_type: TestType) {
         },
     };
 
-    let (datasource_surfnet_url, datasource_svm_locker) =
+    let (datasource_surfnet_url, datasource_svm_locker, _runloop) =
         start_surfnet(vec![], None, test_type).expect("Failed to start datasource surfnet");
 
     datasource_svm_locker
@@ -6000,7 +6018,7 @@ async fn test_offline_account_without_owned_accounts(test_type: TestType) {
         })
         .expect("Failed to seed datasource accounts");
 
-    let (surfnet_url, surfnet_svm_locker) =
+    let (surfnet_url, surfnet_svm_locker, _runloop) =
         start_surfnet(vec![], Some(datasource_surfnet_url), another_test_type)
             .expect("Failed to start surfnet");
     let rpc_client = RpcClient::new(surfnet_url);
@@ -6061,7 +6079,7 @@ async fn test_reset_account_after_offline_restores(test_type: TestType) {
         },
     };
 
-    let (datasource_surfnet_url, datasource_svm_locker) =
+    let (datasource_surfnet_url, datasource_svm_locker, _runloop) =
         start_surfnet(vec![], None, test_type).expect("Failed to start datasource surfnet");
 
     datasource_svm_locker
@@ -6082,7 +6100,7 @@ async fn test_reset_account_after_offline_restores(test_type: TestType) {
         })
         .expect("Failed to seed datasource accounts");
 
-    let (surfnet_url, surfnet_svm_locker) =
+    let (surfnet_url, surfnet_svm_locker, _runloop) =
         start_surfnet(vec![], Some(datasource_surfnet_url), another_test_type)
             .expect("Failed to start surfnet");
     let rpc_client = RpcClient::new(surfnet_url);
@@ -6153,7 +6171,7 @@ async fn test_reset_network_clears_offline_accounts(test_type: TestType) {
         },
     };
 
-    let (datasource_surfnet_url, datasource_svm_locker) =
+    let (datasource_surfnet_url, datasource_svm_locker, _runloop) =
         start_surfnet(vec![], None, test_type).expect("Failed to start datasource surfnet");
 
     datasource_svm_locker
@@ -6174,7 +6192,7 @@ async fn test_reset_network_clears_offline_accounts(test_type: TestType) {
         })
         .expect("Failed to seed datasource accounts");
 
-    let (surfnet_url, surfnet_svm_locker) =
+    let (surfnet_url, surfnet_svm_locker, _runloop) =
         start_surfnet(vec![], Some(datasource_surfnet_url), another_test_type)
             .expect("Failed to start surfnet");
     let rpc_client = RpcClient::new(surfnet_url);
@@ -6239,7 +6257,7 @@ async fn test_remote_get_multiple_accounts_only_program_accounts(test_type: Test
     };
 
     // Start datasource surfnet A (offline, no remote)
-    let (datasource_url, datasource_svm_locker) =
+    let (datasource_url, datasource_svm_locker, _runloop) =
         start_surfnet(vec![], None, test_type).expect("Failed to start datasource surfnet");
     println!("Datasource surfnet started at {}", datasource_url);
 
@@ -6253,7 +6271,7 @@ async fn test_remote_get_multiple_accounts_only_program_accounts(test_type: Test
         .expect("Failed to write program account");
 
     // Start surfnet B pointing to A as remote
-    let (surfnet_url, _surfnet_svm_locker) =
+    let (surfnet_url, _surfnet_svm_locker, _runloop) =
         start_surfnet(vec![], Some(datasource_url), another_test_type)
             .expect("Failed to start surfnet");
     println!("Surfnet B started at {}", surfnet_url);
@@ -6294,7 +6312,7 @@ async fn test_remote_get_multiple_accounts_ordering(test_type: TestType) {
     };
 
     // Start datasource surfnet A (offline, no remote)
-    let (datasource_url, datasource_svm_locker) =
+    let (datasource_url, datasource_svm_locker, _runloop) =
         start_surfnet(vec![], None, test_type).expect("Failed to start datasource surfnet");
 
     // Insert a program account on A
@@ -6310,7 +6328,7 @@ async fn test_remote_get_multiple_accounts_ordering(test_type: TestType) {
         .unwrap();
 
     // Start surfnet B pointing to A as remote
-    let (surfnet_url, _) = start_surfnet(vec![], Some(datasource_url), another_test_type)
+    let (surfnet_url, _, _runloop) = start_surfnet(vec![], Some(datasource_url), another_test_type)
         .expect("Failed to start surfnet B");
 
     let rpc_client = RpcClient::new(surfnet_url);
@@ -6961,7 +6979,7 @@ async fn test_ws_account_subscribe_account_closure(test_type: TestType) {
 async fn test_ws_slot_subscribe_basic(test_type: TestType) {
     use surfpool_types::types::BlockProductionMode;
 
-    let (svm_locker, _simnet_commands_tx, _simnet_events_rx) =
+    let (svm_locker, _simnet_commands_tx, _simnet_events_rx, _runloop) =
         boot_simnet(BlockProductionMode::Clock, Some(100), test_type);
 
     // subscribe to slot updates
@@ -7096,7 +7114,7 @@ async fn test_ws_slot_subscribe_multiple_slot_changes(test_type: TestType) {
 async fn test_ws_slots_updates_subscribe_basic(test_type: TestType) {
     use surfpool_types::types::BlockProductionMode;
 
-    let (svm_locker, _simnet_commands_tx, _simnet_events_rx) =
+    let (svm_locker, _simnet_commands_tx, _simnet_events_rx, _runloop) =
         boot_simnet(BlockProductionMode::Clock, Some(100), test_type);
 
     // subscribe to slots updates
@@ -9920,7 +9938,7 @@ async fn test_duplicate_transaction_rejected(test_type: TestType) {
 #[cfg_attr(feature = "postgres", test_case(TestType::postgres(); "with postgres db"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_account_loaded_twice_rejected(test_type: TestType) {
-    let (svm_locker, _simnet_cmd_tx, _simnet_events_rx) =
+    let (svm_locker, _simnet_cmd_tx, _simnet_events_rx, _runloop) =
         boot_simnet(BlockProductionMode::Clock, Some(400), test_type);
 
     let payer = Keypair::new();
@@ -10146,18 +10164,12 @@ async fn test_send_transaction_skip_sig_verify_processes_and_updates_state(test_
 
     let svm_locker = SurfnetSvmLocker::new(surfnet_svm);
 
-    let _handle = hiro_system_kit::thread_named("test").spawn(move || {
-        let future = start_local_surfnet_runloop(
-            svm_locker,
-            config,
-            simnet_commands_tx,
-            simnet_commands_rx,
-            geyser_events_rx,
-        );
-        if let Err(e) = hiro_system_kit::nestable_block_on(future) {
-            panic!("{e:?}");
-        }
-    });
+    let _runloop = spawn_runloop(
+        svm_locker,
+        config,
+        (simnet_commands_tx, simnet_commands_rx),
+        geyser_events_rx,
+    );
 
     wait_for_ready_and_connected(&simnet_events_rx);
 
@@ -10299,18 +10311,12 @@ async fn test_airdrop_amount_zero_skips_airdrops(test_type: TestType) {
 
     let svm_locker = SurfnetSvmLocker::new(surfnet_svm);
 
-    let _handle = hiro_system_kit::thread_named("test").spawn(move || {
-        let future = start_local_surfnet_runloop(
-            svm_locker,
-            config,
-            simnet_commands_tx,
-            simnet_commands_rx,
-            geyser_events_rx,
-        );
-        if let Err(e) = hiro_system_kit::nestable_block_on(future) {
-            panic!("{e:?}");
-        }
-    });
+    let _runloop = spawn_runloop(
+        svm_locker,
+        config,
+        (simnet_commands_tx, simnet_commands_rx),
+        geyser_events_rx,
+    );
 
     // Startup must reach Ready without panicking. This is the core regression
     // assertion for https://github.com/solana-foundation/surfpool/issues/651.
@@ -10362,18 +10368,12 @@ async fn test_airdrop_amount_below_rent_skips_airdrops(test_type: TestType) {
 
     let svm_locker = SurfnetSvmLocker::new(surfnet_svm);
 
-    let _handle = hiro_system_kit::thread_named("test").spawn(move || {
-        let future = start_local_surfnet_runloop(
-            svm_locker,
-            config,
-            simnet_commands_tx,
-            simnet_commands_rx,
-            geyser_events_rx,
-        );
-        if let Err(e) = hiro_system_kit::nestable_block_on(future) {
-            panic!("{e:?}");
-        }
-    });
+    let _runloop = spawn_runloop(
+        svm_locker,
+        config,
+        (simnet_commands_tx, simnet_commands_rx),
+        geyser_events_rx,
+    );
 
     wait_for_ready_and_connected(&simnet_events_rx);
 

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -1,7 +1,7 @@
 use std::{str::FromStr, sync::Arc, time::Duration};
 
 use base64::Engine;
-use crossbeam_channel::{Sender, unbounded, unbounded as crossbeam_unbounded};
+use crossbeam_channel::{RecvTimeoutError, Sender, unbounded, unbounded as crossbeam_unbounded};
 use ed25519_dalek::Signer as DalekSigner;
 use jsonrpc_core::{
     Error, Result as JsonRpcResult,
@@ -85,24 +85,110 @@ use crate::{
     types::{TimeTravelConfig, TransactionLoadedAddresses},
 };
 
+/// How long a surfnet gets to announce itself before a test gives up on it.
+const READY_DEADLINE: Duration = Duration::from_secs(60);
+
+/// How long a runloop gets to stop once it has been told to.
+const STOP_DEADLINE: Duration = Duration::from_secs(5);
+
+/// The ways owning a runloop from a test can fail.
+///
+/// NotReady and NotStopped carry how long they waited, because a surfnet that
+/// never starts and a runloop that never stops present the same way: a test
+/// that does not finish.
+#[derive(Debug)]
+enum RunloopError {
+    /// The OS refused a thread. This is the shape thread exhaustion arrives
+    /// in, so it is the first thing to fail if the guards below stop working.
+    Spawn(std::io::Error),
+    /// No port was free to bind the surfnet to.
+    NoFreePort(String),
+    /// The event channel closed while waiting: the runloop stopped, or
+    /// panicked, before the surfnet announced itself.
+    Disconnected,
+    /// The surfnet never announced itself.
+    NotReady { waited: Duration },
+    /// The runloop was told to stop and was still running at the deadline.
+    NotStopped { waited: Duration },
+}
+
+impl std::fmt::Display for RunloopError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Spawn(error) => write!(f, "the OS refused a thread for the runloop: {error}"),
+            Self::NoFreePort(reason) => write!(f, "no free port for the surfnet: {reason}"),
+            Self::Disconnected => {
+                write!(f, "the runloop stopped before the surfnet was ready")
+            }
+            Self::NotReady { waited } => {
+                write!(f, "the surfnet was not ready within {waited:?}")
+            }
+            Self::NotStopped { waited } => {
+                write!(
+                    f,
+                    "the runloop was still running {waited:?} after Terminate"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for RunloopError {}
+
 /// A running surfnet and the thread it runs on. Dropping it stops the runloop.
 struct RunloopGuard {
     commands: Sender<SimnetCommand>,
     thread: Option<std::thread::JoinHandle<()>>,
 }
 
+impl RunloopGuard {
+    /// Stops the runloop and waits for its thread to end, reporting whether it
+    /// did. Dropping the guard does the same thing; call this when the test
+    /// wants to assert the surfnet stopped rather than assume it.
+    fn stop(mut self) -> Result<(), RunloopError> {
+        self.terminate()
+    }
+
+    fn terminate(&mut self) -> Result<(), RunloopError> {
+        // Already stopped: `stop()` consumed the handle, and the drop that
+        // follows it has nothing left to do.
+        let Some(thread) = self.thread.take() else {
+            return Ok(());
+        };
+
+        // A closed channel means the runloop is already gone, which is what is
+        // being asked for here; the wait below is what decides.
+        let _ = self.commands.send(SimnetCommand::Terminate(None));
+
+        // Bounded rather than a plain join: a runloop that never reached its
+        // command loop would never see the Terminate, and a wait that blocks
+        // forever turns a failing test into a hanging one.
+        let deadline = std::time::Instant::now() + STOP_DEADLINE;
+        while !thread.is_finished() {
+            if std::time::Instant::now() >= deadline {
+                return Err(RunloopError::NotStopped {
+                    waited: STOP_DEADLINE,
+                });
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        Ok(())
+    }
+}
+
 impl Drop for RunloopGuard {
     fn drop(&mut self) {
-        let _ = self.commands.send(SimnetCommand::Terminate(None));
-        let Some(thread) = self.thread.take() else {
+        let Err(error) = self.terminate() else {
             return;
         };
-        // Bounded rather than a plain join: a runloop that never reached its
-        // command loop would never see the Terminate, and a drop that blocks
-        // forever turns a failing test into a hanging one.
-        let deadline = std::time::Instant::now() + Duration::from_secs(5);
-        while !thread.is_finished() && std::time::Instant::now() < deadline {
-            std::thread::sleep(Duration::from_millis(20));
+        // Raising this while unwinding would abort the process, so a runloop
+        // that outlives a failing test is reported rather than raised: that
+        // test has a failure to show already. On the passing path it is a
+        // failure of its own.
+        if std::thread::panicking() {
+            eprintln!("{error}");
+        } else {
+            panic!("{error}");
         }
     }
 }
@@ -112,7 +198,6 @@ impl Drop for RunloopGuard {
 /// Bind the guard for as long as the test needs the surfnet, conventionally
 /// `let _runloop = spawn_runloop(...)`. A plain `let _ =` drops it there and
 /// then, which stops the runloop before the test has used it.
-#[must_use = "the runloop stops when the guard drops"]
 fn spawn_runloop(
     svm_locker: SurfnetSvmLocker,
     config: SurfpoolConfig,
@@ -121,7 +206,7 @@ fn spawn_runloop(
         crossbeam_channel::Receiver<SimnetCommand>,
     ),
     geyser_events_rx: crossbeam_channel::Receiver<GeyserEvent>,
-) -> RunloopGuard {
+) -> Result<RunloopGuard, RunloopError> {
     let (simnet_commands_tx, simnet_commands_rx) = commands;
     let stop = simnet_commands_tx.clone();
 
@@ -138,33 +223,62 @@ fn spawn_runloop(
                 panic!("{e:?}");
             }
         })
-        .expect("failed to spawn surfnet runloop");
+        .map_err(RunloopError::Spawn)?;
 
-    RunloopGuard {
+    Ok(RunloopGuard {
         commands: stop,
         thread: Some(thread),
-    }
+    })
 }
 
-fn wait_for_ready_and_connected(simnet_events_rx: &crossbeam_channel::Receiver<SimnetEvent>) {
+/// Waits for the surfnet to say it is ready and that it reached its
+/// datasource.
+fn wait_for_ready_and_connected(
+    simnet_events_rx: &crossbeam_channel::Receiver<SimnetEvent>,
+) -> Result<(), RunloopError> {
+    wait_for_startup(simnet_events_rx, Connection::Required)
+}
+
+/// Waits for the surfnet to say it is ready, with no datasource to reach.
+fn wait_for_ready(
+    simnet_events_rx: &crossbeam_channel::Receiver<SimnetEvent>,
+) -> Result<(), RunloopError> {
+    wait_for_startup(simnet_events_rx, Connection::NotExpected)
+}
+
+/// Whether a surfnet has a datasource to connect to, which decides what
+/// counts as having started.
+#[derive(PartialEq)]
+enum Connection {
+    Required,
+    NotExpected,
+}
+
+fn wait_for_startup(
+    simnet_events_rx: &crossbeam_channel::Receiver<SimnetEvent>,
+    connection: Connection,
+) -> Result<(), RunloopError> {
     let mut ready = false;
-    let mut connected = false;
-    loop {
-        match simnet_events_rx.recv() {
-            Ok(SimnetEvent::Ready(_)) => {
-                println!("Simnet is ready");
-                ready = true;
+    let mut connected = connection == Connection::NotExpected;
+    let deadline = std::time::Instant::now() + READY_DEADLINE;
+
+    while !(ready && connected) {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        match simnet_events_rx.recv_timeout(remaining) {
+            Ok(SimnetEvent::Ready(_)) => ready = true,
+            Ok(SimnetEvent::Connected(_)) => connected = true,
+            Ok(_) => (),
+            Err(RecvTimeoutError::Timeout) => {
+                return Err(RunloopError::NotReady {
+                    waited: READY_DEADLINE,
+                });
             }
-            Ok(SimnetEvent::Connected(_)) => {
-                println!("Simnet is connected");
-                connected = true;
-            }
-            _ => (),
-        }
-        if ready && connected {
-            break;
+            // recv returns from a closed channel immediately, so going
+            // round again here spins a core until the test ends.
+            Err(RecvTimeoutError::Disconnected) => return Err(RunloopError::Disconnected),
         }
     }
+    Ok(())
 }
 
 #[cfg_attr(feature = "ignore_tests_ci", ignore = "flaky CI tests")]
@@ -192,12 +306,12 @@ async fn test_simnet_ready(test_type: TestType) {
         config,
         (simnet_commands_tx, simnet_commands_rx),
         geyser_events_rx,
-    );
+    )
+    .expect("the runloop should start");
 
-    // One event, not a loop: both arms leave immediately, so what this asserts
-    // is that the first thing the runloop says is a startup event rather than
-    // an error. Waiting for a particular one would need the accumulating shape
-    // that `wait_for_ready_and_connected` uses.
+    // The assertion is that the first thing the runloop says is a startup
+    // event rather than an error. Waiting for a particular one needs the
+    // accumulating shape `wait_for_ready_and_connected` uses.
     match simnet_events_rx.recv() {
         Ok(SimnetEvent::Ready(_) | SimnetEvent::Connected(_) | SimnetEvent::EpochInfoUpdate(_)) => {
         }
@@ -240,7 +354,8 @@ async fn test_simnet_ticks(test_type: TestType) {
         config,
         (simnet_commands_tx, simnet_commands_rx),
         geyser_events_rx,
-    );
+    )
+    .expect("the runloop should start");
 
     let _ = hiro_system_kit::thread_named("ticks").spawn(move || {
         let mut ticks = 0;
@@ -248,9 +363,9 @@ async fn test_simnet_ticks(test_type: TestType) {
             match simnet_events_rx.recv() {
                 Ok(SimnetEvent::SystemClockUpdated(_)) => ticks += 1,
                 Ok(_) => (),
-                // The runloop has stopped and the channel is closed: recv()
-                // returns immediately from here on, so this loop would spin a
-                // core for the rest of the run.
+                // recv returns from a closed channel immediately, so
+                // going round again here spins a core for the rest of the
+                // run.
                 Err(_) => break,
             }
 
@@ -306,9 +421,10 @@ async fn test_simnet_some_sol_transfers(test_type: TestType) {
         config,
         (simnet_commands_tx, simnet_commands_rx),
         geyser_events_rx,
-    );
+    )
+    .expect("the runloop should start");
 
-    wait_for_ready_and_connected(&simnet_events_rx);
+    wait_for_ready_and_connected(&simnet_events_rx).expect("the surfnet should start");
 
     let minimal_client =
         http::connect::<MinimalClient>(format!("http://{bind_host}:{bind_port}").as_str())
@@ -458,10 +574,11 @@ async fn test_add_alt_entries_fetching(test_type: TestType) {
         config,
         (simnet_commands_tx, simnet_commands_rx),
         geyser_events_rx,
-    );
+    )
+    .expect("the runloop should start");
     let svm_locker = SurfnetSvmLocker(svm_locker);
 
-    wait_for_ready_and_connected(&simnet_events_rx);
+    wait_for_ready_and_connected(&simnet_events_rx).expect("the surfnet should start");
 
     let full_client =
         http::connect::<FullClient>(format!("http://{bind_host}:{bind_port}").as_str())
@@ -623,10 +740,11 @@ async fn test_simulate_add_alt_entries_fetching(test_type: TestType) {
         config,
         (simnet_commands_tx, simnet_commands_rx),
         geyser_events_rx,
-    );
+    )
+    .expect("the runloop should start");
     let svm_locker = SurfnetSvmLocker(svm_locker);
 
-    wait_for_ready_and_connected(&simnet_events_rx);
+    wait_for_ready_and_connected(&simnet_events_rx).expect("the surfnet should start");
 
     let full_client =
         http::connect::<FullClient>(format!("http://{bind_host}:{bind_port}").as_str())
@@ -751,10 +869,11 @@ async fn test_simulate_transaction_no_signers(test_type: TestType) {
         config,
         (simnet_commands_tx, simnet_commands_rx),
         geyser_events_rx,
-    );
+    )
+    .expect("the runloop should start");
     let svm_locker = SurfnetSvmLocker(svm_locker);
 
-    wait_for_ready_and_connected(&simnet_events_rx);
+    wait_for_ready_and_connected(&simnet_events_rx).expect("the surfnet should start");
 
     let full_client =
         http::connect::<FullClient>(format!("http://{bind_host}:{bind_port}").as_str())
@@ -940,7 +1059,8 @@ async fn test_load_snapshot_program_is_invokable() {
         config,
         (simnet_commands_tx, simnet_commands_rx),
         geyser_events_rx,
-    );
+    )
+    .expect("the runloop should start");
 
     loop {
         match simnet_events_rx.recv_timeout(Duration::from_secs(5)) {
@@ -4061,15 +4181,18 @@ fn boot_simnet(
     block_production_mode: BlockProductionMode,
     slot_time: Option<u64>,
     test_type: TestType,
-) -> (
-    SurfnetSvmLocker,
-    crossbeam_channel::Sender<SimnetCommand>,
-    crossbeam_channel::Receiver<SimnetEvent>,
-    RunloopGuard,
-) {
+) -> Result<
+    (
+        SurfnetSvmLocker,
+        crossbeam_channel::Sender<SimnetCommand>,
+        crossbeam_channel::Receiver<SimnetEvent>,
+        RunloopGuard,
+    ),
+    RunloopError,
+> {
     let bind_host = "127.0.0.1";
-    let bind_port = get_free_port().unwrap();
-    let ws_port = get_free_port().unwrap();
+    let bind_port = get_free_port().map_err(RunloopError::NoFreePort)?;
+    let ws_port = get_free_port().map_err(RunloopError::NoFreePort)?;
     let config = SurfpoolConfig {
         simnets: vec![SimnetConfig {
             slot_time: slot_time.unwrap_or(DEFAULT_SLOT_TIME_MS),
@@ -4098,17 +4221,26 @@ fn boot_simnet(
         config,
         (simnet_commands_tx.clone(), simnet_commands_rx),
         geyser_events_rx,
-    );
+    )?;
 
-    loop {
-        if let Ok(SimnetEvent::Ready(_)) =
-            simnet_events_rx.recv_timeout(Duration::from_millis(1000))
-        {
-            break;
-        }
-    }
+    wait_for_ready(&simnet_events_rx)?;
 
-    (svm_locker, simnet_commands_tx, simnet_events_rx, runloop)
+    Ok((svm_locker, simnet_commands_tx, simnet_events_rx, runloop))
+}
+
+/// The guard's claim, as a test: a surfnet that is told to stop does, within
+/// the deadline. Every other test leans on this happening silently at drop,
+/// where a failure has nowhere to go.
+#[test_case(TestType::in_memory(); "with in-memory sqlite db")]
+#[test_case(TestType::no_db(); "with no db")]
+fn a_surfnet_stops_when_it_is_told_to(test_type: TestType) {
+    let (_svm_locker, _simnet_commands_tx, _simnet_events_rx, runloop) =
+        boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
+            .expect("the simnet should boot");
+
+    runloop
+        .stop()
+        .expect("the runloop should stop when told to");
 }
 
 #[test_case(TestType::sqlite(); "with on-disk sqlite db")]
@@ -4118,7 +4250,8 @@ fn boot_simnet(
 fn test_time_travel_resume_paused_clock(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
     let (svm_locker, simnet_cmd_tx, _, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(100), test_type);
+        boot_simnet(BlockProductionMode::Clock, Some(100), test_type)
+            .expect("the simnet should boot");
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
 
     let runloop_context = RunloopContext {
@@ -4200,7 +4333,8 @@ fn test_time_travel_absolute_timestamp(test_type: TestType) {
         BlockProductionMode::Clock,
         Some(slot_time.clone()),
         test_type,
-    );
+    )
+    .expect("the simnet should boot");
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
 
     let runloop_context = RunloopContext {
@@ -4284,7 +4418,8 @@ fn test_time_travel_absolute_timestamp(test_type: TestType) {
 fn test_time_travel_absolute_slot(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
     let (svm_locker, simnet_cmd_tx, simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(400), test_type);
+        boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
+            .expect("the simnet should boot");
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
 
     let runloop_context = RunloopContext {
@@ -4362,7 +4497,8 @@ fn test_time_travel_absolute_slot(test_type: TestType) {
 fn test_time_travel_absolute_epoch(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
     let (svm_locker, simnet_cmd_tx, simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(400), test_type);
+        boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
+            .expect("the simnet should boot");
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
 
     let runloop_context = RunloopContext {
@@ -4443,7 +4579,8 @@ fn test_time_travel_absolute_epoch(test_type: TestType) {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_ix_profiling_with_alt_tx(test_type: TestType) {
     let (svm_locker, _simnet_cmd_tx, _simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(400), test_type);
+        boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
+            .expect("the simnet should boot");
 
     let p1 = Keypair::new();
     let p2 = Keypair::new();
@@ -4732,7 +4869,8 @@ async fn test_ix_profiling_with_alt_tx(test_type: TestType) {
 #[tokio::test(flavor = "multi_thread")]
 async fn it_should_delete_accounts_with_no_lamports(test_type: TestType) {
     let (svm_locker, _simnet_cmd_tx, _simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(400), test_type);
+        boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
+            .expect("the simnet should boot");
     let p1 = Keypair::new();
     let p2 = Keypair::new();
 
@@ -4784,7 +4922,8 @@ async fn it_should_delete_accounts_with_no_lamports(test_type: TestType) {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_compute_budget_profiling(test_type: TestType) {
     let (svm_locker, _simnet_cmd_tx, _simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(400), test_type);
+        boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
+            .expect("the simnet should boot");
     let p1 = Keypair::new();
     let p2 = Keypair::new();
 
@@ -5288,7 +5427,8 @@ fn test_reset_network_keeps_latest_blockhash_valid(test_type: TestType) {
 fn test_reset_network_time_travel_timestamp(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
     let (svm_locker, simnet_cmd_tx, simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(400), test_type);
+        boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
+            .expect("the simnet should boot");
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
 
     let runloop_context = RunloopContext {
@@ -5341,7 +5481,8 @@ fn test_reset_network_time_travel_timestamp(test_type: TestType) {
 fn test_reset_network_time_travel_slot(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
     let (svm_locker, simnet_cmd_tx, simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(400), test_type);
+        boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
+            .expect("the simnet should boot");
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
 
     let runloop_context = RunloopContext {
@@ -5398,7 +5539,8 @@ fn test_reset_network_time_travel_slot(test_type: TestType) {
 fn test_reset_network_time_travel_epoch(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
     let (svm_locker, simnet_cmd_tx, simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(400), test_type);
+        boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
+            .expect("the simnet should boot");
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
 
     let runloop_context = RunloopContext {
@@ -5459,10 +5601,10 @@ fn start_surfnet(
     airdrop_addresses: Vec<Pubkey>,
     datasource_rpc_url: Option<String>,
     test_type: TestType,
-) -> Result<(String, SurfnetSvmLocker, RunloopGuard), String> {
+) -> Result<(String, SurfnetSvmLocker, RunloopGuard), RunloopError> {
     let bind_host = "127.0.0.1";
-    let bind_port = get_free_port().unwrap();
-    let ws_port = get_free_port().unwrap();
+    let bind_port = get_free_port().map_err(RunloopError::NoFreePort)?;
+    let ws_port = get_free_port().map_err(RunloopError::NoFreePort)?;
     let offline_mode = datasource_rpc_url.is_none();
 
     let config = SurfpoolConfig {
@@ -5491,24 +5633,14 @@ fn start_surfnet(
         config,
         (simnet_commands_tx, simnet_commands_rx),
         geyser_events_rx,
-    );
+    )?;
 
-    let mut ready = false;
-    // don't wait for connection in offline mode
-    let mut connected = offline_mode;
-    loop {
-        match simnet_events_rx.recv() {
-            Ok(SimnetEvent::Ready(_)) => {
-                ready = true;
-            }
-            Ok(SimnetEvent::Connected(_)) => {
-                connected = true;
-            }
-            _ => (),
-        }
-        if ready && connected {
-            break;
-        }
+    // An offline surfnet has no datasource to reach, so waiting for Connected
+    // would wait out the deadline.
+    if offline_mode {
+        wait_for_ready(&simnet_events_rx)?;
+    } else {
+        wait_for_ready_and_connected(&simnet_events_rx)?;
     }
 
     Ok((
@@ -6980,7 +7112,8 @@ async fn test_ws_slot_subscribe_basic(test_type: TestType) {
     use surfpool_types::types::BlockProductionMode;
 
     let (svm_locker, _simnet_commands_tx, _simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(100), test_type);
+        boot_simnet(BlockProductionMode::Clock, Some(100), test_type)
+            .expect("the simnet should boot");
 
     // subscribe to slot updates
     let slot_rx = svm_locker.subscribe_for_slot_updates();
@@ -7115,7 +7248,8 @@ async fn test_ws_slots_updates_subscribe_basic(test_type: TestType) {
     use surfpool_types::types::BlockProductionMode;
 
     let (svm_locker, _simnet_commands_tx, _simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(100), test_type);
+        boot_simnet(BlockProductionMode::Clock, Some(100), test_type)
+            .expect("the simnet should boot");
 
     // subscribe to slots updates
     let slots_updates_rx = svm_locker.subscribe_for_slots_updates();
@@ -9939,7 +10073,8 @@ async fn test_duplicate_transaction_rejected(test_type: TestType) {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_account_loaded_twice_rejected(test_type: TestType) {
     let (svm_locker, _simnet_cmd_tx, _simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(400), test_type);
+        boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
+            .expect("the simnet should boot");
 
     let payer = Keypair::new();
     svm_locker
@@ -10169,9 +10304,10 @@ async fn test_send_transaction_skip_sig_verify_processes_and_updates_state(test_
         config,
         (simnet_commands_tx, simnet_commands_rx),
         geyser_events_rx,
-    );
+    )
+    .expect("the runloop should start");
 
-    wait_for_ready_and_connected(&simnet_events_rx);
+    wait_for_ready_and_connected(&simnet_events_rx).expect("the surfnet should start");
 
     let minimal_client =
         http::connect::<MinimalClient>(format!("http://{bind_host}:{bind_port}").as_str())
@@ -10316,11 +10452,12 @@ async fn test_airdrop_amount_zero_skips_airdrops(test_type: TestType) {
         config,
         (simnet_commands_tx, simnet_commands_rx),
         geyser_events_rx,
-    );
+    )
+    .expect("the runloop should start");
 
     // Startup must reach Ready without panicking. This is the core regression
     // assertion for https://github.com/solana-foundation/surfpool/issues/651.
-    wait_for_ready_and_connected(&simnet_events_rx);
+    wait_for_ready_and_connected(&simnet_events_rx).expect("the surfnet should start");
 
     let minimal_client =
         http::connect::<MinimalClient>(format!("http://{bind_host}:{bind_port}").as_str())
@@ -10373,9 +10510,10 @@ async fn test_airdrop_amount_below_rent_skips_airdrops(test_type: TestType) {
         config,
         (simnet_commands_tx, simnet_commands_rx),
         geyser_events_rx,
-    );
+    )
+    .expect("the runloop should start");
 
-    wait_for_ready_and_connected(&simnet_events_rx);
+    wait_for_ready_and_connected(&simnet_events_rx).expect("the surfnet should start");
 
     let minimal_client =
         http::connect::<MinimalClient>(format!("http://{bind_host}:{bind_port}").as_str())

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -86,10 +86,19 @@ use crate::{
 };
 
 /// How long a surfnet gets to announce itself before a test gives up on it.
-const READY_DEADLINE: Duration = Duration::from_secs(60);
+///
+/// The value has to exceed the worst case of the remote calls underneath it:
+/// reaching a datasource means asking it for epoch info, the epoch schedule and
+/// the declared clones, each bounded separately. A ready deadline set to what a
+/// single call may take fails a startup whose first call was merely slow.
+const READY_DEADLINE: Duration = Duration::from_secs(180);
 
 /// How long a runloop gets to stop once it has been told to.
-const STOP_DEADLINE: Duration = Duration::from_secs(5);
+///
+/// Generous on purpose. Exceeding this fails the test, so the value leaves room
+/// for a loaded machine rather than sitting near what a healthy shutdown takes,
+/// which is tens of milliseconds.
+const STOP_DEADLINE: Duration = Duration::from_secs(15);
 
 /// The ways owning a runloop from a test can fail.
 ///
@@ -4173,23 +4182,24 @@ async fn test_get_local_signatures_with_limit(test_type: TestType) {
 // Clock Control Tests (pauseClock, resumeClock, timeTravel)
 // ============================================================================
 
-/// Boots a simnet and waits for it to be ready.
+/// A booted simnet, with the handles a test drives it through.
 ///
-/// The [`RunloopGuard`] comes back with the handles because it has to outlive
-/// them: held here, it would stop the runloop as this function returns.
+/// The guard rides along rather than being handed back separately, so holding
+/// the simnet is what keeps its runloop alive; there is no fourth element to
+/// forget to bind.
+struct BootedSimnet {
+    locker: SurfnetSvmLocker,
+    commands: Sender<SimnetCommand>,
+    events: crossbeam_channel::Receiver<SimnetEvent>,
+    runloop: RunloopGuard,
+}
+
+/// Boots a simnet and waits for it to be ready.
 fn boot_simnet(
     block_production_mode: BlockProductionMode,
     slot_time: Option<u64>,
     test_type: TestType,
-) -> Result<
-    (
-        SurfnetSvmLocker,
-        crossbeam_channel::Sender<SimnetCommand>,
-        crossbeam_channel::Receiver<SimnetEvent>,
-        RunloopGuard,
-    ),
-    RunloopError,
-> {
+) -> Result<BootedSimnet, RunloopError> {
     let bind_host = "127.0.0.1";
     let bind_port = get_free_port().map_err(RunloopError::NoFreePort)?;
     let ws_port = get_free_port().map_err(RunloopError::NoFreePort)?;
@@ -4225,7 +4235,12 @@ fn boot_simnet(
 
     wait_for_ready(&simnet_events_rx)?;
 
-    Ok((svm_locker, simnet_commands_tx, simnet_events_rx, runloop))
+    Ok(BootedSimnet {
+        locker: svm_locker,
+        commands: simnet_commands_tx,
+        events: simnet_events_rx,
+        runloop,
+    })
 }
 
 /// The guard's claim, as a test: a surfnet that is told to stop does, within
@@ -4234,11 +4249,11 @@ fn boot_simnet(
 #[test_case(TestType::in_memory(); "with in-memory sqlite db")]
 #[test_case(TestType::no_db(); "with no db")]
 fn a_surfnet_stops_when_it_is_told_to(test_type: TestType) {
-    let (_svm_locker, _simnet_commands_tx, _simnet_events_rx, runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
-            .expect("the simnet should boot");
+    let simnet = boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
+        .expect("the simnet should boot");
 
-    runloop
+    simnet
+        .runloop
         .stop()
         .expect("the runloop should stop when told to");
 }
@@ -4249,9 +4264,10 @@ fn a_surfnet_stops_when_it_is_told_to(test_type: TestType) {
 #[cfg_attr(feature = "postgres", test_case(TestType::postgres(); "with postgres db"))]
 fn test_time_travel_resume_paused_clock(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
-    let (svm_locker, simnet_cmd_tx, _, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(100), test_type)
-            .expect("the simnet should boot");
+    let simnet = boot_simnet(BlockProductionMode::Clock, Some(100), test_type)
+        .expect("the simnet should boot");
+    let svm_locker = simnet.locker.clone();
+    let simnet_cmd_tx = simnet.commands.clone();
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
 
     let runloop_context = RunloopContext {
@@ -4329,12 +4345,15 @@ fn test_time_travel_resume_paused_clock(test_type: TestType) {
 fn test_time_travel_absolute_timestamp(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
     let slot_time = 100;
-    let (svm_locker, simnet_cmd_tx, simnet_events_rx, _runloop) = boot_simnet(
+    let simnet = boot_simnet(
         BlockProductionMode::Clock,
         Some(slot_time.clone()),
         test_type,
     )
     .expect("the simnet should boot");
+    let svm_locker = simnet.locker.clone();
+    let simnet_cmd_tx = simnet.commands.clone();
+    let simnet_events_rx = simnet.events.clone();
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
 
     let runloop_context = RunloopContext {
@@ -4417,9 +4436,11 @@ fn test_time_travel_absolute_timestamp(test_type: TestType) {
 #[cfg_attr(feature = "postgres", test_case(TestType::postgres(); "with postgres db"))]
 fn test_time_travel_absolute_slot(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
-    let (svm_locker, simnet_cmd_tx, simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
-            .expect("the simnet should boot");
+    let simnet = boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
+        .expect("the simnet should boot");
+    let svm_locker = simnet.locker.clone();
+    let simnet_cmd_tx = simnet.commands.clone();
+    let simnet_events_rx = simnet.events.clone();
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
 
     let runloop_context = RunloopContext {
@@ -4496,9 +4517,11 @@ fn test_time_travel_absolute_slot(test_type: TestType) {
 #[cfg_attr(feature = "postgres", test_case(TestType::postgres(); "with postgres db"))]
 fn test_time_travel_absolute_epoch(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
-    let (svm_locker, simnet_cmd_tx, simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
-            .expect("the simnet should boot");
+    let simnet = boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
+        .expect("the simnet should boot");
+    let svm_locker = simnet.locker.clone();
+    let simnet_cmd_tx = simnet.commands.clone();
+    let simnet_events_rx = simnet.events.clone();
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
 
     let runloop_context = RunloopContext {
@@ -4578,9 +4601,9 @@ fn test_time_travel_absolute_epoch(test_type: TestType) {
 #[cfg_attr(feature = "postgres", test_case(TestType::postgres(); "with postgres db"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_ix_profiling_with_alt_tx(test_type: TestType) {
-    let (svm_locker, _simnet_cmd_tx, _simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
-            .expect("the simnet should boot");
+    let simnet = boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
+        .expect("the simnet should boot");
+    let svm_locker = simnet.locker.clone();
 
     let p1 = Keypair::new();
     let p2 = Keypair::new();
@@ -4868,9 +4891,9 @@ async fn test_ix_profiling_with_alt_tx(test_type: TestType) {
 #[cfg_attr(feature = "postgres", test_case(TestType::postgres(); "with postgres db"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn it_should_delete_accounts_with_no_lamports(test_type: TestType) {
-    let (svm_locker, _simnet_cmd_tx, _simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
-            .expect("the simnet should boot");
+    let simnet = boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
+        .expect("the simnet should boot");
+    let svm_locker = simnet.locker.clone();
     let p1 = Keypair::new();
     let p2 = Keypair::new();
 
@@ -4921,9 +4944,9 @@ async fn it_should_delete_accounts_with_no_lamports(test_type: TestType) {
 #[cfg_attr(feature = "postgres", test_case(TestType::postgres(); "with postgres db"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_compute_budget_profiling(test_type: TestType) {
-    let (svm_locker, _simnet_cmd_tx, _simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
-            .expect("the simnet should boot");
+    let simnet = boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
+        .expect("the simnet should boot");
+    let svm_locker = simnet.locker.clone();
     let p1 = Keypair::new();
     let p2 = Keypair::new();
 
@@ -5426,9 +5449,10 @@ fn test_reset_network_keeps_latest_blockhash_valid(test_type: TestType) {
 #[cfg_attr(feature = "postgres", test_case(TestType::postgres(); "with postgres db"))]
 fn test_reset_network_time_travel_timestamp(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
-    let (svm_locker, simnet_cmd_tx, simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
-            .expect("the simnet should boot");
+    let simnet = boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
+        .expect("the simnet should boot");
+    let svm_locker = simnet.locker.clone();
+    let simnet_cmd_tx = simnet.commands.clone();
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
 
     let runloop_context = RunloopContext {
@@ -5480,9 +5504,10 @@ fn test_reset_network_time_travel_timestamp(test_type: TestType) {
 #[cfg_attr(feature = "postgres", test_case(TestType::postgres(); "with postgres db"))]
 fn test_reset_network_time_travel_slot(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
-    let (svm_locker, simnet_cmd_tx, simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
-            .expect("the simnet should boot");
+    let simnet = boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
+        .expect("the simnet should boot");
+    let svm_locker = simnet.locker.clone();
+    let simnet_cmd_tx = simnet.commands.clone();
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
 
     let runloop_context = RunloopContext {
@@ -5538,9 +5563,10 @@ fn test_reset_network_time_travel_slot(test_type: TestType) {
 #[cfg_attr(feature = "postgres", test_case(TestType::postgres(); "with postgres db"))]
 fn test_reset_network_time_travel_epoch(test_type: TestType) {
     let rpc_server = SurfnetCheatcodesRpc::empty();
-    let (svm_locker, simnet_cmd_tx, simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
-            .expect("the simnet should boot");
+    let simnet = boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
+        .expect("the simnet should boot");
+    let svm_locker = simnet.locker.clone();
+    let simnet_cmd_tx = simnet.commands.clone();
     let (plugin_commands_tx, _plugin_commands_rx) = crossbeam_channel::unbounded::<PluginCommand>();
 
     let runloop_context = RunloopContext {
@@ -7111,9 +7137,9 @@ async fn test_ws_account_subscribe_account_closure(test_type: TestType) {
 async fn test_ws_slot_subscribe_basic(test_type: TestType) {
     use surfpool_types::types::BlockProductionMode;
 
-    let (svm_locker, _simnet_commands_tx, _simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(100), test_type)
-            .expect("the simnet should boot");
+    let simnet = boot_simnet(BlockProductionMode::Clock, Some(100), test_type)
+        .expect("the simnet should boot");
+    let svm_locker = simnet.locker.clone();
 
     // subscribe to slot updates
     let slot_rx = svm_locker.subscribe_for_slot_updates();
@@ -7247,9 +7273,9 @@ async fn test_ws_slot_subscribe_multiple_slot_changes(test_type: TestType) {
 async fn test_ws_slots_updates_subscribe_basic(test_type: TestType) {
     use surfpool_types::types::BlockProductionMode;
 
-    let (svm_locker, _simnet_commands_tx, _simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(100), test_type)
-            .expect("the simnet should boot");
+    let simnet = boot_simnet(BlockProductionMode::Clock, Some(100), test_type)
+        .expect("the simnet should boot");
+    let svm_locker = simnet.locker.clone();
 
     // subscribe to slots updates
     let slots_updates_rx = svm_locker.subscribe_for_slots_updates();
@@ -10072,9 +10098,9 @@ async fn test_duplicate_transaction_rejected(test_type: TestType) {
 #[cfg_attr(feature = "postgres", test_case(TestType::postgres(); "with postgres db"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_account_loaded_twice_rejected(test_type: TestType) {
-    let (svm_locker, _simnet_cmd_tx, _simnet_events_rx, _runloop) =
-        boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
-            .expect("the simnet should boot");
+    let simnet = boot_simnet(BlockProductionMode::Clock, Some(400), test_type)
+        .expect("the simnet should boot");
+    let svm_locker = simnet.locker.clone();
 
     let payer = Keypair::new();
     svm_locker

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -119,6 +119,9 @@ enum RunloopError {
     NotReady { waited: Duration },
     /// The runloop was told to stop and was still running at the deadline.
     NotStopped { waited: Duration },
+    /// The runloop thread ended by panicking, which is finished rather than
+    /// stopped.
+    Panicked,
 }
 
 impl std::fmt::Display for RunloopError {
@@ -138,6 +141,7 @@ impl std::fmt::Display for RunloopError {
                     "the runloop was still running {waited:?} after Terminate"
                 )
             }
+            Self::Panicked => write!(f, "the runloop thread panicked"),
         }
     }
 }
@@ -181,6 +185,12 @@ impl RunloopGuard {
             }
             std::thread::sleep(Duration::from_millis(20));
         }
+
+        // The thread has finished, so this join returns at once; what it adds
+        // is the thread's verdict. A runloop that ended by panicking has
+        // finished without having stopped, and `is_finished` cannot tell the
+        // two apart.
+        thread.join().map_err(|_| RunloopError::Panicked)?;
         Ok(())
     }
 }
@@ -4241,6 +4251,23 @@ fn boot_simnet(
         events: simnet_events_rx,
         runloop,
     })
+}
+
+/// A runloop that ends by panicking has finished without having stopped, and
+/// the guard tells the difference. The panic message this prints is the
+/// spawned thread's own, and is expected output.
+#[test]
+fn a_panicking_runloop_is_not_a_clean_stop() {
+    let (commands, _keep_open) = unbounded();
+    let guard = RunloopGuard {
+        commands,
+        thread: Some(std::thread::spawn(|| panic!("the runloop fell over"))),
+    };
+
+    assert!(
+        matches!(guard.stop(), Err(RunloopError::Panicked)),
+        "a panicked runloop should not report a clean stop"
+    );
 }
 
 /// The guard's claim, as a test: a surfnet that is told to stop does, within

--- a/crates/core/src/tests/integration.rs
+++ b/crates/core/src/tests/integration.rs
@@ -139,13 +139,14 @@ async fn test_simnet_ready(test_type: TestType) {
         }
     });
 
-    loop {
-        match simnet_events_rx.recv() {
-            Ok(SimnetEvent::Ready(_))
-            | Ok(SimnetEvent::Connected(_))
-            | Ok(SimnetEvent::EpochInfoUpdate(_)) => break,
-            e => panic!("Expected startup event: {e:?}"),
+    // One event, not a loop: both arms leave immediately, so what this asserts
+    // is that the first thing the runloop says is a startup event rather than
+    // an error. Waiting for a particular one would need the accumulating shape
+    // that `wait_for_ready_and_connected` uses.
+    match simnet_events_rx.recv() {
+        Ok(SimnetEvent::Ready(_) | SimnetEvent::Connected(_) | SimnetEvent::EpochInfoUpdate(_)) => {
         }
+        event => panic!("Expected startup event: {event:?}"),
     }
 }
 


### PR DESCRIPTION
# Problem

`cargo test --workspace` leaks one runloop per test in twelve integration tests. Because each runloop owns a Tokio runtime, RPC ports, and storage, the test process continually accumulates resources instead of returning to its baseline.

CI never exercises these tests because they are behind `ignore_tests_ci`, so the leak only affects local runs, where it turns a developer workstation into a small local sun: **6648 threads, 1274% CPU, three and a half hours in, still running.** 

# Changes

The commits are intended to review in order:

1. Lint the entire workspace (`c0be437`), exposing the `never_loop` lint that hid the problem.
2. Introduce `RunloopGuard` so every test shuts down the runloop it starts, even on panic.
3. Replace panic- and hang-based lifecycle failures with `RunloopError`, bounded waits, and `BootedSimnet`.
4. Widen lifecycle deadlines and make `boot_simnet` return a `BootedSimnet` instead of a tuple.

> `RunloopGuard::drop` fails the test when a runloop outlives it, which turns a silent leak into a visible failure and makes a slow shutdown a red test. 😅 

# Result

Running the leaking tests serially, sampling the test process twice a second:

|              | before | after |
| ------------ | -----: | ----: |
| peak threads |   1404 |   479 |
| wall clock   |   ~21s |  ~22s |

The same workload now peaks at roughly one third the thread count, with no measurable change in runtime.

More importantly, the process no longer accumulates runloops: running one test's three variants in sequence produces thread counts of **76, 77, 81** rather than roughly tripling. Each test leaves the process as it found it.

# How to test

* `cargo clippy --workspace --all-targets`
* `cargo test --all --features surfpool-core/ignore_tests_ci`
