### PR TITLE
fix(sdk-node): record the platform package versions in the lockfile

### DIFF
--- a/crates/sdk-node/package-lock.json
+++ b/crates/sdk-node/package-lock.json
@@ -1025,6 +1025,54 @@
         }
       }
     },
+    "node_modules/@solana/surfpool-darwin-arm64": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@solana/surfpool-darwin-arm64/-/surfpool-darwin-arm64-1.5.0.tgz",
+      "integrity": "sha512-RdjEN7WDAr1Vrp1CD+NAS3pwT//TJclX9zyxjhAMpmBofwDzlCO8/yqv2CbD77UOuB/y3UWz3MvEEHxZfetKsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/surfpool-darwin-x64": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@solana/surfpool-darwin-x64/-/surfpool-darwin-x64-1.5.0.tgz",
+      "integrity": "sha512-8ScgLVX32JX7HH0XkijZxlpsNAALuzaJQDUTjJ1aPazKzunliek27TP9ZkVzzBHypyiY59wpwNue9PUGnGKdIw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/surfpool-linux-x64-gnu": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@solana/surfpool-linux-x64-gnu/-/surfpool-linux-x64-gnu-1.5.0.tgz",
+      "integrity": "sha512-d+wUCBdzw7U4inKoe+Lj7XlH8Nmd6A00IZOsG3R61NQbqhRVp7zFpVCCzV00RvgAOsSedkI87I6B4ehAuyGPAg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@solana/sysvars": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-7.0.0.tgz",
@@ -1235,15 +1283,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@solana/surfpool-darwin-x64": {
-      "optional": true
-    },
-    "node_modules/@solana/surfpool-darwin-arm64": {
-      "optional": true
-    },
-    "node_modules/@solana/surfpool-linux-x64-gnu": {
-      "optional": true
     }
   }
 }


### PR DESCRIPTION
`npm ci` rejects the lockfile on `main` because it is out of sync with `package.json`. Issue #728 added bare `{"optional": true}` stubs for the three platform packages to unblock `npm publish`, but entries without a version cannot satisfy the `optionalDependencies` version pins.

Replace the stubs with complete `1.5.0` lockfile entries. Each integrity hash matches the registry tarball, `npm ci` accepts the lockfile again, and installs the appropriate platform package.